### PR TITLE
feat: #24 기록 화면 잔디 그리드 컴포넌트

### DIFF
--- a/src/components/ContributionGrid.tsx
+++ b/src/components/ContributionGrid.tsx
@@ -1,0 +1,102 @@
+import { ScrollView, View, StyleSheet } from 'react-native';
+import { Colors } from '../theme';
+import { useCompletionsByCategory } from '../hooks/useCompletions';
+
+type Props = {
+  categoryId: number;
+  color: string;
+  year: number;
+};
+
+const CELL_SIZE = 11;
+const CELL_GAP = 2;
+const DAYS_IN_WEEK = 7;
+
+// 완료 수 → 색상 (0=빈셀, 1=20%, 2=40%, 3=65%, 4+=85%)
+const OPACITY_HEX = ['', '33', '66', 'A6', 'D9'];
+
+function getCellColor(count: number, baseColor: string): string {
+  if (count === 0) return Colors.surface;
+  const opacityIndex = Math.min(count, 4);
+  const opacity = OPACITY_HEX[opacityIndex];
+  // 4 이상은 불투명도 100% → 색상 그대로
+  return opacity === 'FF' ? baseColor : baseColor + opacity;
+}
+
+const TODAY = new Date();
+TODAY.setHours(23, 59, 59, 999);
+
+function buildGrid(year: number): { date: string; isFuture: boolean }[] {
+  const dates: { date: string; isFuture: boolean }[] = [];
+  for (let d = new Date(year, 0, 1); d.getFullYear() === year; d.setDate(d.getDate() + 1)) {
+    const mm = String(d.getMonth() + 1).padStart(2, '0');
+    const dd = String(d.getDate()).padStart(2, '0');
+    dates.push({ date: `${year}-${mm}-${dd}`, isFuture: d > TODAY });
+  }
+  return dates;
+}
+
+type Cell = { date: string; isFuture: boolean } | null;
+
+function groupByWeek(dates: { date: string; isFuture: boolean }[], year: number): Cell[][] {
+  const jan1DayOfWeek = new Date(year, 0, 1).getDay();
+  const padded: Cell[] = [...Array(jan1DayOfWeek).fill(null), ...dates];
+
+  const weeks: Cell[][] = [];
+  for (let i = 0; i < padded.length; i += DAYS_IN_WEEK) {
+    const week = padded.slice(i, i + DAYS_IN_WEEK);
+    while (week.length < DAYS_IN_WEEK) week.push(null);
+    weeks.push(week);
+  }
+  return weeks;
+}
+
+export default function ContributionGrid({ categoryId, color, year }: Props) {
+  const { data: completionMap = {} } = useCompletionsByCategory(categoryId, year);
+
+  const dates = buildGrid(year);
+  const weeks = groupByWeek(dates, year);
+
+  return (
+    <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+      <View style={styles.grid}>
+        {weeks.map((week, wi) => (
+          <View key={wi} style={styles.column}>
+            {week.map((cell, di) => {
+              let cellColor = 'transparent';
+              if (cell) {
+                cellColor = cell.isFuture
+                  ? Colors.surface
+                  : getCellColor(completionMap[cell.date] ?? 0, color);
+              }
+              return (
+                <View
+                  key={di}
+                  style={[styles.cell, { backgroundColor: cellColor }]}
+                />
+              );
+            })}
+          </View>
+        ))}
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  grid: {
+    flexDirection: 'row',
+    flexWrap: 'nowrap',
+    gap: CELL_GAP,
+    paddingVertical: 2,
+  },
+  column: {
+    flexDirection: 'column',
+    gap: CELL_GAP,
+  },
+  cell: {
+    width: CELL_SIZE,
+    height: CELL_SIZE,
+    borderRadius: 2,
+  },
+});

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -35,8 +35,11 @@ export const initDb = async () => {
       urgency INTEGER NOT NULL DEFAULT 0,
       importance INTEGER NOT NULL DEFAULT 0,
       sort_order INTEGER NOT NULL DEFAULT 0,
+      sort_order INTEGER NOT NULL DEFAULT 0,
       is_completed INTEGER NOT NULL DEFAULT 0,
       completed_at INTEGER,
+      is_deleted INTEGER NOT NULL DEFAULT 0,
+      deleted_at INTEGER,
       created_at INTEGER NOT NULL,
       updated_at INTEGER NOT NULL
     );
@@ -45,9 +48,22 @@ export const initDb = async () => {
   // migration: add sort_order if not exists (existing installs)
   try {
     sqlite.execSync('ALTER TABLE todos ADD COLUMN sort_order INTEGER NOT NULL DEFAULT 0;');
-  } catch {
-    // column already exists, ignore
-  }
+  } catch { /* already exists */ }
+
+  // migration: add soft delete columns if not exists
+  try {
+    sqlite.execSync('ALTER TABLE todos ADD COLUMN is_deleted INTEGER NOT NULL DEFAULT 0;');
+  } catch { /* already exists */ }
+  try {
+    sqlite.execSync('ALTER TABLE todos ADD COLUMN deleted_at INTEGER;');
+  } catch { /* already exists */ }
+
+  // migration: remove stale completion records for uncompleted/deleted todos
+  // (bug: toggle-back did not delete todoCompletions until fixed)
+  sqlite.execSync(`
+    DELETE FROM todo_completions
+    WHERE todo_id IN (SELECT id FROM todos WHERE is_completed = 0 OR is_deleted = 1);
+  `);
 
   sqlite.execSync(`
     CREATE TABLE IF NOT EXISTS todo_completions (

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -23,6 +23,8 @@ export const todos = sqliteTable('todos', {
   sortOrder: int('sort_order').notNull().default(0),
   isCompleted: int('is_completed').notNull().default(0),
   completedAt: int('completed_at'),
+  isDeleted: int('is_deleted').notNull().default(0),
+  deletedAt: int('deleted_at'),
   createdAt: int('created_at').notNull(),
   updatedAt: int('updated_at').notNull(),
 });

--- a/src/hooks/useCompletions.ts
+++ b/src/hooks/useCompletions.ts
@@ -3,6 +3,21 @@ import { eq, and, gte, lte, sql } from 'drizzle-orm';
 import { db } from '../db';
 import { todoCompletions, todos } from '../db/schema';
 
+export const useEarliestCompletionYear = () =>
+  useQuery({
+    queryKey: ['completions', 'earliest-year'],
+    queryFn: () => {
+      const row = db
+        .select({ minDate: sql<string>`min(${todoCompletions.completedDate})` })
+        .from(todoCompletions)
+        .get();
+      if (!row?.minDate) return CURRENT_YEAR;
+      return parseInt(row.minDate.slice(0, 4), 10);
+    },
+  });
+
+const CURRENT_YEAR = new Date().getFullYear();
+
 // 특정 카테고리 + 년도 범위의 날짜별 완료 수 반환
 // { '2026-01-03': 2, '2026-01-05': 1, ... }
 export const useCompletionsByCategory = (categoryId: number, year: number) =>

--- a/src/hooks/useTodos.ts
+++ b/src/hooks/useTodos.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { asc, eq } from 'drizzle-orm';
+import { and, asc, eq } from 'drizzle-orm';
 import { db } from '../db';
 import { todos, todoCompletions } from '../db/schema';
 
@@ -8,7 +8,7 @@ export const useTodos = (isCompleted: 0 | 1) =>
     queryKey: ['todos', isCompleted],
     queryFn: () =>
       db.select().from(todos)
-        .where(eq(todos.isCompleted, isCompleted))
+        .where(and(eq(todos.isCompleted, isCompleted), eq(todos.isDeleted, 0)))
         .orderBy(asc(todos.sortOrder))
         .all(),
   });
@@ -31,7 +31,9 @@ export const useCreateTodo = () => {
       urgency?: number;
       importance?: number;
     }) => {
-      const all = db.select().from(todos).where(eq(todos.isCompleted, 0)).all();
+      const all = db.select().from(todos)
+        .where(and(eq(todos.isCompleted, 0), eq(todos.isDeleted, 0)))
+        .all();
       const minOrder = all.reduce((min, t) => Math.min(min, t.sortOrder), 0);
       const now = Date.now();
       await db.insert(todos).values({
@@ -96,9 +98,13 @@ export const useToggleTodo = () => {
         updatedAt: now,
       }).where(eq(todos.id, id)).run();
 
+      const today = new Date().toISOString().split('T')[0];
       if (newCompleted === 1) {
-        const today = new Date().toISOString().split('T')[0];
         await db.insert(todoCompletions).values({ todoId: id, completedDate: today }).run();
+      } else {
+        await db.delete(todoCompletions)
+          .where(and(eq(todoCompletions.todoId, id), eq(todoCompletions.completedDate, today)))
+          .run();
       }
     },
     onSuccess: () => {
@@ -112,7 +118,11 @@ export const useDeleteTodo = () => {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async (id: number) => {
-      await db.delete(todos).where(eq(todos.id, id)).run();
+      await db.update(todos).set({
+        isDeleted: 1,
+        deletedAt: Date.now(),
+        updatedAt: Date.now(),
+      }).where(eq(todos.id, id)).run();
     },
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['todos'] }),
   });
@@ -122,7 +132,12 @@ export const useClearCompleted = () => {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async () => {
-      await db.delete(todos).where(eq(todos.isCompleted, 1)).run();
+      const now = Date.now();
+      await db.update(todos).set({
+        isDeleted: 1,
+        deletedAt: now,
+        updatedAt: now,
+      }).where(and(eq(todos.isCompleted, 1), eq(todos.isDeleted, 0))).run();
     },
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['todos'] }),
   });

--- a/src/screens/RecordScreen.tsx
+++ b/src/screens/RecordScreen.tsx
@@ -3,19 +3,23 @@ import { View, ScrollView, StyleSheet } from 'react-native';
 import { Appbar, Text, IconButton } from 'react-native-paper';
 import { Colors } from '../theme';
 import { useCategories } from '../hooks/useCategories';
+import { useEarliestCompletionYear } from '../hooks/useCompletions';
+import ContributionGrid from '../components/ContributionGrid';
 
 const CURRENT_YEAR = new Date().getFullYear();
 
 export default function RecordScreen() {
   const [year, setYear] = useState(CURRENT_YEAR);
   const { data: categories = [] } = useCategories();
+  const { data: earliestYear = CURRENT_YEAR } = useEarliestCompletionYear();
 
   return (
     <View style={styles.container}>
       <Appbar.Header>
         <IconButton
           icon="chevron-left"
-          iconColor={Colors.text}
+          iconColor={year <= earliestYear ? Colors.textMuted : Colors.text}
+          disabled={year <= earliestYear}
           onPress={() => setYear((y) => y - 1)}
         />
         <Appbar.Content title={String(year)} titleStyle={styles.yearTitle} />
@@ -41,8 +45,7 @@ export default function RecordScreen() {
                 </Text>
               ) : null}
             </View>
-            {/* 잔디 그리드는 이슈 #24에서 구현 */}
-            <View style={styles.gridPlaceholder} />
+            <ContributionGrid categoryId={category.id} color={category.color} year={year} />
           </View>
         ))}
       </ScrollView>
@@ -67,9 +70,4 @@ const styles = StyleSheet.create({
   dot: { width: 10, height: 10, borderRadius: 5 },
   categoryName: { color: Colors.text },
   categoryDesc: { color: Colors.textMuted, flexShrink: 1 },
-  gridPlaceholder: {
-    height: 80,
-    backgroundColor: Colors.surface,
-    borderRadius: 6,
-  },
 });


### PR DESCRIPTION
## Summary
- `ContributionGrid`: 52주×7일 격자, 카테고리 색상 농도 단계별 표시 (20/40/65/85%)
- 1년 전체 렌더링, 미래 날짜는 빈 셀로 표시
- 좌측 화살표: 가장 오래된 completion 기록 년도까지만 이동 가능
- **Soft delete 도입**: `todos`에 `is_deleted`, `deleted_at` 컬럼 추가
  - `useDeleteTodo`, `useClearCompleted` → soft delete로 전환
  - 모든 todo 조회에 `isDeleted = 0` 필터 적용
- **완료 토글 버그 수정**: 완료 해제 시 오늘 날짜의 `todoCompletions` 레코드 삭제
- **Migration**: 미완료/삭제된 할 일의 stale completion 기록 정리

## Test plan
- [ ] 기록 화면에서 카테고리별 잔디 그리드 표시 확인
- [ ] 완료한 할 일이 해당 날짜 셀에 반영되는지 확인
- [ ] 완료 해제 시 셀 비워지는지 확인
- [ ] 할 일 삭제 후 DB에 실제로 남아있는지 확인 (soft delete)
- [ ] 좌측 화살표가 첫 데이터 년도에서 비활성화되는지 확인

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)