### PR TITLE
feat: #35 contribution grid UI improvements

### DIFF
--- a/src/components/ContributionGrid.tsx
+++ b/src/components/ContributionGrid.tsx
@@ -1,4 +1,4 @@
-import { ScrollView, View, StyleSheet } from 'react-native';
+import { View, StyleSheet } from 'react-native';
 import { Colors } from '../theme';
 import { useCompletionsByCategory } from '../hooks/useCompletions';
 
@@ -8,9 +8,16 @@ type Props = {
   year: number;
 };
 
-const CELL_SIZE = 11;
 const CELL_GAP = 2;
 const DAYS_IN_WEEK = 7;
+const NUM_WEEKS = 53;
+
+const TODAY_STR = (() => {
+  const d = new Date();
+  const mm = String(d.getMonth() + 1).padStart(2, '0');
+  const dd = String(d.getDate()).padStart(2, '0');
+  return `${d.getFullYear()}-${mm}-${dd}`;
+})();
 
 // 완료 수 → 색상 (0=빈셀, 1=20%, 2=40%, 3=65%, 4+=85%)
 const OPACITY_HEX = ['', '33', '66', 'A6', 'D9'];
@@ -18,10 +25,10 @@ const OPACITY_HEX = ['', '33', '66', 'A6', 'D9'];
 function getCellColor(count: number, baseColor: string): string {
   if (count === 0) return Colors.surface;
   const opacityIndex = Math.min(count, 4);
-  const opacity = OPACITY_HEX[opacityIndex];
-  // 4 이상은 불투명도 100% → 색상 그대로
-  return opacity === 'FF' ? baseColor : baseColor + opacity;
+  return baseColor + OPACITY_HEX[opacityIndex];
 }
+
+type Cell = { date: string; isFuture: boolean } | null;
 
 const TODAY = new Date();
 TODAY.setHours(23, 59, 59, 999);
@@ -36,8 +43,6 @@ function buildGrid(year: number): { date: string; isFuture: boolean }[] {
   return dates;
 }
 
-type Cell = { date: string; isFuture: boolean } | null;
-
 function groupByWeek(dates: { date: string; isFuture: boolean }[], year: number): Cell[][] {
   const jan1DayOfWeek = new Date(year, 0, 1).getDay();
   const padded: Cell[] = [...Array(jan1DayOfWeek).fill(null), ...dates];
@@ -47,6 +52,9 @@ function groupByWeek(dates: { date: string; isFuture: boolean }[], year: number)
     const week = padded.slice(i, i + DAYS_IN_WEEK);
     while (week.length < DAYS_IN_WEEK) week.push(null);
     weeks.push(week);
+  }
+  while (weeks.length < NUM_WEEKS) {
+    weeks.push(Array(DAYS_IN_WEEK).fill(null));
   }
   return weeks;
 }
@@ -58,45 +66,50 @@ export default function ContributionGrid({ categoryId, color, year }: Props) {
   const weeks = groupByWeek(dates, year);
 
   return (
-    <ScrollView horizontal showsHorizontalScrollIndicator={false}>
-      <View style={styles.grid}>
-        {weeks.map((week, wi) => (
-          <View key={wi} style={styles.column}>
-            {week.map((cell, di) => {
-              let cellColor = 'transparent';
-              if (cell) {
-                cellColor = cell.isFuture
-                  ? Colors.surface
-                  : getCellColor(completionMap[cell.date] ?? 0, color);
-              }
-              return (
-                <View
-                  key={di}
-                  style={[styles.cell, { backgroundColor: cellColor }]}
-                />
-              );
-            })}
-          </View>
-        ))}
-      </View>
-    </ScrollView>
+    <View style={styles.grid}>
+      {weeks.map((week, wi) => (
+        <View key={wi} style={[styles.column, { gap: CELL_GAP }]}>
+          {week.map((cell, di) => {
+            const isToday = cell?.date === TODAY_STR;
+            let cellColor = 'transparent';
+            if (cell) {
+              cellColor = cell.isFuture
+                ? Colors.surface
+                : getCellColor(completionMap[cell.date] ?? 0, color);
+            }
+            return (
+              <View
+                key={di}
+                style={[
+                  styles.cell,
+                  { backgroundColor: cellColor },
+                  isToday && styles.todayCell,
+                ]}
+              />
+            );
+          })}
+        </View>
+      ))}
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
   grid: {
     flexDirection: 'row',
-    flexWrap: 'nowrap',
     gap: CELL_GAP,
     paddingVertical: 2,
   },
   column: {
+    flex: 1,
     flexDirection: 'column',
-    gap: CELL_GAP,
   },
   cell: {
-    width: CELL_SIZE,
-    height: CELL_SIZE,
+    aspectRatio: 1,
     borderRadius: 2,
+  },
+  todayCell: {
+    borderWidth: 1.5,
+    borderColor: '#FFFFFF99',
   },
 });

--- a/src/screens/RecordScreen.tsx
+++ b/src/screens/RecordScreen.tsx
@@ -58,7 +58,7 @@ const styles = StyleSheet.create({
   yearTitle: { textAlign: 'center', fontWeight: '700', fontSize: 18 },
   content: { paddingVertical: 8 },
   section: {
-    paddingHorizontal: 16,
+    paddingHorizontal: 2,
     paddingVertical: 12,
   },
   sectionHeader: {
@@ -66,6 +66,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     gap: 8,
     marginBottom: 10,
+    paddingHorizontal: 12,
   },
   dot: { width: 10, height: 10, borderRadius: 5 },
   categoryName: { color: Colors.text },


### PR DESCRIPTION
## Summary
- 가로 스크롤 제거 — `flex: 1` + `aspectRatio: 1`로 그리드가 화면 너비에 꽉 차도록 수정
- 오늘 날짜 셀에 테두리 하이라이트 추가 (`borderWidth: 1.5, borderColor: #FFFFFF99`)
- 좌우 여백 2px로 최소화, 섹션 헤더에만 별도 패딩 적용

## Test plan
- [ ] 기록 화면에서 그리드가 좌우 여백 없이 꽉 차는지 확인
- [ ] 오늘 날짜 셀에 테두리가 표시되는지 확인
- [ ] 가로 스크롤이 동작하지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)