### PR TITLE
#52 [Phase 3] 인앱 구매 구현 - 광고 제거 구매/복원 화면 및 설정 연동

### DIFF
--- a/.claude/phase-map.json
+++ b/.claude/phase-map.json
@@ -13,14 +13,14 @@
       "title": "배너 광고 구현",
       "issueNumber": 51,
       "branch": "feature/issue-51/banner-ad-implementation",
-      "status": "in_progress"
+      "status": "done"
     },
     {
       "number": 3,
       "title": "인앱 구매 구현",
       "issueNumber": 52,
       "branch": "feature/issue-52/in-app-purchase-implementation",
-      "status": "pending"
+      "status": "in_progress"
     }
   ]
 }

--- a/App.tsx
+++ b/App.tsx
@@ -8,6 +8,7 @@ import { PaperProvider } from 'react-native-paper';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { initDb } from './src/db';
 import { loadPremiumStatus } from './src/hooks/usePremiumStatus';
+import { configurePurchases } from './src/screens/PremiumScreen';
 import TabNavigator from './src/navigation/TabNavigator';
 import { AppTheme, NavTheme } from './src/theme';
 
@@ -17,6 +18,7 @@ export default function App() {
   const [ready, setReady] = useState(false);
 
   useEffect(() => {
+    configurePurchases();
     initDb()
       .then(() => loadPremiumStatus())
       .then(() => setReady(true))

--- a/src/navigation/SettingsStack.tsx
+++ b/src/navigation/SettingsStack.tsx
@@ -2,6 +2,7 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import SettingsScreen from '../screens/SettingsScreen';
 import CategoryManagementScreen from '../screens/CategoryManagementScreen';
 import CategoryFormScreen from '../screens/CategoryFormScreen';
+import PremiumScreen from '../screens/PremiumScreen';
 
 export type SettingsStackParamList = {
   SettingsHome: undefined;
@@ -14,6 +15,7 @@ export type SettingsStackParamList = {
       color: string;
     };
   } | undefined;
+  Premium: undefined;
 };
 
 const Stack = createNativeStackNavigator<SettingsStackParamList>();
@@ -24,6 +26,7 @@ export default function SettingsStack() {
       <Stack.Screen name="SettingsHome" component={SettingsScreen} />
       <Stack.Screen name="CategoryManagement" component={CategoryManagementScreen} />
       <Stack.Screen name="CategoryForm" component={CategoryFormScreen} />
+      <Stack.Screen name="Premium" component={PremiumScreen} />
     </Stack.Navigator>
   );
 }

--- a/src/screens/PremiumScreen.tsx
+++ b/src/screens/PremiumScreen.tsx
@@ -1,0 +1,162 @@
+import { useState, useEffect } from 'react';
+import { View, StyleSheet, Alert } from 'react-native';
+import { Appbar, Text, Button, ActivityIndicator } from 'react-native-paper';
+import { useNavigation } from '@react-navigation/native';
+import Purchases, { PurchasesPackage, PACKAGE_TYPE } from 'react-native-purchases';
+import { Colors } from '../theme';
+import { savePremiumStatus } from '../hooks/usePremiumStatus';
+import { usePremiumStore } from '../stores/premiumStore';
+
+// RevenueCat 대시보드에서 발급받은 iOS API 키로 교체하세요
+export const REVENUECAT_API_KEY_IOS = 'test_cDiAAHedAhYcuFQPHeyoNUoxfTD';
+// RevenueCat 대시보드에서 설정한 Entitlement ID
+const ENTITLEMENT_ID = 'premium';
+
+export function configurePurchases() {
+  Purchases.configure({ apiKey: REVENUECAT_API_KEY_IOS });
+}
+
+export default function PremiumScreen() {
+  const navigation = useNavigation();
+  const isPremium = usePremiumStore((s) => s.isPremium);
+  const [pkg, setPkg] = useState<PurchasesPackage | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [purchasing, setPurchasing] = useState(false);
+  const [restoring, setRestoring] = useState(false);
+
+  useEffect(() => {
+    loadOfferings();
+  }, []);
+
+  async function loadOfferings() {
+    try {
+      const offerings = await Purchases.getOfferings();
+      const available = offerings.current?.availablePackages ?? [];
+      const lifetime = available.find((p) => p.packageType === PACKAGE_TYPE.LIFETIME) ?? available[0];
+      if (lifetime) setPkg(lifetime);
+    } catch (e) {
+      console.error('[Purchases] getOfferings error:', e);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handlePurchase() {
+    if (!pkg) return;
+    setPurchasing(true);
+    try {
+      const { customerInfo } = await Purchases.purchasePackage(pkg);
+      const active = customerInfo.entitlements.active[ENTITLEMENT_ID];
+      if (active) {
+        await savePremiumStatus(true);
+        Alert.alert('구매 완료', '광고가 제거되었습니다.');
+        navigation.goBack();
+      }
+    } catch (e: any) {
+      if (!e.userCancelled) {
+        Alert.alert('구매 실패', '잠시 후 다시 시도해 주세요.');
+      }
+    } finally {
+      setPurchasing(false);
+    }
+  }
+
+  async function handleRestore() {
+    setRestoring(true);
+    try {
+      const customerInfo = await Purchases.restorePurchases();
+      const active = customerInfo.entitlements.active[ENTITLEMENT_ID];
+      if (active) {
+        await savePremiumStatus(true);
+        Alert.alert('복원 완료', '구매 내역이 복원되었습니다.');
+        navigation.goBack();
+      } else {
+        Alert.alert('복원할 구매 내역이 없습니다.');
+      }
+    } catch (e) {
+      Alert.alert('복원 실패', '잠시 후 다시 시도해 주세요.');
+    } finally {
+      setRestoring(false);
+    }
+  }
+
+  const priceText = pkg?.product.priceString ?? '';
+
+  return (
+    <View style={styles.container}>
+      <Appbar.Header>
+        <Appbar.BackAction onPress={() => navigation.goBack()} />
+        <Appbar.Content title="프리미엄" />
+      </Appbar.Header>
+
+      <View style={styles.content}>
+        {isPremium ? (
+          <View style={styles.activeBox}>
+            <Text variant="headlineSmall" style={styles.activeTitle}>프리미엄 이용 중</Text>
+            <Text variant="bodyMedium" style={styles.activeDesc}>광고 없이 앱을 이용하고 있습니다.</Text>
+          </View>
+        ) : (
+          <>
+            <View style={styles.benefitBox}>
+              <Text variant="headlineSmall" style={styles.benefitTitle}>광고 제거</Text>
+              <Text variant="bodyMedium" style={styles.benefitDesc}>
+                일회성 구매로 모든 광고를 영구적으로 제거합니다.{'\n'}
+                기기를 바꿔도 구매 복원으로 유지됩니다.
+              </Text>
+            </View>
+
+            {loading ? (
+              <ActivityIndicator color={Colors.text} style={styles.loader} />
+            ) : (
+              <Button
+                mode="contained"
+                onPress={handlePurchase}
+                loading={purchasing}
+                disabled={purchasing || restoring || !pkg}
+                style={styles.purchaseBtn}
+                contentStyle={styles.btnContent}
+              >
+                {pkg ? `광고 제거 ${priceText}` : '상품 정보를 불러오는 중...'}
+              </Button>
+            )}
+
+            <Button
+              mode="text"
+              onPress={handleRestore}
+              loading={restoring}
+              disabled={purchasing || restoring}
+              style={styles.restoreBtn}
+            >
+              구매 복원
+            </Button>
+          </>
+        )}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: Colors.background },
+  content: { flex: 1, padding: 24 },
+  benefitBox: {
+    backgroundColor: Colors.surface,
+    borderRadius: 12,
+    padding: 24,
+    marginBottom: 32,
+  },
+  benefitTitle: { color: Colors.text, fontWeight: '700', marginBottom: 12 },
+  benefitDesc: { color: Colors.textSecondary, lineHeight: 22 },
+  loader: { marginTop: 8 },
+  purchaseBtn: { borderRadius: 8 },
+  btnContent: { paddingVertical: 6 },
+  restoreBtn: { marginTop: 12, alignSelf: 'center' },
+  activeBox: {
+    backgroundColor: Colors.surface,
+    borderRadius: 12,
+    padding: 24,
+    alignItems: 'center',
+  },
+  activeTitle: { color: Colors.text, fontWeight: '700', marginBottom: 8 },
+  activeDesc: { color: Colors.textSecondary },
+});

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -6,6 +6,7 @@ import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useEffect } from 'react';
 import { SettingsStackParamList } from '../navigation/SettingsStack';
 import Constants from 'expo-constants';
+import { usePremiumStore } from '../stores/premiumStore';
 
 type NavigationProp = NativeStackNavigationProp<SettingsStackParamList, 'SettingsHome'>;
 
@@ -21,6 +22,7 @@ const APP_INFO = [
 
 export default function SettingsScreen() {
   const navigation = useNavigation<NavigationProp>();
+  const isPremium = usePremiumStore((s) => s.isPremium);
 
   useEffect(() => {
     const parentNav = navigation.getParent();
@@ -55,6 +57,26 @@ export default function SettingsScreen() {
             {index < SETTINGS_ITEMS.length - 1 && <Divider />}
           </View>
         ))}
+      </View>
+
+      <Text variant="labelSmall" style={styles.sectionLabel}>프리미엄</Text>
+      <View style={styles.section}>
+        <TouchableOpacity
+          style={styles.item}
+          onPress={() => navigation.navigate('Premium')}
+          disabled={isPremium}
+        >
+          <View>
+            <Text variant="bodyLarge">{isPremium ? '프리미엄 이용 중' : '광고 제거'}</Text>
+            <Text variant="bodySmall" style={styles.description}>
+              {isPremium ? '모든 광고가 제거된 상태입니다' : '일회성 구매로 광고를 영구 제거'}
+            </Text>
+          </View>
+          {isPremium
+            ? <Text style={styles.checkmark}>✓</Text>
+            : <Text style={styles.arrow}>›</Text>
+          }
+        </TouchableOpacity>
       </View>
 
       <Text variant="labelSmall" style={styles.sectionLabel}>앱</Text>
@@ -93,6 +115,7 @@ const styles = StyleSheet.create({
   },
   description: { color: Colors.textSecondary, marginTop: 2 },
   arrow: { fontSize: 20, color: Colors.textMuted },
+  checkmark: { fontSize: 18, color: '#A78BFA', fontWeight: '700' },
   infoItem: {
     flexDirection: 'row',
     justifyContent: 'space-between',

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -1,4 +1,4 @@
-import { View, StyleSheet, TouchableOpacity } from 'react-native';
+import { View, StyleSheet, TouchableOpacity, Alert } from 'react-native';
 import { Appbar, Text, Divider } from 'react-native-paper';
 import { Colors } from '../theme';
 import { useNavigation, CommonActions } from '@react-navigation/native';
@@ -7,6 +7,7 @@ import { useEffect } from 'react';
 import { SettingsStackParamList } from '../navigation/SettingsStack';
 import Constants from 'expo-constants';
 import { usePremiumStore } from '../stores/premiumStore';
+import { savePremiumStatus } from '../hooks/usePremiumStatus';
 
 type NavigationProp = NativeStackNavigationProp<SettingsStackParamList, 'SettingsHome'>;
 
@@ -78,6 +79,23 @@ export default function SettingsScreen() {
           }
         </TouchableOpacity>
       </View>
+
+      {__DEV__ && isPremium && (
+        <>
+          <Text variant="labelSmall" style={[styles.sectionLabel, { color: Colors.danger }]}>개발용</Text>
+          <View style={styles.section}>
+            <TouchableOpacity
+              style={styles.item}
+              onPress={() => Alert.alert('프리미엄 초기화', '프리미엄 상태를 초기화할까요?', [
+                { text: '취소', style: 'cancel' },
+                { text: '초기화', style: 'destructive', onPress: () => savePremiumStatus(false) },
+              ])}
+            >
+              <Text variant="bodyLarge" style={{ color: Colors.danger }}>프리미엄 초기화</Text>
+            </TouchableOpacity>
+          </View>
+        </>
+      )}
 
       <Text variant="labelSmall" style={styles.sectionLabel}>앱</Text>
       <View style={styles.section}>


### PR DESCRIPTION
## 변경 사항
- `PremiumScreen.tsx` 신규 생성 — RevenueCat(react-native-purchases) 연동, 구매/복원 버튼, 이미 구매 시 비활성화
- `SettingsStack.tsx` — `Premium` 라우트 추가
- `SettingsScreen.tsx` — "프리미엄" 섹션 추가, `isPremium` 상태에 따라 구매 유도 또는 이용 중 표시
- `App.tsx` — 앱 시작 시 `configurePurchases()` 호출

## 테스트
- [ ] 설정 탭 → 프리미엄 섹션 노출 확인
- [ ] "광고 제거" 탭 → PremiumScreen 진입 확인
- [ ] 구매 버튼 클릭 → Test valid purchase → "프리미엄 이용 중" 전환 확인
- [ ] 구매 후 할 일/기록 탭 배너 광고 제거 확인
- [ ] 앱 재시작 후 프리미엄 상태 유지 확인
- [ ] 구매 복원 버튼 동작 확인

Closes #52