### PR TITLE
bugfix: #18 할 일 수정 시 카테고리 변경이 반영되지 않는 버그 수정

### DIFF
--- a/src/hooks/useTodos.ts
+++ b/src/hooks/useTodos.ts
@@ -49,6 +49,7 @@ export const useUpdateTodo = () => {
   return useMutation({
     mutationFn: async ({
       id,
+      categoryId,
       title,
       description,
       dueDate,
@@ -56,6 +57,7 @@ export const useUpdateTodo = () => {
       importance,
     }: {
       id: number;
+      categoryId: number;
       title: string;
       description?: string;
       dueDate?: number;
@@ -63,6 +65,7 @@ export const useUpdateTodo = () => {
       importance?: number;
     }) => {
       await db.update(todos).set({
+        categoryId,
         title,
         description: description ?? null,
         dueDate: dueDate ?? null,


### PR DESCRIPTION
## Summary
- `useUpdateTodo`의 `mutationFn` 타입과 `db.update` `.set()`에 `categoryId`가 누락되어 카테고리 변경이 DB에 저장되지 않는 버그 수정
- `TodoFormScreen`에서는 `categoryId`를 정상적으로 전달하고 있었으나, 훅 내부에서 받지 않아 silently drop되던 문제

## Root Cause
```ts
// Before: categoryId 없음
mutationFn: async ({ id, title, description, ... }) => {
  await db.update(todos).set({ title, description, ... }) // categoryId 누락
}

// After: categoryId 추가
mutationFn: async ({ id, categoryId, title, description, ... }) => {
  await db.update(todos).set({ categoryId, title, description, ... })
}
```

## Test plan
- [ ] 할 일 수정 화면에서 카테고리 변경 후 저장
- [ ] 목록 화면에서 변경된 카테고리 색상/이름 즉시 반영 확인

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)