### PR TITLE
feat: #5 설정 - 카테고리 관리 구현

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -5,4 +5,15 @@ const config = getDefaultConfig(__dirname);
 // expo-sqlite web support requires WASM files to be resolved as assets
 config.resolver.assetExts.push('wasm');
 
+// SharedArrayBuffer requires Cross-Origin Isolation headers for expo-sqlite web support
+config.server = {
+  enhanceMiddleware: (middleware) => {
+    return (req, res, next) => {
+      res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
+      res.setHeader('Cross-Origin-Embedder-Policy', 'credentialless');
+      middleware(req, res, next);
+    };
+  },
+};
+
 module.exports = config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@react-navigation/bottom-tabs": "^7.15.9",
         "@react-navigation/native": "^7.2.2",
+        "@react-navigation/native-stack": "^7.14.10",
         "@tanstack/react-query": "^5.96.2",
         "drizzle-orm": "^0.45.2",
         "expo": "~54.0.33",
@@ -22,6 +23,7 @@
         "react-native-safe-area-context": "^5.7.0",
         "react-native-screens": "^4.24.0",
         "react-native-web": "^0.21.0",
+        "sql.js": "^1.14.1",
         "zustand": "^5.0.12"
       },
       "devDependencies": {
@@ -3877,6 +3879,25 @@
       "peerDependencies": {
         "react": ">= 18.2.0",
         "react-native": "*"
+      }
+    },
+    "node_modules/@react-navigation/native-stack": {
+      "version": "7.14.10",
+      "resolved": "https://registry.npmjs.org/@react-navigation/native-stack/-/native-stack-7.14.10.tgz",
+      "integrity": "sha512-mCbYbYhi7Em2R2nEgwYGdLU38smy+KK+HMMVcwuzllWsF3Qb+jOUEYbB6Or7LvE7SS77BZ6sHdx4HptCEv50hQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-navigation/elements": "^2.9.14",
+        "color": "^4.2.3",
+        "sf-symbols-typescript": "^2.1.0",
+        "warn-once": "^0.1.1"
+      },
+      "peerDependencies": {
+        "@react-navigation/native": "^7.2.2",
+        "react": ">= 18.2.0",
+        "react-native": "*",
+        "react-native-safe-area-context": ">= 4.0.0",
+        "react-native-screens": ">= 4.0.0"
       }
     },
     "node_modules/@react-navigation/routers": {
@@ -9224,6 +9245,12 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/sql.js": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/sql.js/-/sql.js-1.14.1.tgz",
+      "integrity": "sha512-gcj8zBWU5cFsi9WUP+4bFNXAyF1iRpA3LLyS/DP5xlrNzGmPIizUeBggKa8DbDwdqaKwUcTEnChtd2grWo/x/A==",
+      "license": "MIT"
     },
     "node_modules/stack-utils": {
       "version": "2.0.6",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@react-navigation/bottom-tabs": "^7.15.9",
     "@react-navigation/native": "^7.2.2",
+    "@react-navigation/native-stack": "^7.14.10",
     "@tanstack/react-query": "^5.96.2",
     "drizzle-orm": "^0.45.2",
     "expo": "~54.0.33",
@@ -25,6 +26,7 @@
     "react-native-safe-area-context": "^5.7.0",
     "react-native-screens": "^4.24.0",
     "react-native-web": "^0.21.0",
+    "sql.js": "^1.14.1",
     "zustand": "^5.0.12"
   },
   "devDependencies": {

--- a/src/components/CategoryFormSheet.tsx
+++ b/src/components/CategoryFormSheet.tsx
@@ -1,0 +1,129 @@
+import { useEffect, useState } from 'react';
+import { View, StyleSheet } from 'react-native';
+import { Modal, Portal, Text, TextInput, Button, IconButton } from 'react-native-paper';
+import { generateRandomColor } from '../constants/colors';
+
+type Category = {
+  id?: number;
+  name: string;
+  description?: string | null;
+  color: string;
+};
+
+type Props = {
+  visible: boolean;
+  category?: Category | null;
+  onDismiss: () => void;
+  onSave: (data: { name: string; description?: string; color: string }) => void;
+  onDelete?: () => void;
+};
+
+export default function CategoryFormSheet({ visible, category, onDismiss, onSave, onDelete }: Props) {
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [color, setColor] = useState(generateRandomColor);
+
+  const isEdit = !!category?.id;
+
+  useEffect(() => {
+    if (visible) {
+      setName(category?.name ?? '');
+      setDescription(category?.description ?? '');
+      setColor(category?.color ?? generateRandomColor());
+    }
+  }, [visible, category]);
+
+  const handleSave = () => {
+    if (!name.trim()) return;
+    onSave({ name: name.trim(), description: description.trim() || undefined, color });
+  };
+
+  return (
+    <Portal>
+      <Modal visible={visible} onDismiss={onDismiss} contentContainerStyle={styles.container}>
+        <Text variant="titleLarge" style={styles.title}>
+          {isEdit ? '카테고리 수정' : '새 카테고리'}
+        </Text>
+
+        <TextInput
+          label="이름 *"
+          value={name}
+          onChangeText={setName}
+          mode="outlined"
+          style={styles.input}
+        />
+        <TextInput
+          label="설명"
+          value={description}
+          onChangeText={setDescription}
+          mode="outlined"
+          style={styles.input}
+        />
+
+        <Text variant="labelLarge" style={styles.colorLabel}>색상</Text>
+        <View style={styles.colorRow}>
+          <View style={[styles.colorPreview, { backgroundColor: color }]} />
+          <Text style={styles.colorHex}>{color.toUpperCase()}</Text>
+          <IconButton
+            icon="refresh"
+            size={20}
+            onPress={() => setColor(generateRandomColor())}
+          />
+        </View>
+
+        <View style={styles.actions}>
+          {isEdit && onDelete && (
+            <Button mode="text" textColor="#EA4335" onPress={onDelete}>
+              삭제
+            </Button>
+          )}
+          <View style={styles.rightActions}>
+            <Button mode="text" onPress={onDismiss}>취소</Button>
+            <Button mode="contained" onPress={handleSave} disabled={!name.trim()}>
+              저장
+            </Button>
+          </View>
+        </View>
+      </Modal>
+    </Portal>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: 'white',
+    margin: 20,
+    borderRadius: 12,
+    padding: 24,
+  },
+  title: { marginBottom: 16 },
+  input: { marginBottom: 12 },
+  colorLabel: { marginBottom: 8 },
+  colorRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 20,
+    gap: 8,
+  },
+  colorPreview: {
+    width: 36,
+    height: 36,
+    borderRadius: 8,
+  },
+  colorHex: {
+    fontFamily: 'monospace',
+    fontSize: 14,
+    color: '#555',
+    flex: 1,
+  },
+  actions: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  rightActions: {
+    flexDirection: 'row',
+    gap: 8,
+    marginLeft: 'auto',
+  },
+});

--- a/src/constants/colors.ts
+++ b/src/constants/colors.ts
@@ -1,0 +1,19 @@
+// GitHub 태그 스타일 — 채도 낮은 파스텔 계열 랜덤 생성
+export const generateRandomColor = (): string => {
+  const hue = Math.floor(Math.random() * 360);
+  const saturation = 55 + Math.floor(Math.random() * 20); // 55~75%
+  const lightness = 45 + Math.floor(Math.random() * 15);  // 45~60%
+  return hslToHex(hue, saturation, lightness);
+};
+
+const hslToHex = (h: number, s: number, l: number): string => {
+  s /= 100;
+  l /= 100;
+  const a = s * Math.min(l, 1 - l);
+  const f = (n: number) => {
+    const k = (n + h / 30) % 12;
+    const color = l - a * Math.max(Math.min(k - 3, 9 - k, 1), -1);
+    return Math.round(255 * color).toString(16).padStart(2, '0');
+  };
+  return `#${f(0)}${f(8)}${f(4)}`;
+};

--- a/src/db/index.native.ts
+++ b/src/db/index.native.ts
@@ -1,6 +1,5 @@
 import { openDatabaseAsync } from 'expo-sqlite';
 import { drizzle } from 'drizzle-orm/expo-sqlite';
-import { Platform } from 'react-native';
 import * as schema from './schema';
 
 type Db = ReturnType<typeof drizzle<typeof schema>>;
@@ -11,10 +10,7 @@ export let db: Db = null as unknown as Db;
 export const initDb = async () => {
   const sqlite = await openDatabaseAsync('todo.db');
 
-  // WAL mode is not supported on web (sql.js)
-  if (Platform.OS !== 'web') {
-    await sqlite.execAsync('PRAGMA journal_mode = WAL;');
-  }
+  await sqlite.execAsync('PRAGMA journal_mode = WAL;');
 
   await sqlite.execAsync(`
     PRAGMA foreign_keys = ON;
@@ -22,6 +18,7 @@ export const initDb = async () => {
     CREATE TABLE IF NOT EXISTS categories (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       name TEXT NOT NULL,
+      description TEXT,
       color TEXT NOT NULL DEFAULT '#6200ee',
       created_at INTEGER NOT NULL
     );
@@ -45,4 +42,17 @@ export const initDb = async () => {
   `);
 
   db = drizzle(sqlite, { schema });
+
+  // 기본 카테고리 시드
+  const existing = await db.select().from(schema.categories).all();
+  if (existing.length === 0) {
+    const now = Date.now();
+    await db.insert(schema.categories).values([
+      { name: '업무', description: '직장 관련 할 일', color: '#4285F4', createdAt: now },
+      { name: '개인', description: '개인적인 할 일', color: '#EA4335', createdAt: now },
+      { name: '운동', description: '운동 및 건강 관리', color: '#34A853', createdAt: now },
+      { name: '학습', description: '공부 및 자기계발', color: '#FBBC05', createdAt: now },
+      { name: '쇼핑', description: '구매 목록', color: '#9C27B0', createdAt: now },
+    ]).run();
+  }
 };

--- a/src/db/index.web.ts
+++ b/src/db/index.web.ts
@@ -1,0 +1,59 @@
+// Web: sql.js ASM.js 버전 사용 (SharedArrayBuffer 불필요)
+import initSqlJs from 'sql.js/dist/sql-asm.js';
+import { drizzle } from 'drizzle-orm/sql-js';
+import * as schema from './schema';
+
+type Db = ReturnType<typeof drizzle<typeof schema>>;
+
+// eslint-disable-next-line prefer-const
+export let db: Db = null as unknown as Db;
+
+const DDL = `
+  CREATE TABLE IF NOT EXISTS categories (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    description TEXT,
+    color TEXT NOT NULL DEFAULT '#6200ee',
+    created_at INTEGER NOT NULL
+  );
+
+  CREATE TABLE IF NOT EXISTS todos (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    category_id INTEGER NOT NULL REFERENCES categories(id) ON DELETE CASCADE,
+    title TEXT NOT NULL,
+    description TEXT,
+    is_completed INTEGER NOT NULL DEFAULT 0,
+    completed_at INTEGER,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL
+  );
+
+  CREATE TABLE IF NOT EXISTS todo_completions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    todo_id INTEGER NOT NULL REFERENCES todos(id) ON DELETE CASCADE,
+    completed_date TEXT NOT NULL
+  );
+`;
+
+export const initDb = async () => {
+  const SQL = await initSqlJs();
+  const client = new SQL.Database();
+
+  client.run('PRAGMA foreign_keys = ON;');
+  client.run(DDL);
+
+  db = drizzle(client, { schema });
+
+  // 기본 카테고리 시드
+  const existing = db.select().from(schema.categories).all();
+  if (existing.length === 0) {
+    const now = Date.now();
+    db.insert(schema.categories).values([
+      { name: '업무', description: '직장 관련 할 일', color: '#4285F4', createdAt: now },
+      { name: '개인', description: '개인적인 할 일', color: '#EA4335', createdAt: now },
+      { name: '운동', description: '운동 및 건강 관리', color: '#34A853', createdAt: now },
+      { name: '학습', description: '공부 및 자기계발', color: '#FBBC05', createdAt: now },
+      { name: '쇼핑', description: '구매 목록', color: '#9C27B0', createdAt: now },
+    ]).run();
+  }
+};

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -3,6 +3,7 @@ import { int, sqliteTable, text } from 'drizzle-orm/sqlite-core';
 export const categories = sqliteTable('categories', {
   id: int('id').primaryKey({ autoIncrement: true }),
   name: text('name').notNull(),
+  description: text('description'),
   color: text('color').notNull().default('#6200ee'),
   createdAt: int('created_at').notNull(),
 });

--- a/src/hooks/useCategories.ts
+++ b/src/hooks/useCategories.ts
@@ -12,8 +12,18 @@ export const useCategories = () =>
 export const useCreateCategory = () => {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async ({ name, color }: { name: string; color: string }) => {
-      await db.insert(categories).values({ name, color, createdAt: Date.now() }).run();
+    mutationFn: async ({ name, description, color }: { name: string; description?: string; color: string }) => {
+      await db.insert(categories).values({ name, description, color, createdAt: Date.now() }).run();
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['categories'] }),
+  });
+};
+
+export const useUpdateCategory = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ id, name, description, color }: { id: number; name: string; description?: string; color: string }) => {
+      await db.update(categories).set({ name, description, color }).where(eq(categories.id, id)).run();
     },
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['categories'] }),
   });

--- a/src/navigation/SettingsStack.tsx
+++ b/src/navigation/SettingsStack.tsx
@@ -1,0 +1,19 @@
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import SettingsScreen from '../screens/SettingsScreen';
+import CategoryManagementScreen from '../screens/CategoryManagementScreen';
+
+export type SettingsStackParamList = {
+  SettingsHome: undefined;
+  CategoryManagement: undefined;
+};
+
+const Stack = createNativeStackNavigator<SettingsStackParamList>();
+
+export default function SettingsStack() {
+  return (
+    <Stack.Navigator screenOptions={{ headerShown: false }}>
+      <Stack.Screen name="SettingsHome" component={SettingsScreen} />
+      <Stack.Screen name="CategoryManagement" component={CategoryManagementScreen} />
+    </Stack.Navigator>
+  );
+}

--- a/src/navigation/TabNavigator.tsx
+++ b/src/navigation/TabNavigator.tsx
@@ -1,7 +1,7 @@
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import TodoScreen from '../screens/TodoScreen';
 import RecordScreen from '../screens/RecordScreen';
-import SettingsScreen from '../screens/SettingsScreen';
+import SettingsStack from './SettingsStack';
 
 const Tab = createBottomTabNavigator();
 
@@ -10,7 +10,11 @@ export default function TabNavigator() {
     <Tab.Navigator>
       <Tab.Screen name="할일" component={TodoScreen} />
       <Tab.Screen name="기록" component={RecordScreen} />
-      <Tab.Screen name="설정" component={SettingsScreen} />
+      <Tab.Screen
+        name="설정"
+        component={SettingsStack}
+        options={{ headerShown: false }}
+      />
     </Tab.Navigator>
   );
 }

--- a/src/screens/CategoryManagementScreen.tsx
+++ b/src/screens/CategoryManagementScreen.tsx
@@ -1,0 +1,105 @@
+import { useState } from 'react';
+import { View, FlatList, StyleSheet, TouchableOpacity } from 'react-native';
+import { Appbar, Text, Divider, FAB } from 'react-native-paper';
+import { useNavigation } from '@react-navigation/native';
+import { useCategories, useCreateCategory, useUpdateCategory, useDeleteCategory } from '../hooks/useCategories';
+import CategoryFormSheet from '../components/CategoryFormSheet';
+
+type Category = {
+  id: number;
+  name: string;
+  description?: string | null;
+  color: string;
+  createdAt: number;
+};
+
+export default function CategoryManagementScreen() {
+  const navigation = useNavigation();
+  const { data: categories = [] } = useCategories();
+  const { mutate: createCategory } = useCreateCategory();
+  const { mutate: updateCategory } = useUpdateCategory();
+  const { mutate: deleteCategory } = useDeleteCategory();
+
+  const [sheetVisible, setSheetVisible] = useState(false);
+  const [selectedCategory, setSelectedCategory] = useState<Category | null>(null);
+
+  const openCreate = () => {
+    setSelectedCategory(null);
+    setSheetVisible(true);
+  };
+
+  const openEdit = (category: Category) => {
+    setSelectedCategory(category);
+    setSheetVisible(true);
+  };
+
+  const handleSave = (data: { name: string; description?: string; color: string }) => {
+    if (selectedCategory) {
+      updateCategory({ id: selectedCategory.id, ...data });
+    } else {
+      createCategory(data);
+    }
+    setSheetVisible(false);
+  };
+
+  const handleDelete = () => {
+    if (selectedCategory) {
+      deleteCategory(selectedCategory.id);
+      setSheetVisible(false);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <Appbar.Header>
+        <Appbar.BackAction onPress={() => navigation.goBack()} />
+        <Appbar.Content title="카테고리 관리" />
+      </Appbar.Header>
+
+      <FlatList
+        data={categories}
+        keyExtractor={(item) => String(item.id)}
+        ItemSeparatorComponent={() => <Divider />}
+        renderItem={({ item }) => (
+          <TouchableOpacity style={styles.item} onPress={() => openEdit(item)}>
+            <View style={[styles.colorBadge, { backgroundColor: item.color }]} />
+            <View style={styles.itemText}>
+              <Text variant="bodyLarge">{item.name}</Text>
+              {item.description ? (
+                <Text variant="bodySmall" style={styles.description}>{item.description}</Text>
+              ) : null}
+            </View>
+          </TouchableOpacity>
+        )}
+      />
+
+      <FAB icon="plus" style={styles.fab} onPress={openCreate} />
+
+      <CategoryFormSheet
+        visible={sheetVisible}
+        category={selectedCategory}
+        onDismiss={() => setSheetVisible(false)}
+        onSave={handleSave}
+        onDelete={handleDelete}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#fff' },
+  item: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: 16,
+    gap: 12,
+  },
+  colorBadge: {
+    width: 20,
+    height: 20,
+    borderRadius: 10,
+  },
+  itemText: { flex: 1 },
+  description: { color: '#888', marginTop: 2 },
+  fab: { position: 'absolute', right: 16, bottom: 16 },
+});

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -1,14 +1,57 @@
-import { View, StyleSheet } from 'react-native';
-import { Text } from 'react-native-paper';
+import { View, StyleSheet, TouchableOpacity } from 'react-native';
+import { Appbar, Text, Divider } from 'react-native-paper';
+import { useNavigation } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { SettingsStackParamList } from '../navigation/SettingsStack';
+
+type NavigationProp = NativeStackNavigationProp<SettingsStackParamList, 'SettingsHome'>;
+
+const SETTINGS_ITEMS = [
+  { key: 'CategoryManagement', label: '카테고리 관리', description: '카테고리 추가, 수정, 삭제' },
+] as const;
 
 export default function SettingsScreen() {
+  const navigation = useNavigation<NavigationProp>();
+
   return (
     <View style={styles.container}>
-      <Text variant="headlineMedium">설정</Text>
+      <Appbar.Header>
+        <Appbar.Content title="설정" />
+      </Appbar.Header>
+
+      <View style={styles.section}>
+        {SETTINGS_ITEMS.map((item, index) => (
+          <View key={item.key}>
+            <TouchableOpacity
+              style={styles.item}
+              onPress={() => navigation.navigate(item.key)}
+            >
+              <View>
+                <Text variant="bodyLarge">{item.label}</Text>
+                <Text variant="bodySmall" style={styles.description}>{item.description}</Text>
+              </View>
+              <Text style={styles.arrow}>›</Text>
+            </TouchableOpacity>
+            {index < SETTINGS_ITEMS.length - 1 && <Divider />}
+          </View>
+        ))}
+      </View>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  container: { flex: 1, backgroundColor: '#f5f5f5' },
+  section: {
+    backgroundColor: '#fff',
+    marginTop: 16,
+  },
+  item: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    padding: 16,
+  },
+  description: { color: '#888', marginTop: 2 },
+  arrow: { fontSize: 20, color: '#ccc' },
 });


### PR DESCRIPTION
## 관련 이슈
#5

## 작업 내용
설정 화면에 설정 목록을 구성하고 카테고리 생성/수정/삭제 기능을 구현합니다.

## 변경 사항 요약

| 파일 | 변경 내용 |
|------|----------|
| `src/screens/SettingsScreen.tsx` | 설정 목록 UI 구성 |
| `src/screens/CategoryManagementScreen.tsx` | 카테고리 목록 + FAB |
| `src/components/CategoryFormSheet.tsx` | 생성/수정/삭제 모달 |
| `src/navigation/SettingsStack.tsx` | 설정 스택 네비게이터 추가 |
| `src/constants/colors.ts` | GitHub 태그 스타일 랜덤 색상 생성 |
| `src/db/index.native.ts` | 플랫폼 분기 (native) + 시드 데이터 |
| `src/db/index.web.ts` | 플랫폼 분기 (web, sql.js ASM.js) |
| `src/db/schema.ts` | categories에 description 컬럼 추가 |
| `src/hooks/useCategories.ts` | useUpdateCategory 추가 |

## 시각화

```mermaid
graph TD
  Settings[설정 화면] -->|카테고리 관리| CategoryList[카테고리 목록]
  CategoryList -->|FAB +| CreateSheet[생성 모달\n이름 / 설명 / 랜덤 색상]
  CategoryList -->|아이템 탭| EditSheet[수정 모달\n이름 / 설명 / 색상 변경]
  EditSheet -->|삭제| CategoryList
  CreateSheet -->|저장| CategoryList
  EditSheet -->|저장| CategoryList
```

## 테스트
- [ ] 카테고리 생성 (FAB → 모달 → 저장)
- [ ] 카테고리 수정 (아이템 탭 → 모달 → 저장)
- [ ] 카테고리 삭제 (아이템 탭 → 삭제)
- [ ] 랜덤 색상 생성 및 새로고침
- [ ] 기본 카테고리 5개 시드 확인
- [ ] iOS / Android / Web

## 참고 사항
- 웹에서 expo-sqlite SharedArrayBuffer 이슈로 sql.js ASM.js 방식으로 플랫폼 분기 처리
- 색상은 HSL 기반 랜덤 생성 (채도 55~75%, 명도 45~60%)
- 시드 데이터는 고정 색상 사용