### PR TITLE
#58 홈 탭 반복 클릭 시 불필요한 페이지 전환 발생 수정

### DIFF
--- a/src/screens/TodoScreen.tsx
+++ b/src/screens/TodoScreen.tsx
@@ -58,8 +58,11 @@ export default function TodoScreen() {
     const parentNav = navigation.getParent<BottomTabNavigationProp<Record<string, undefined>>>();
     if (!parentNav) return;
     return parentNav.addListener('tabPress', () => {
+      const state = navigation.getState();
+      if (state && state.routes.length > 1) {
+        navigation.dispatch(CommonActions.reset({ index: 0, routes: [{ name: 'TodoList' }] }));
+      }
       setActiveTab('active');
-      navigation.dispatch(CommonActions.reset({ index: 0, routes: [{ name: 'TodoList' }] }));
     });
   }, [navigation]);
 


### PR DESCRIPTION
## 변경 사항
- `TodoScreen.tsx` tabPress 리스너에 스택 depth 조건 추가
- `navigation.getState().routes.length > 1`일 때만 reset 실행 (하위 화면에서 홈 탭 누를 때만 루트로 복귀)
- 이미 루트(`TodoList`)에 있을 때는 reset 생략하여 불필요한 전환 방지

## 테스트
- [ ] 홈 탭을 여러 번 반복 클릭해도 화면 전환 없음
- [ ] `TodoForm` 화면에서 홈 탭 누르면 `TodoList`로 복귀
- [ ] 기록/설정 탭에서 홈 탭 누르면 정상 이동

Closes #58