### PR TITLE
bugfix: #16 fix todo checkbox toggle not responding to touch

### DIFF
--- a/src/components/TodoItem.tsx
+++ b/src/components/TodoItem.tsx
@@ -27,7 +27,6 @@ type Props = {
 };
 
 const LEVEL_LABELS = ['', '낮음', '보통', '높음'];
-
 const URGENCY_COLOR = '#FF6B6B';
 const IMPORTANCE_COLOR = '#4ECDC4';
 
@@ -40,13 +39,15 @@ export default function TodoItem({ todo, category, onToggle, onPress }: Props) {
   const importanceLevel = todo.importance ?? 0;
 
   return (
-    <TouchableOpacity style={styles.container} onPress={onPress} activeOpacity={0.7}>
-      <Checkbox.Android
-        status={todo.isCompleted === 1 ? 'checked' : 'unchecked'}
-        onPress={onToggle}
-        color={category?.color}
-      />
-      <View style={styles.content}>
+    <View style={styles.container}>
+      <TouchableOpacity onPress={onToggle} activeOpacity={0.6} style={styles.checkboxArea}>
+        <Checkbox.Android
+          status={todo.isCompleted === 1 ? 'checked' : 'unchecked'}
+          color={category?.color}
+        />
+      </TouchableOpacity>
+
+      <TouchableOpacity style={styles.content} onPress={onPress} activeOpacity={0.7}>
         <Text
           variant="bodyLarge"
           style={[styles.titleText, todo.isCompleted === 1 && styles.completed]}
@@ -80,8 +81,8 @@ export default function TodoItem({ todo, category, onToggle, onPress }: Props) {
             </View>
           )}
         </View>
-      </View>
-    </TouchableOpacity>
+      </TouchableOpacity>
+    </View>
   );
 }
 
@@ -89,10 +90,13 @@ const styles = StyleSheet.create({
   container: {
     flexDirection: 'row',
     alignItems: 'center',
-    paddingVertical: 10,
+    paddingVertical: 6,
     paddingHorizontal: 16,
   },
-  content: { flex: 1, marginLeft: 4 },
+  checkboxArea: {
+    padding: 4,
+  },
+  content: { flex: 1, marginLeft: 4, paddingVertical: 4 },
   titleText: { flexShrink: 1 },
   completed: { textDecorationLine: 'line-through', color: Colors.textMuted },
   meta: { flexDirection: 'row', alignItems: 'center', gap: 6, marginTop: 4, flexWrap: 'wrap' },


### PR DESCRIPTION
## Summary
- `Checkbox.Android`를 `TouchableOpacity` 안에 넣으면 부모가 터치 이벤트를 가로채 체크박스 토글이 동작하지 않는 버그 수정
- `TodoItem` 컨테이너를 `TouchableOpacity`에서 `View`로 변경
- 체크박스 영역과 콘텐츠 영역을 독립적인 `TouchableOpacity`로 분리

## Test plan
- [ ] 할 일 목록에서 체크박스 탭 → `isCompleted` 토글 확인
- [ ] 콘텐츠 영역 탭 → 수정 화면으로 이동 확인
- [ ] 체크박스와 콘텐츠 영역이 각각 독립적으로 동작하는지 확인

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)