### PR TITLE
feat: #39 완료 목록 최근 완료 순 정렬 및 날짜 구분선 추가

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -81,12 +81,7 @@ export const initDb = async () => {
 
   db = drizzle(sqlite, { schema });
 
-  // 개발 환경 임시 데이터 (1회 실행, 재생성은 seed.ts 주석 참고)
-  if (__DEV__) {
-    const { runDevSeed } = require('./seed');
-    runDevSeed();
-  }
-
+  // 기본 카테고리 삽입 (seed보다 먼저 실행되어야 함)
   const existing = db.select().from(schema.categories).all();
   if (existing.length === 0) {
     const now = Date.now();
@@ -98,5 +93,11 @@ export const initDb = async () => {
       { name: '학습', description: '공부 및 자기계발', color: '#FBBC05', sortOrder: 4, isDefault: 0, createdAt: now },
       { name: '쇼핑', description: '구매 목록', color: '#9C27B0', sortOrder: 5, isDefault: 0, createdAt: now },
     ]).run();
+  }
+
+  // 개발 환경 임시 데이터 (1회 실행, 재생성은 seed.ts 주석 참고)
+  if (__DEV__) {
+    const { runDevSeed } = require('./seed');
+    runDevSeed();
   }
 };

--- a/src/db/seed.ts
+++ b/src/db/seed.ts
@@ -11,7 +11,7 @@
  * 🔄 재생성 방법 (앱 재시작 필요):
  *   Expo DevTools 또는 앱 내 DB 쿼리 실행:
  *
- *     DELETE FROM app_settings WHERE key = 'seed_v1';
+ *     DELETE FROM app_settings WHERE key = 'seed_v3';
  *
  *   위 한 줄만 실행하면 다음 앱 시작 시 seed 데이터가 다시 생성됨.
  *   (기존 seed 완료 기록도 함께 초기화하려면 앱 삭제 후 재설치)
@@ -21,7 +21,7 @@ import { eq } from 'drizzle-orm';
 import { db } from './index';
 import { categories, todos, todoCompletions, appSettings } from './schema';
 
-const SEED_KEY = 'seed_v2';
+const SEED_KEY = 'seed_v3';
 
 // 카테고리별 하루 완료 확률 (0~1) — 다양한 패턴 연출
 const CATEGORY_FREQUENCY: Record<string, number> = {
@@ -59,7 +59,7 @@ export async function runDevSeed() {
   const today = new Date();
   today.setHours(0, 0, 0, 0);
 
-  // 카테고리별 시드 todo 1개씩 생성
+  // 카테고리별 시드 todo 1개씩 생성 (잔디용)
   const seedTodoIds: Record<number, number> = {};
   for (const cat of allCategories) {
     const result = db.insert(todos).values({
@@ -74,7 +74,52 @@ export async function runDevSeed() {
     if (result) seedTodoIds[cat.id] = result.id;
   }
 
-  // 지난 365일 completions 생성
+  // 완료 탭 확인용 — 최근 30일에 걸쳐 다양한 날짜의 완료 todo 생성
+  const COMPLETED_TODO_TITLES: Record<string, string[]> = {
+    업무: ['기획서 작성', '팀 미팅 참석', '코드 리뷰', '보고서 제출', '이메일 정리', '주간 회의'],
+    개인: ['독서 30분', '일기 쓰기', '방 청소', '친구 연락', '영화 보기', '요리하기'],
+    운동: ['러닝 5km', '헬스장', '스트레칭', '자전거 타기', '수영', '요가'],
+    학습: ['알고리즘 풀기', '영어 단어 암기', '강의 수강', '책 읽기', 'TIL 작성', '사이드 프로젝트'],
+    쇼핑: ['장보기', '생필품 구매', '온라인 주문'],
+    미분류: ['메모 정리', '사진 백업', '앱 업데이트'],
+  };
+
+  const completedTodoValues: {
+    categoryId: number; title: string; sortOrder: number;
+    isCompleted: number; completedAt: number; createdAt: number; updatedAt: number;
+  }[] = [];
+
+  for (let daysAgo = 0; daysAgo <= 30; daysAgo++) {
+    const date = new Date(today);
+    date.setDate(date.getDate() - daysAgo);
+    const ts = date.getTime() + 9 * 60 * 60 * 1000; // 오전 9시 기준
+
+    for (const cat of allCategories) {
+      const titles = COMPLETED_TODO_TITLES[cat.name] ?? COMPLETED_TODO_TITLES['미분류'];
+      // 날짜마다 0~3개 랜덤 생성
+      const count = Math.floor(Math.random() * 4);
+      const shuffled = [...titles].sort(() => Math.random() - 0.5).slice(0, count);
+      for (const title of shuffled) {
+        const offset = Math.floor(Math.random() * 8 * 60 * 60 * 1000); // 최대 8시간 내 랜덤
+        completedTodoValues.push({
+          categoryId: cat.id,
+          title,
+          sortOrder: -9998,
+          isCompleted: 1,
+          completedAt: ts + offset,
+          createdAt: ts,
+          updatedAt: ts + offset,
+        });
+      }
+    }
+  }
+
+  const BATCH_TODO = 50;
+  for (let i = 0; i < completedTodoValues.length; i += BATCH_TODO) {
+    db.insert(todos).values(completedTodoValues.slice(i, i + BATCH_TODO)).run();
+  }
+
+  // 지난 2년 completions 생성 (잔디용)
   const completionValues: { todoId: number; completedDate: string }[] = [];
 
   for (let i = SEED_DAYS - 1; i >= 0; i--) {
@@ -105,5 +150,5 @@ export async function runDevSeed() {
   // 완료 플래그 저장
   db.insert(appSettings).values({ key: SEED_KEY, value: '1' }).run();
 
-  console.log(`[seed] ${completionValues.length}개 completion 생성 완료`);
+  console.log(`[seed] todo ${completedTodoValues.length}개, completion ${completionValues.length}개 생성 완료`);
 }

--- a/src/hooks/useTodos.ts
+++ b/src/hooks/useTodos.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { and, asc, eq } from 'drizzle-orm';
+import { and, asc, desc, eq } from 'drizzle-orm';
 import { db } from '../db';
 import { todos, todoCompletions } from '../db/schema';
 
@@ -9,7 +9,7 @@ export const useTodos = (isCompleted: 0 | 1) =>
     queryFn: () =>
       db.select().from(todos)
         .where(and(eq(todos.isCompleted, isCompleted), eq(todos.isDeleted, 0)))
-        .orderBy(asc(todos.sortOrder))
+        .orderBy(isCompleted === 1 ? desc(todos.completedAt) : asc(todos.sortOrder))
         .all(),
   });
 

--- a/src/screens/TodoScreen.tsx
+++ b/src/screens/TodoScreen.tsx
@@ -1,4 +1,4 @@
-import { StyleSheet, View } from 'react-native';
+import { StyleSheet, View, FlatList } from 'react-native';
 import { Appbar, Text, FAB, Button, Divider, Dialog, Portal } from 'react-native-paper';
 import { Colors } from '../theme';
 import { useNavigation, CommonActions } from '@react-navigation/native';
@@ -21,9 +21,51 @@ type Todo = {
   urgency?: number | null;
   importance?: number | null;
   isCompleted: number;
+  completedAt?: number | null;
   categoryId: number;
   sortOrder: number;
 };
+
+type ListItem =
+  | { type: 'header'; label: string; key: string }
+  | { type: 'todo'; todo: Todo };
+
+function formatDateLabel(ts: number | null | undefined): string {
+  if (!ts) return '날짜 없음';
+  const d = new Date(ts);
+  const now = new Date();
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const yesterday = new Date(today);
+  yesterday.setDate(today.getDate() - 1);
+  const day = new Date(d.getFullYear(), d.getMonth(), d.getDate());
+
+  if (day.getTime() === today.getTime()) return '오늘';
+  if (day.getTime() === yesterday.getTime()) return '어제';
+  if (d.getFullYear() === now.getFullYear()) {
+    return `${d.getMonth() + 1}월 ${d.getDate()}일`;
+  }
+  return `${d.getFullYear()}년 ${d.getMonth() + 1}월 ${d.getDate()}일`;
+}
+
+function toDateKey(ts: number | null | undefined): string {
+  if (!ts) return 'none';
+  const d = new Date(ts);
+  return `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`;
+}
+
+function buildCompletedList(todos: Todo[]): ListItem[] {
+  const result: ListItem[] = [];
+  let lastKey = '';
+  for (const todo of todos) {
+    const key = toDateKey(todo.completedAt);
+    if (key !== lastKey) {
+      result.push({ type: 'header', label: formatDateLabel(todo.completedAt), key });
+      lastKey = key;
+    }
+    result.push({ type: 'todo', todo });
+  }
+  return result;
+}
 
 export default function TodoScreen() {
   const navigation = useNavigation<Nav>();
@@ -48,21 +90,39 @@ export default function TodoScreen() {
   const { mutate: clearCompleted } = useClearCompleted();
   const { mutate: reorderTodos } = useReorderTodos();
 
-  const currentTodos = activeTab === 'active' ? activeTodos : completedTodos;
   const getCategoryById = (id: number) => categories.find((c) => c.id === id);
 
-  const renderItem = ({ item, drag, isActive }: RenderItemParams<Todo>) => (
+  const renderActiveItem = ({ item, drag, isActive }: RenderItemParams<Todo>) => (
     <ScaleDecorator>
       <TodoItem
         todo={item}
         category={getCategoryById(item.categoryId)}
         onToggle={() => toggleTodo({ id: item.id, isCompleted: item.isCompleted })}
         onPress={() => navigation.navigate('TodoForm', { todo: item })}
-        onDrag={activeTab === 'active' ? drag : undefined}
+        onDrag={drag}
         isDragging={isActive}
       />
     </ScaleDecorator>
   );
+
+  const completedList = buildCompletedList(completedTodos as Todo[]);
+
+  const renderCompletedItem = ({ item }: { item: ListItem }) => {
+    if (item.type === 'header') {
+      return <Text style={styles.dateHeader}>{item.label}</Text>;
+    }
+    return (
+      <>
+        <TodoItem
+          todo={item.todo}
+          category={getCategoryById(item.todo.categoryId)}
+          onToggle={() => toggleTodo({ id: item.todo.id, isCompleted: item.todo.isCompleted })}
+          onPress={() => navigation.navigate('TodoForm', { todo: item.todo })}
+        />
+        <Divider />
+      </>
+    );
+  };
 
   return (
     <View style={styles.container}>
@@ -92,25 +152,33 @@ export default function TodoScreen() {
         </Button>
       </View>
 
-      <DraggableFlatList
-        data={currentTodos as Todo[]}
-        keyExtractor={(item) => String(item.id)}
-        ItemSeparatorComponent={() => <Divider />}
-        ListEmptyComponent={
-          <Text style={styles.empty}>
-            {activeTab === 'active' ? '할 일이 없어요' : '완료된 항목이 없어요'}
-          </Text>
-        }
-        renderItem={renderItem}
-        onDragEnd={({ data }) => {
-          if (activeTab === 'active') {
-            reorderTodos(data.map((t) => t.id));
+      {activeTab === 'active' ? (
+        <DraggableFlatList
+          data={activeTodos as Todo[]}
+          keyExtractor={(item) => String(item.id)}
+          ItemSeparatorComponent={() => <Divider />}
+          ListEmptyComponent={
+            <Text style={styles.empty}>할 일이 없어요</Text>
           }
-        }}
-        autoscrollThreshold={80}
-        autoscrollSpeed={200}
-        containerStyle={{ flex: 1 }}
-      />
+          renderItem={renderActiveItem}
+          onDragEnd={({ data }) => reorderTodos(data.map((t) => t.id))}
+          autoscrollThreshold={80}
+          autoscrollSpeed={200}
+          containerStyle={{ flex: 1 }}
+        />
+      ) : (
+        <FlatList
+          data={completedList}
+          keyExtractor={(item, index) =>
+            item.type === 'header' ? `header-${item.key}` : `todo-${item.todo.id}`
+          }
+          renderItem={renderCompletedItem}
+          ListEmptyComponent={
+            <Text style={styles.empty}>완료된 항목이 없어요</Text>
+          }
+          style={{ flex: 1 }}
+        />
+      )}
 
       {activeTab === 'active' && (
         <FAB icon="plus" style={styles.fab} onPress={() => navigation.navigate('TodoForm')} />
@@ -150,4 +218,12 @@ const styles = StyleSheet.create({
   tabBtn: { flex: 1 },
   empty: { textAlign: 'center', marginTop: 60, color: Colors.textMuted },
   fab: { position: 'absolute', right: 16, bottom: 16 },
+  dateHeader: {
+    paddingHorizontal: 16,
+    paddingTop: 20,
+    paddingBottom: 6,
+    fontSize: 12,
+    fontWeight: '600',
+    color: Colors.textMuted,
+  },
 });


### PR DESCRIPTION
## Summary
- 완료 탭 목록을 `completedAt DESC` 최근 완료 순으로 정렬
- 날짜별 구분선 추가 (오늘 / 어제 / M월 D일 / YYYY년 M월 D일)
- 완료 탭은 드래그 불필요하여 `FlatList`로 분리
- seed_v3: 완료 탭 테스트용 최근 30일 완료 todo 생성 추가
- `initDb` 실행 순서 수정: 기본 카테고리 삽입 후 seed 실행

## Test plan
- [ ] 완료 탭에서 최근 완료 항목이 상단에 표시되는지 확인
- [ ] 날짜별 구분선이 올바르게 표시되는지 확인 (오늘/어제/날짜)
- [ ] 앱 재설치 후 seed_v3 데이터가 정상 생성되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)