### PR TITLE
feat: #27 하단 탭 아이콘/텍스트 및 삭제 버튼 UI 개선

### DIFF
--- a/src/navigation/TabNavigator.tsx
+++ b/src/navigation/TabNavigator.tsx
@@ -1,16 +1,48 @@
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
 import TodoStack from './TodoStack';
 import RecordScreen from '../screens/RecordScreen';
 import SettingsStack from './SettingsStack';
 
 const Tab = createBottomTabNavigator();
 
+type IconProps = { color: string; size: number };
+
 export default function TabNavigator() {
   return (
-    <Tab.Navigator screenOptions={{ headerShown: false }}>
-      <Tab.Screen name="할일" component={TodoStack} />
-      <Tab.Screen name="기록" component={RecordScreen} />
-      <Tab.Screen name="설정" component={SettingsStack} />
+    <Tab.Navigator
+      screenOptions={{
+        headerShown: false,
+        tabBarLabelStyle: { fontSize: 11 },
+      }}
+    >
+      <Tab.Screen
+        name="할 일"
+        component={TodoStack}
+        options={{
+          tabBarIcon: ({ color, size }: IconProps) => (
+            <MaterialCommunityIcons name="checkbox-marked-circle-outline" size={size} color={color} />
+          ),
+        }}
+      />
+      <Tab.Screen
+        name="기록"
+        component={RecordScreen}
+        options={{
+          tabBarIcon: ({ color, size }: IconProps) => (
+            <MaterialCommunityIcons name="calendar-month-outline" size={size} color={color} />
+          ),
+        }}
+      />
+      <Tab.Screen
+        name="설정"
+        component={SettingsStack}
+        options={{
+          tabBarIcon: ({ color, size }: IconProps) => (
+            <MaterialCommunityIcons name="cog-outline" size={size} color={color} />
+          ),
+        }}
+      />
     </Tab.Navigator>
   );
 }

--- a/src/screens/CategoryFormScreen.tsx
+++ b/src/screens/CategoryFormScreen.tsx
@@ -58,19 +58,12 @@ export default function CategoryFormScreen() {
       <Appbar.Header>
         <Appbar.BackAction onPress={() => navigation.goBack()} />
         <Appbar.Content title={isEdit ? '카테고리 수정' : '새 카테고리'} />
-        {isEdit && (
-          <Appbar.Action
-            icon="delete-outline"
-            iconColor="#EA4335"
-            onPress={() => setDeleteDialogVisible(true)}
-          />
-        )}
         <Button
           mode="contained"
           onPress={handleSave}
           disabled={!name.trim()}
           style={styles.saveButton}
-          labelStyle={styles.saveButtonLabel}
+          labelStyle={styles.actionButtonLabel}
         >
           저장
         </Button>
@@ -106,6 +99,18 @@ export default function CategoryFormScreen() {
           />
         </View>
 
+        {isEdit && (
+          <Button
+            mode="outlined"
+            textColor="#B03A2E"
+            icon="delete-outline"
+            onPress={() => setDeleteDialogVisible(true)}
+            style={styles.deleteButton}
+            labelStyle={styles.actionButtonLabel}
+          >
+            삭제
+          </Button>
+        )}
       </ScrollView>
 
       <Portal>
@@ -133,8 +138,9 @@ const styles = StyleSheet.create({
   input: { marginBottom: 16 },
   descriptionInput: { minHeight: 80 },
   label: { marginBottom: 12 },
+  deleteButton: { marginTop: 8 },
   saveButton: { marginRight: 8, alignSelf: 'center' },
-  saveButtonLabel: { fontSize: 14 },
+  actionButtonLabel: { fontSize: 14 },
   colorPreviewRow: {
     flexDirection: 'row',
     alignItems: 'center',

--- a/src/screens/TodoFormScreen.tsx
+++ b/src/screens/TodoFormScreen.tsx
@@ -82,15 +82,12 @@ export default function TodoFormScreen() {
       <Appbar.Header>
         <Appbar.BackAction onPress={() => navigation.goBack()} />
         <Appbar.Content title={isEdit ? '할 일 수정' : '새 할 일'} />
-        {isEdit && (
-          <Appbar.Action icon="delete-outline" iconColor="#EA4335" onPress={() => setDeleteDialogVisible(true)} />
-        )}
         <Button
           mode="contained"
           onPress={handleSave}
           disabled={!title.trim()}
           style={styles.saveButton}
-          labelStyle={styles.saveButtonLabel}
+          labelStyle={styles.actionButtonLabel}
         >
           저장
         </Button>
@@ -201,6 +198,19 @@ export default function TodoFormScreen() {
           buttons={LEVEL_OPTIONS}
           style={styles.segment}
         />
+
+        {isEdit && (
+          <Button
+            mode="outlined"
+            textColor="#B03A2E"
+            icon="delete-outline"
+            onPress={() => setDeleteDialogVisible(true)}
+            style={styles.deleteButton}
+            labelStyle={styles.actionButtonLabel}
+          >
+            삭제
+          </Button>
+        )}
       </ScrollView>
 
       <Portal>
@@ -225,8 +235,9 @@ const styles = StyleSheet.create({
   input: { marginBottom: 16 },
   descriptionInput: { minHeight: 120 },
   label: { marginBottom: 8, marginTop: 4 },
+  deleteButton: { marginTop: 8 },
   saveButton: { marginRight: 8, alignSelf: 'center' },
-  saveButtonLabel: { fontSize: 14 },
+  actionButtonLabel: { fontSize: 14 },
   dateButton: {
     flexDirection: 'row',
     alignItems: 'center',


### PR DESCRIPTION
## Summary
- 하단 탭 아이콘 교체: `MaterialCommunityIcons` (checkbox-marked-circle-outline / calendar-month-outline / cog-outline)
- "할일" → "할 일" 띄어쓰기 수정, 탭 레이블 `fontSize: 11`
- 삭제 버튼: 헤더 아이콘 → 폼 하단 outlined 버튼 (`delete-outline` 아이콘 + "삭제" 텍스트)
- 삭제 버튼 색상: `#EA4335` → `#B03A2E` (채도/밝기 낮춤)
- 할 일 수정 / 카테고리 수정 화면 모두 적용

## Test plan
- [ ] 하단 탭 3개 아이콘 및 텍스트 확인
- [ ] 할 일 수정 화면 하단 삭제 버튼 확인
- [ ] 카테고리 수정 화면 하단 삭제 버튼 확인
- [ ] 신규 등록 화면에서 삭제 버튼 미표시 확인

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)