### PR TITLE
refactor: #44 DB 마이그레이션 PRAGMA table_info 방식으로 교체

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -44,18 +44,14 @@ export const initDb = async () => {
     );
   `);
 
-  // migration: add sort_order if not exists (existing installs)
-  try {
+  // migration: add columns if not exists (safe check via PRAGMA)
+  const todoColumns = (sqlite.getAllSync('PRAGMA table_info(todos)') as { name: string }[]).map(c => c.name);
+  if (!todoColumns.includes('sort_order'))
     sqlite.execSync('ALTER TABLE todos ADD COLUMN sort_order INTEGER NOT NULL DEFAULT 0;');
-  } catch { /* already exists */ }
-
-  // migration: add soft delete columns if not exists
-  try {
+  if (!todoColumns.includes('is_deleted'))
     sqlite.execSync('ALTER TABLE todos ADD COLUMN is_deleted INTEGER NOT NULL DEFAULT 0;');
-  } catch { /* already exists */ }
-  try {
+  if (!todoColumns.includes('deleted_at'))
     sqlite.execSync('ALTER TABLE todos ADD COLUMN deleted_at INTEGER;');
-  } catch { /* already exists */ }
 
   sqlite.execSync(`
     CREATE TABLE IF NOT EXISTS app_settings (


### PR DESCRIPTION
## Summary
- `ALTER TABLE` try/catch → `PRAGMA table_info` 사전 조회 방식으로 교체
- expo-sqlite v16 + New Architecture 환경에서 catch 미작동으로 인한 크래시 방지

## Test plan
- [ ] 신규 설치 시 DB 초기화 정상 동작 확인
- [ ] 기존 DB 유지 상태에서 앱 업데이트 시 데이터 유실 없는지 확인

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)