### PR TITLE
chore: #33 기록 화면 확인용 개발 임시 데이터 생성

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -66,6 +66,13 @@ export const initDb = async () => {
   `);
 
   sqlite.execSync(`
+    CREATE TABLE IF NOT EXISTS app_settings (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL
+    );
+  `);
+
+  sqlite.execSync(`
     CREATE TABLE IF NOT EXISTS todo_completions (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       todo_id INTEGER NOT NULL REFERENCES todos(id) ON DELETE CASCADE,
@@ -74,6 +81,12 @@ export const initDb = async () => {
   `);
 
   db = drizzle(sqlite, { schema });
+
+  // 개발 환경 임시 데이터 (1회 실행, 재생성은 seed.ts 주석 참고)
+  if (__DEV__) {
+    const { runDevSeed } = require('./seed');
+    runDevSeed();
+  }
 
   const existing = db.select().from(schema.categories).all();
   if (existing.length === 0) {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -29,6 +29,11 @@ export const todos = sqliteTable('todos', {
   updatedAt: int('updated_at').notNull(),
 });
 
+export const appSettings = sqliteTable('app_settings', {
+  key: text('key').primaryKey(),
+  value: text('value').notNull(),
+});
+
 export const todoCompletions = sqliteTable('todo_completions', {
   id: int('id').primaryKey({ autoIncrement: true }),
   todoId: int('todo_id')

--- a/src/db/seed.ts
+++ b/src/db/seed.ts
@@ -1,0 +1,109 @@
+/**
+ * 개발용 임시 데이터 생성 (DEV only)
+ *
+ * ✅ 프로덕션 안전:
+ *   __DEV__ 는 Metro 번들러(로컬 개발)에서만 true.
+ *   eas build / 프로덕션 빌드에서는 false → 이 파일 전체가 실행되지 않음.
+ *
+ * ✅ 1회 실행:
+ *   app_settings 테이블의 'seed_v1' 키로 중복 실행 방지.
+ *
+ * 🔄 재생성 방법 (앱 재시작 필요):
+ *   Expo DevTools 또는 앱 내 DB 쿼리 실행:
+ *
+ *     DELETE FROM app_settings WHERE key = 'seed_v1';
+ *
+ *   위 한 줄만 실행하면 다음 앱 시작 시 seed 데이터가 다시 생성됨.
+ *   (기존 seed 완료 기록도 함께 초기화하려면 앱 삭제 후 재설치)
+ */
+
+import { eq } from 'drizzle-orm';
+import { db } from './index';
+import { categories, todos, todoCompletions, appSettings } from './schema';
+
+const SEED_KEY = 'seed_v2';
+
+// 카테고리별 하루 완료 확률 (0~1) — 다양한 패턴 연출
+const CATEGORY_FREQUENCY: Record<string, number> = {
+  default: 0.5,
+  업무: 0.8,
+  개인: 0.65,
+  운동: 0.7,
+  학습: 0.6,
+  쇼핑: 0.3,
+};
+
+// 하루 최대 완료 수 (1~max 랜덤)
+const MAX_PER_DAY = 4;
+
+// 생성 기간 (일)
+const SEED_DAYS = 730; // 2년
+
+function dateToString(date: Date): string {
+  const mm = String(date.getMonth() + 1).padStart(2, '0');
+  const dd = String(date.getDate()).padStart(2, '0');
+  return `${date.getFullYear()}-${mm}-${dd}`;
+}
+
+export async function runDevSeed() {
+  if (!__DEV__) return;
+
+  // 이미 실행됐으면 스킵
+  const flag = db.select().from(appSettings).where(eq(appSettings.key, SEED_KEY)).get();
+  if (flag) return;
+
+  const allCategories = db.select().from(categories).all();
+  if (allCategories.length === 0) return;
+
+  const now = Date.now();
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  // 카테고리별 시드 todo 1개씩 생성
+  const seedTodoIds: Record<number, number> = {};
+  for (const cat of allCategories) {
+    const result = db.insert(todos).values({
+      categoryId: cat.id,
+      title: `[seed] ${cat.name} 활동`,
+      sortOrder: -9999,
+      isCompleted: 1,
+      completedAt: now,
+      createdAt: now,
+      updatedAt: now,
+    }).returning({ id: todos.id }).get();
+    if (result) seedTodoIds[cat.id] = result.id;
+  }
+
+  // 지난 365일 completions 생성
+  const completionValues: { todoId: number; completedDate: string }[] = [];
+
+  for (let i = SEED_DAYS - 1; i >= 0; i--) {
+    const date = new Date(today);
+    date.setDate(date.getDate() - i);
+    const dateStr = dateToString(date);
+
+    for (const cat of allCategories) {
+      const todoId = seedTodoIds[cat.id];
+      if (!todoId) continue;
+
+      const freq = CATEGORY_FREQUENCY[cat.name] ?? CATEGORY_FREQUENCY.default;
+      if (Math.random() > freq) continue;
+
+      const count = Math.floor(Math.random() * MAX_PER_DAY) + 1;
+      for (let c = 0; c < count; c++) {
+        completionValues.push({ todoId, completedDate: dateStr });
+      }
+    }
+  }
+
+  // 배치 삽입
+  const BATCH = 200;
+  for (let i = 0; i < completionValues.length; i += BATCH) {
+    db.insert(todoCompletions).values(completionValues.slice(i, i + BATCH)).run();
+  }
+
+  // 완료 플래그 저장
+  db.insert(appSettings).values({ key: SEED_KEY, value: '1' }).run();
+
+  console.log(`[seed] ${completionValues.length}개 completion 생성 완료`);
+}


### PR DESCRIPTION
## Summary
- `app_settings` 테이블 추가 (seed 완료 플래그 저장용)
- `__DEV__` 환경에서만 실행, 프로덕션 빌드에서는 완전히 비활성화
- 지난 730일(2년) `todoCompletions` 생성, 카테고리별 다른 빈도
- `seed_v2` 키로 1회 실행 관리

## 카테고리별 완료 확률
| 카테고리 | 확률 | 하루 최대 |
|---------|------|---------|
| 업무 | 80% | 4건 |
| 운동 | 70% | 4건 |
| 개인 | 65% | 4건 |
| 학습 | 60% | 4건 |
| 미분류 | 50% | 4건 |
| 쇼핑 | 30% | 4건 |

## 재생성 방법
```sql
DELETE FROM app_settings WHERE key = 'seed_v2';
```
앱 재시작 시 자동 재생성. 완전 초기화는 앱 삭제 후 재설치.

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)