### PR TITLE
#62 [Phase 1] DB 스키마 확장 및 기한 필수화

### DIFF
--- a/.claude/phase-map.json
+++ b/.claude/phase-map.json
@@ -3,24 +3,31 @@
   "phases": [
     {
       "number": 1,
-      "title": "기반 세팅",
-      "issueNumber": 50,
-      "branch": "feature/issue-50/admob-iap-base-setup",
-      "status": "done"
+      "title": "DB 스키마 확장 및 기한 필수화",
+      "issueNumber": 62,
+      "branch": "feature/issue-62/db-schema-extension-and-due-date-required",
+      "status": "in_progress"
     },
     {
       "number": 2,
-      "title": "배너 광고 구현",
-      "issueNumber": 51,
-      "branch": "feature/issue-51/banner-ad-implementation",
-      "status": "done"
+      "title": "할 일 탭 UI 개편",
+      "issueNumber": 63,
+      "branch": "feature/issue-63/todo-tab-ui-refactor",
+      "status": "pending"
     },
     {
       "number": 3,
-      "title": "인앱 구매 구현",
-      "issueNumber": 52,
-      "branch": "feature/issue-52/in-app-purchase-implementation",
-      "status": "in_progress"
+      "title": "루틴 관리",
+      "issueNumber": 64,
+      "branch": "feature/issue-64/routine-management",
+      "status": "pending"
+    },
+    {
+      "number": 4,
+      "title": "오늘 탭 루틴 연동",
+      "issueNumber": 65,
+      "branch": "feature/issue-65/today-tab-routine-integration",
+      "status": "pending"
     }
   ]
 }

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -68,6 +68,31 @@ export const initDb = async () => {
     );
   `);
 
+  sqlite.execSync(`
+    CREATE TABLE IF NOT EXISTS routines (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      category_id INTEGER NOT NULL REFERENCES categories(id),
+      title TEXT NOT NULL,
+      description TEXT,
+      repeat_type TEXT NOT NULL,
+      repeat_value TEXT,
+      urgency INTEGER NOT NULL DEFAULT 0,
+      importance INTEGER NOT NULL DEFAULT 0,
+      sort_order INTEGER NOT NULL DEFAULT 0,
+      is_active INTEGER NOT NULL DEFAULT 1,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+  `);
+
+  sqlite.execSync(`
+    CREATE TABLE IF NOT EXISTS routine_completions (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      routine_id INTEGER NOT NULL REFERENCES routines(id) ON DELETE CASCADE,
+      completed_date TEXT NOT NULL
+    );
+  `);
+
   // migration: remove stale completion records for uncompleted/deleted todos
   // (bug: toggle-back did not delete todoCompletions until fixed)
   sqlite.execSync(`

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -41,3 +41,28 @@ export const todoCompletions = sqliteTable('todo_completions', {
     .references(() => todos.id, { onDelete: 'cascade' }),
   completedDate: text('completed_date').notNull(), // 'YYYY-MM-DD'
 });
+
+export const routines = sqliteTable('routines', {
+  id: int('id').primaryKey({ autoIncrement: true }),
+  categoryId: int('category_id')
+    .notNull()
+    .references(() => categories.id),
+  title: text('title').notNull(),
+  description: text('description'),
+  repeatType: text('repeat_type').notNull(), // 'daily' | 'weekly' | 'monthly'
+  repeatValue: text('repeat_value'),         // weekly: '1,3,5' (0=일), monthly: '15' (날짜)
+  urgency: int('urgency').default(0),
+  importance: int('importance').default(0),
+  sortOrder: int('sort_order').notNull().default(0),
+  isActive: int('is_active').notNull().default(1),
+  createdAt: int('created_at').notNull(),
+  updatedAt: int('updated_at').notNull(),
+});
+
+export const routineCompletions = sqliteTable('routine_completions', {
+  id: int('id').primaryKey({ autoIncrement: true }),
+  routineId: int('routine_id')
+    .notNull()
+    .references(() => routines.id, { onDelete: 'cascade' }),
+  completedDate: text('completed_date').notNull(), // 'YYYY-MM-DD'
+});

--- a/src/hooks/useTodos.ts
+++ b/src/hooks/useTodos.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { and, asc, desc, eq } from 'drizzle-orm';
+import { and, asc, desc, eq, gte, lt } from 'drizzle-orm';
+import dayjs from 'dayjs';
 import { db } from '../db';
 import { todos, todoCompletions } from '../db/schema';
 
@@ -10,6 +11,70 @@ export const useTodos = (isCompleted: 0 | 1) =>
       db.select().from(todos)
         .where(and(eq(todos.isCompleted, isCompleted), eq(todos.isDeleted, 0)))
         .orderBy(isCompleted === 1 ? desc(todos.completedAt) : asc(todos.sortOrder))
+        .all(),
+  });
+
+/** 오늘 탭: 기한 == 오늘 AND 미완료 */
+export const useTodosToday = () => {
+  const todayStart = dayjs().startOf('day').valueOf();
+  const todayEnd = dayjs().endOf('day').valueOf();
+  return useQuery({
+    queryKey: ['todos', 'today'],
+    queryFn: () =>
+      db.select().from(todos)
+        .where(and(
+          eq(todos.isCompleted, 0),
+          eq(todos.isDeleted, 0),
+          gte(todos.dueDate, todayStart),
+          lt(todos.dueDate, todayEnd + 1),
+        ))
+        .orderBy(asc(todos.sortOrder))
+        .all(),
+  });
+};
+
+/** 할 일 탭: 기한 >= 오늘 AND 미완료 */
+export const useTodosList = () => {
+  const todayStart = dayjs().startOf('day').valueOf();
+  return useQuery({
+    queryKey: ['todos', 'list'],
+    queryFn: () =>
+      db.select().from(todos)
+        .where(and(
+          eq(todos.isCompleted, 0),
+          eq(todos.isDeleted, 0),
+          gte(todos.dueDate, todayStart),
+        ))
+        .orderBy(asc(todos.sortOrder))
+        .all(),
+  });
+};
+
+/** 미완료 탭: 기한 < 오늘 AND 미완료 */
+export const useTodosOverdue = () => {
+  const todayStart = dayjs().startOf('day').valueOf();
+  return useQuery({
+    queryKey: ['todos', 'overdue'],
+    queryFn: () =>
+      db.select().from(todos)
+        .where(and(
+          eq(todos.isCompleted, 0),
+          eq(todos.isDeleted, 0),
+          lt(todos.dueDate, todayStart),
+        ))
+        .orderBy(asc(todos.sortOrder))
+        .all(),
+  });
+};
+
+/** 완료 탭: 완료된 항목, 최신순 */
+export const useTodosCompleted = () =>
+  useQuery({
+    queryKey: ['todos', 'completed'],
+    queryFn: () =>
+      db.select().from(todos)
+        .where(and(eq(todos.isCompleted, 1), eq(todos.isDeleted, 0)))
+        .orderBy(desc(todos.completedAt))
         .all(),
   });
 

--- a/src/screens/TodoFormScreen.tsx
+++ b/src/screens/TodoFormScreen.tsx
@@ -29,7 +29,7 @@ export default function TodoFormScreen() {
 
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
-  const [dueDate, setDueDate] = useState<Date | null>(null);
+  const [dueDate, setDueDate] = useState<Date>(new Date(today));
   const [showDatePicker, setShowDatePicker] = useState(false);
   const [deleteDialogVisible, setDeleteDialogVisible] = useState(false);
 
@@ -41,7 +41,7 @@ export default function TodoFormScreen() {
   useEffect(() => {
     setTitle(todo?.title ?? '');
     setDescription(todo?.description ?? '');
-    setDueDate(todo?.dueDate ? new Date(todo.dueDate) : null);
+    setDueDate(todo?.dueDate ? new Date(todo.dueDate) : new Date(today));
     setUrgency(String(todo?.urgency ?? 0));
     setImportance(String(todo?.importance ?? 0));
     setCategoryId(todo?.categoryId ?? (categories[0]?.id ?? null));
@@ -52,7 +52,7 @@ export default function TodoFormScreen() {
     const data = {
       title: title.trim(),
       description: description.trim() || undefined,
-      dueDate: dueDate ? dueDate.getTime() : undefined,
+      dueDate: dueDate.getTime(),
       urgency: Number(urgency),
       importance: Number(importance),
       categoryId,
@@ -109,44 +109,30 @@ export default function TodoFormScreen() {
           keyboardAppearance="dark"
         />
 
-        <Text variant="labelLarge" style={styles.label}>기한</Text>
+        <Text variant="labelLarge" style={styles.label}>기한 *</Text>
         <TouchableOpacity
           style={styles.dateButton}
-          onPress={() => {
-            if (!dueDate) setDueDate(new Date(today));
-            setShowDatePicker(true);
-          }}
+          onPress={() => setShowDatePicker(true)}
         >
-          <Text style={[styles.dateText, !dueDate && styles.datePlaceholder]}>
-            {dueDate
-              ? dueDate.toLocaleDateString('ko-KR', { year: 'numeric', month: 'long', day: 'numeric' })
-              : '기한 없음'}
+          <Text style={styles.dateText}>
+            {dueDate.toLocaleDateString('ko-KR', { year: 'numeric', month: 'long', day: 'numeric' })}
           </Text>
-          {dueDate && (
-            <TouchableOpacity onPress={() => setDueDate(null)} hitSlop={8}>
-              <Text style={styles.dateClear}>✕</Text>
-            </TouchableOpacity>
-          )}
         </TouchableOpacity>
 
         {showDatePicker && (
           <DateTimePicker
-            value={dueDate ?? today}
+            value={dueDate}
             mode="date"
             display="spinner"
             locale="ko"
-            minimumDate={today}
             textColor="#F2F2F7"
             onChange={(_, date) => {
-              if (date && date >= today) setDueDate(date);
+              if (date) setDueDate(date);
             }}
           />
         )}
         {showDatePicker && (
           <View style={styles.dateConfirmRow}>
-            <Button mode="text" onPress={() => { setDueDate(null); setShowDatePicker(false); }}>
-              초기화
-            </Button>
             <Button mode="contained" onPress={() => setShowDatePicker(false)}>
               확인
             </Button>


### PR DESCRIPTION
## 변경 사항
- `src/db/schema.ts` — routines, routineCompletions 테이블 정의 추가
- `src/db/index.ts` — routines / routine_completions CREATE TABLE 구문 추가
- `src/hooks/useTodos.ts` — 탭별 쿼리 훅 추가 (useTodosToday / useTodosList / useTodosOverdue / useTodosCompleted)
- `src/screens/TodoFormScreen.tsx` — 기한 기본값 오늘로 변경, 기한 없음/초기화 옵션 제거

## 테스트
- [ ] 앱 실행 후 routines / routine_completions 테이블 생성 확인
- [ ] 할 일 등록 폼 기한 기본값이 오늘로 설정되는지 확인
- [ ] 기한 없음 옵션 및 초기화 버튼이 사라졌는지 확인
- [ ] 기존 할 일 수정 시 기존 기한이 그대로 표시되는지 확인

Closes #62