### PR TITLE
feat: #46 할 일 드래그 동작 카테고리와 통일

### DIFF
--- a/src/components/TodoItem.tsx
+++ b/src/components/TodoItem.tsx
@@ -49,7 +49,7 @@ export default function TodoItem({ todo, category, onToggle, onPress, onDrag, is
         />
       </TouchableOpacity>
 
-      <TouchableOpacity style={styles.content} onPress={onPress} activeOpacity={0.7}>
+      <TouchableOpacity style={styles.content} onPress={onPress} onLongPress={onDrag} activeOpacity={0.7}>
         <Text
           variant="bodyLarge"
           style={[styles.titleText, todo.isCompleted === 1 && styles.completed]}
@@ -85,11 +85,6 @@ export default function TodoItem({ todo, category, onToggle, onPress, onDrag, is
         </View>
       </TouchableOpacity>
 
-      {onDrag && (
-        <TouchableOpacity onLongPress={onDrag} style={styles.dragHandle} hitSlop={8}>
-          <Text style={styles.dragHandleText}>☰</Text>
-        </TouchableOpacity>
-      )}
     </View>
   );
 }
@@ -118,6 +113,4 @@ const styles = StyleSheet.create({
     borderRadius: 4,
   },
   badgeText: { fontSize: 10, fontWeight: '600' },
-  dragHandle: { paddingLeft: 8, paddingVertical: 4 },
-  dragHandleText: { color: Colors.textMuted, fontSize: 18 },
 });

--- a/src/components/TodoItem.tsx
+++ b/src/components/TodoItem.tsx
@@ -85,6 +85,7 @@ export default function TodoItem({ todo, category, onToggle, onPress, onDrag, is
         </View>
       </TouchableOpacity>
 
+      {onDrag && <Text style={styles.dragHandle}>☰</Text>}
     </View>
   );
 }
@@ -113,4 +114,5 @@ const styles = StyleSheet.create({
     borderRadius: 4,
   },
   badgeText: { fontSize: 10, fontWeight: '600' },
+  dragHandle: { paddingLeft: 8, color: Colors.textMuted, fontSize: 18 },
 });


### PR DESCRIPTION
## Summary
- 할 일 아이템 content 영역 길게 누르면 드래그 실행되도록 변경
- 별도 드래그 핸들(☰) 버튼 제거
- 카테고리와 동일한 UX로 통일

## Test plan
- [ ] 할 일 아이템 길게 눌러 순서 변경 동작 확인
- [ ] 체크박스 탭, 아이템 탭(수정) 기존 동작 정상 확인

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)