### PR TITLE
fix: #31 탭 전환 시 스택 상태 초기화

### DIFF
--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -1,8 +1,9 @@
 import { View, StyleSheet, TouchableOpacity } from 'react-native';
 import { Appbar, Text, Divider } from 'react-native-paper';
 import { Colors } from '../theme';
-import { useNavigation } from '@react-navigation/native';
+import { useNavigation, CommonActions } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { useEffect } from 'react';
 import { SettingsStackParamList } from '../navigation/SettingsStack';
 
 type NavigationProp = NativeStackNavigationProp<SettingsStackParamList, 'SettingsHome'>;
@@ -13,6 +14,16 @@ const SETTINGS_ITEMS = [
 
 export default function SettingsScreen() {
   const navigation = useNavigation<NavigationProp>();
+
+  useEffect(() => {
+    const parentNav = navigation.getParent();
+    if (!parentNav) return;
+    return parentNav.addListener('focus', () => {
+      navigation.setOptions({ animation: 'none' });
+      navigation.dispatch(CommonActions.reset({ index: 0, routes: [{ name: 'SettingsHome' }] }));
+      requestAnimationFrame(() => navigation.setOptions({ animation: 'default' }));
+    });
+  }, [navigation]);
 
   return (
     <View style={styles.container}>

--- a/src/screens/TodoScreen.tsx
+++ b/src/screens/TodoScreen.tsx
@@ -1,9 +1,9 @@
 import { StyleSheet, View } from 'react-native';
 import { Appbar, Text, FAB, Button, Divider, Dialog, Portal } from 'react-native-paper';
 import { Colors } from '../theme';
-import { useNavigation } from '@react-navigation/native';
+import { useNavigation, CommonActions } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useCategories } from '../hooks/useCategories';
 import { useTodos, useToggleTodo, useClearCompleted, useReorderTodos } from '../hooks/useTodos';
 import TodoItem from '../components/TodoItem';
@@ -29,6 +29,17 @@ export default function TodoScreen() {
   const navigation = useNavigation<Nav>();
   const [activeTab, setActiveTab] = useState<Tab>('active');
   const [clearDialogVisible, setClearDialogVisible] = useState(false);
+
+  useEffect(() => {
+    const parentNav = navigation.getParent();
+    if (!parentNav) return;
+    return parentNav.addListener('focus', () => {
+      setActiveTab('active');
+      navigation.setOptions({ animation: 'none' });
+      navigation.dispatch(CommonActions.reset({ index: 0, routes: [{ name: 'TodoList' }] }));
+      requestAnimationFrame(() => navigation.setOptions({ animation: 'default' }));
+    });
+  }, [navigation]);
 
   const { data: activeTodos = [] } = useTodos(0);
   const { data: completedTodos = [] } = useTodos(1);


### PR DESCRIPTION
## Summary
- 탭 진입(focus) 시 각 탭의 스택을 루트 화면으로 초기화
- 할 일 탭: TodoList로 스택 초기화 + activeTab → 'active' 리셋
- 설정 탭: SettingsHome으로 스택 초기화
- 스택 초기화 시 `animation: 'none'` 적용 후 `requestAnimationFrame`으로 `'default'` 복원
  - 초기화 자체는 애니메이션 없이 즉시
  - 이후 페이지 이동은 기본 슬라이드 애니메이션 유지

## Test plan
- [ ] 할 일 탭 → 완료 탭 선택 → 다른 탭 이동 → 돌아오면 진행 중 탭으로 초기화 확인
- [ ] 설정 → 카테고리 추가 폼 진입 → 다른 탭 이동 → 돌아오면 설정 홈으로 초기화 확인
- [ ] 초기화 시 슬라이딩 애니메이션 없는지 확인
- [ ] 이후 페이지 이동(카테고리 관리 진입 등) 자연스러운 애니메이션 확인

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)