### PR TITLE
feat: #13 할 일 드래그로 우선순위 변경

### DIFF
--- a/src/components/TodoItem.tsx
+++ b/src/components/TodoItem.tsx
@@ -24,13 +24,15 @@ type Props = {
   category?: Category;
   onToggle: () => void;
   onPress: () => void;
+  onDrag?: () => void;
+  isDragging?: boolean;
 };
 
 const LEVEL_LABELS = ['', '낮음', '보통', '높음'];
 const URGENCY_COLOR = '#FF6B6B';
 const IMPORTANCE_COLOR = '#4ECDC4';
 
-export default function TodoItem({ todo, category, onToggle, onPress }: Props) {
+export default function TodoItem({ todo, category, onToggle, onPress, onDrag, isDragging }: Props) {
   const dueDateStr = todo.dueDate
     ? new Date(todo.dueDate).toLocaleDateString('ko-KR', { month: 'short', day: 'numeric' })
     : null;
@@ -39,7 +41,7 @@ export default function TodoItem({ todo, category, onToggle, onPress }: Props) {
   const importanceLevel = todo.importance ?? 0;
 
   return (
-    <View style={styles.container}>
+    <View style={[styles.container, isDragging && styles.containerDragging]}>
       <TouchableOpacity onPress={onToggle} activeOpacity={0.6} style={styles.checkboxArea}>
         <Checkbox.Android
           status={todo.isCompleted === 1 ? 'checked' : 'unchecked'}
@@ -82,6 +84,12 @@ export default function TodoItem({ todo, category, onToggle, onPress }: Props) {
           )}
         </View>
       </TouchableOpacity>
+
+      {onDrag && (
+        <TouchableOpacity onLongPress={onDrag} style={styles.dragHandle} hitSlop={8}>
+          <Text style={styles.dragHandleText}>☰</Text>
+        </TouchableOpacity>
+      )}
     </View>
   );
 }
@@ -92,7 +100,9 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     paddingVertical: 6,
     paddingHorizontal: 16,
+    backgroundColor: Colors.background,
   },
+  containerDragging: { backgroundColor: Colors.surfaceVariant, elevation: 4 },
   checkboxArea: {
     padding: 4,
   },
@@ -108,4 +118,6 @@ const styles = StyleSheet.create({
     borderRadius: 4,
   },
   badgeText: { fontSize: 10, fontWeight: '600' },
+  dragHandle: { paddingLeft: 8, paddingVertical: 4 },
+  dragHandleText: { color: Colors.textMuted, fontSize: 18 },
 });

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -34,12 +34,20 @@ export const initDb = async () => {
       due_date INTEGER,
       urgency INTEGER NOT NULL DEFAULT 0,
       importance INTEGER NOT NULL DEFAULT 0,
+      sort_order INTEGER NOT NULL DEFAULT 0,
       is_completed INTEGER NOT NULL DEFAULT 0,
       completed_at INTEGER,
       created_at INTEGER NOT NULL,
       updated_at INTEGER NOT NULL
     );
   `);
+
+  // migration: add sort_order if not exists (existing installs)
+  try {
+    sqlite.execSync('ALTER TABLE todos ADD COLUMN sort_order INTEGER NOT NULL DEFAULT 0;');
+  } catch {
+    // column already exists, ignore
+  }
 
   sqlite.execSync(`
     CREATE TABLE IF NOT EXISTS todo_completions (

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -20,6 +20,7 @@ export const todos = sqliteTable('todos', {
   dueDate: int('due_date'),
   urgency: int('urgency').default(0),
   importance: int('importance').default(0),
+  sortOrder: int('sort_order').notNull().default(0),
   isCompleted: int('is_completed').notNull().default(0),
   completedAt: int('completed_at'),
   createdAt: int('created_at').notNull(),

--- a/src/hooks/useTodos.ts
+++ b/src/hooks/useTodos.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { eq } from 'drizzle-orm';
+import { asc, eq } from 'drizzle-orm';
 import { db } from '../db';
 import { todos, todoCompletions } from '../db/schema';
 
@@ -7,7 +7,10 @@ export const useTodos = (isCompleted: 0 | 1) =>
   useQuery({
     queryKey: ['todos', isCompleted],
     queryFn: () =>
-      db.select().from(todos).where(eq(todos.isCompleted, isCompleted)).all(),
+      db.select().from(todos)
+        .where(eq(todos.isCompleted, isCompleted))
+        .orderBy(asc(todos.sortOrder))
+        .all(),
   });
 
 export const useCreateTodo = () => {
@@ -28,6 +31,8 @@ export const useCreateTodo = () => {
       urgency?: number;
       importance?: number;
     }) => {
+      const all = db.select().from(todos).where(eq(todos.isCompleted, 0)).all();
+      const minOrder = all.reduce((min, t) => Math.min(min, t.sortOrder), 0);
       const now = Date.now();
       await db.insert(todos).values({
         categoryId,
@@ -36,6 +41,7 @@ export const useCreateTodo = () => {
         dueDate: dueDate ?? null,
         urgency: urgency ?? 0,
         importance: importance ?? 0,
+        sortOrder: minOrder - 1,
         createdAt: now,
         updatedAt: now,
       }).run();
@@ -117,6 +123,18 @@ export const useClearCompleted = () => {
   return useMutation({
     mutationFn: async () => {
       await db.delete(todos).where(eq(todos.isCompleted, 1)).run();
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['todos'] }),
+  });
+};
+
+export const useReorderTodos = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (orderedIds: number[]) => {
+      for (let i = 0; i < orderedIds.length; i++) {
+        await db.update(todos).set({ sortOrder: i }).where(eq(todos.id, orderedIds[i])).run();
+      }
     },
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['todos'] }),
   });

--- a/src/screens/TodoScreen.tsx
+++ b/src/screens/TodoScreen.tsx
@@ -1,16 +1,29 @@
-import { View, FlatList, StyleSheet } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import { Appbar, Text, FAB, Button, Divider } from 'react-native-paper';
 import { Colors } from '../theme';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useState } from 'react';
 import { useCategories } from '../hooks/useCategories';
-import { useTodos, useToggleTodo, useClearCompleted } from '../hooks/useTodos';
+import { useTodos, useToggleTodo, useClearCompleted, useReorderTodos } from '../hooks/useTodos';
 import TodoItem from '../components/TodoItem';
 import { TodoStackParamList } from '../navigation/TodoStack';
+import DraggableFlatList, { RenderItemParams, ScaleDecorator } from 'react-native-draggable-flatlist';
 
 type Nav = NativeStackNavigationProp<TodoStackParamList, 'TodoList'>;
 type Tab = 'active' | 'completed';
+
+type Todo = {
+  id: number;
+  title: string;
+  description?: string | null;
+  dueDate?: number | null;
+  urgency?: number | null;
+  importance?: number | null;
+  isCompleted: number;
+  categoryId: number;
+  sortOrder: number;
+};
 
 export default function TodoScreen() {
   const navigation = useNavigation<Nav>();
@@ -21,9 +34,23 @@ export default function TodoScreen() {
   const { data: categories = [] } = useCategories();
   const { mutate: toggleTodo } = useToggleTodo();
   const { mutate: clearCompleted } = useClearCompleted();
+  const { mutate: reorderTodos } = useReorderTodos();
 
   const currentTodos = activeTab === 'active' ? activeTodos : completedTodos;
   const getCategoryById = (id: number) => categories.find((c) => c.id === id);
+
+  const renderItem = ({ item, drag, isActive }: RenderItemParams<Todo>) => (
+    <ScaleDecorator>
+      <TodoItem
+        todo={item}
+        category={getCategoryById(item.categoryId)}
+        onToggle={() => toggleTodo({ id: item.id, isCompleted: item.isCompleted })}
+        onPress={() => navigation.navigate('TodoForm', { todo: item })}
+        onDrag={activeTab === 'active' ? drag : undefined}
+        isDragging={isActive}
+      />
+    </ScaleDecorator>
+  );
 
   return (
     <View style={styles.container}>
@@ -53,8 +80,8 @@ export default function TodoScreen() {
         </Button>
       </View>
 
-      <FlatList
-        data={currentTodos}
+      <DraggableFlatList
+        data={currentTodos as Todo[]}
         keyExtractor={(item) => String(item.id)}
         ItemSeparatorComponent={() => <Divider />}
         ListEmptyComponent={
@@ -62,14 +89,15 @@ export default function TodoScreen() {
             {activeTab === 'active' ? '할 일이 없어요' : '완료된 항목이 없어요'}
           </Text>
         }
-        renderItem={({ item }) => (
-          <TodoItem
-            todo={item}
-            category={getCategoryById(item.categoryId)}
-            onToggle={() => toggleTodo({ id: item.id, isCompleted: item.isCompleted })}
-            onPress={() => navigation.navigate('TodoForm', { todo: item })}
-          />
-        )}
+        renderItem={renderItem}
+        onDragEnd={({ data }) => {
+          if (activeTab === 'active') {
+            reorderTodos(data.map((t) => t.id));
+          }
+        }}
+        autoscrollThreshold={80}
+        autoscrollSpeed={200}
+        containerStyle={{ flex: 1 }}
       />
 
       {activeTab === 'active' && (


### PR DESCRIPTION
## Summary
- `todos` 테이블에 `sort_order` 컬럼 추가 (기존 설치 대응 migration 포함)
- 새로 등록된 할 일은 목록 최상단에 배치 (`minOrder - 1`)
- `FlatList` → `DraggableFlatList` 교체, 진행 중 탭에서만 드래그 활성화
- `useReorderTodos` 훅으로 순서 변경 시 DB에 즉시 저장
- 드래그 핸들(`☰`) 진행 중 탭 아이템에만 표시
- 드래그 중인 아이템 `surfaceVariant` 배경 강조 (카테고리 화면과 동일)

## Test plan
- [ ] 진행 중 탭에서 `☰` 핸들 길게 누르면 드래그 가능한지 확인
- [ ] 드래그 후 앱 재시작해도 순서 유지되는지 확인
- [ ] 새 할 일 등록 시 목록 최상단에 추가되는지 확인
- [ ] 완료 탭에서는 핸들 미표시 및 드래그 비활성화 확인
- [ ] 드래그 중 아이템 배경 강조 표시 확인

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)