### PR TITLE
#64 [Phase 3] 루틴 관리 (설정 탭)

### DIFF
--- a/.claude/phase-map.json
+++ b/.claude/phase-map.json
@@ -13,14 +13,14 @@
       "title": "할 일 탭 UI 개편",
       "issueNumber": 63,
       "branch": "feature/issue-63/todo-tab-ui-refactor",
-      "status": "in_progress"
+      "status": "done"
     },
     {
       "number": 3,
       "title": "루틴 관리",
       "issueNumber": 64,
       "branch": "feature/issue-64/routine-management",
-      "status": "pending"
+      "status": "in_progress"
     },
     {
       "number": 4,

--- a/src/hooks/useRoutines.ts
+++ b/src/hooks/useRoutines.ts
@@ -1,0 +1,187 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { and, asc, eq } from 'drizzle-orm';
+import dayjs from 'dayjs';
+import { db } from '../db';
+import { routines, routineCompletions } from '../db/schema';
+
+export const useRoutines = () =>
+  useQuery({
+    queryKey: ['routines'],
+    queryFn: () =>
+      db.select().from(routines)
+        .where(eq(routines.isActive, 1))
+        .orderBy(asc(routines.sortOrder))
+        .all(),
+  });
+
+export const useCreateRoutine = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      categoryId,
+      title,
+      description,
+      repeatType,
+      repeatValue,
+      urgency,
+      importance,
+    }: {
+      categoryId: number;
+      title: string;
+      description?: string;
+      repeatType: string;
+      repeatValue?: string;
+      urgency?: number;
+      importance?: number;
+    }) => {
+      const all = db.select().from(routines).all();
+      const maxOrder = all.reduce((max, r) => Math.max(max, r.sortOrder), 0);
+      const now = Date.now();
+      await db.insert(routines).values({
+        categoryId,
+        title,
+        description: description ?? null,
+        repeatType,
+        repeatValue: repeatValue ?? null,
+        urgency: urgency ?? 0,
+        importance: importance ?? 0,
+        sortOrder: maxOrder + 1,
+        createdAt: now,
+        updatedAt: now,
+      }).run();
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['routines'] }),
+  });
+};
+
+export const useUpdateRoutine = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      id,
+      categoryId,
+      title,
+      description,
+      repeatType,
+      repeatValue,
+      urgency,
+      importance,
+    }: {
+      id: number;
+      categoryId: number;
+      title: string;
+      description?: string;
+      repeatType: string;
+      repeatValue?: string;
+      urgency?: number;
+      importance?: number;
+    }) => {
+      await db.update(routines).set({
+        categoryId,
+        title,
+        description: description ?? null,
+        repeatType,
+        repeatValue: repeatValue ?? null,
+        urgency: urgency ?? 0,
+        importance: importance ?? 0,
+        updatedAt: Date.now(),
+      }).where(eq(routines.id, id)).run();
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['routines'] }),
+  });
+};
+
+export const useDeleteRoutine = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (id: number) => {
+      await db.update(routines).set({
+        isActive: 0,
+        updatedAt: Date.now(),
+      }).where(eq(routines.id, id)).run();
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['routines'] }),
+  });
+};
+
+export const useReorderRoutines = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (orderedIds: number[]) => {
+      for (let i = 0; i < orderedIds.length; i++) {
+        await db.update(routines).set({ sortOrder: i }).where(eq(routines.id, orderedIds[i])).run();
+      }
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['routines'] }),
+  });
+};
+
+export const useToggleRoutineCompletion = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ routineId, date }: { routineId: number; date: string }) => {
+      const existing = db.select().from(routineCompletions)
+        .where(and(
+          eq(routineCompletions.routineId, routineId),
+          eq(routineCompletions.completedDate, date),
+        ))
+        .get();
+      if (existing) {
+        await db.delete(routineCompletions)
+          .where(and(
+            eq(routineCompletions.routineId, routineId),
+            eq(routineCompletions.completedDate, date),
+          ))
+          .run();
+      } else {
+        await db.insert(routineCompletions).values({ routineId, completedDate: date }).run();
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['routineCompletions'] });
+      queryClient.invalidateQueries({ queryKey: ['routinesToday'] });
+    },
+  });
+};
+
+/** 오늘 해당하는 루틴 목록 + 완료 여부 */
+export const useRoutinesToday = () => {
+  const today = dayjs().format('YYYY-MM-DD');
+  const dayOfWeek = String(dayjs().day());   // 0=일 ~ 6=토
+  const dayOfMonth = String(dayjs().date()); // 1~31
+
+  return useQuery({
+    queryKey: ['routinesToday', today],
+    queryFn: () => {
+      const allRoutines = db.select().from(routines)
+        .where(eq(routines.isActive, 1))
+        .orderBy(asc(routines.sortOrder))
+        .all();
+
+      const todayRoutines = allRoutines.filter((r) => {
+        if (r.repeatType === 'daily') return true;
+        if (r.repeatType === 'weekly') {
+          return r.repeatValue?.split(',').includes(dayOfWeek) ?? false;
+        }
+        if (r.repeatType === 'monthly') {
+          const values = r.repeatValue?.split(',') ?? [];
+          const isLastDay = dayjs().date() === dayjs().daysInMonth();
+          return values.includes(dayOfMonth) || (isLastDay && values.includes('last'));
+        }
+        return false;
+      });
+
+      const completedIds = new Set(
+        db.select().from(routineCompletions)
+          .where(eq(routineCompletions.completedDate, today))
+          .all()
+          .map((rc) => rc.routineId),
+      );
+
+      return todayRoutines.map((r) => ({
+        ...r,
+        isCompletedToday: completedIds.has(r.id),
+      }));
+    },
+  });
+};

--- a/src/navigation/SettingsStack.tsx
+++ b/src/navigation/SettingsStack.tsx
@@ -2,6 +2,8 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import SettingsScreen from '../screens/SettingsScreen';
 import CategoryManagementScreen from '../screens/CategoryManagementScreen';
 import CategoryFormScreen from '../screens/CategoryFormScreen';
+import RoutineManagementScreen from '../screens/RoutineManagementScreen';
+import RoutineFormScreen from '../screens/RoutineFormScreen';
 import PremiumScreen from '../screens/PremiumScreen';
 
 export type SettingsStackParamList = {
@@ -15,6 +17,23 @@ export type SettingsStackParamList = {
       color: string;
     };
   } | undefined;
+  RoutineManagement: undefined;
+  RoutineForm: {
+    routine?: {
+      id: number;
+      categoryId: number;
+      title: string;
+      description?: string | null;
+      repeatType: string;
+      repeatValue?: string | null;
+      urgency: number | null;
+      importance: number | null;
+      sortOrder: number;
+      isActive: number;
+      createdAt: number;
+      updatedAt: number;
+    };
+  } | undefined;
   Premium: undefined;
 };
 
@@ -26,6 +45,8 @@ export default function SettingsStack() {
       <Stack.Screen name="SettingsHome" component={SettingsScreen} />
       <Stack.Screen name="CategoryManagement" component={CategoryManagementScreen} />
       <Stack.Screen name="CategoryForm" component={CategoryFormScreen} />
+      <Stack.Screen name="RoutineManagement" component={RoutineManagementScreen} />
+      <Stack.Screen name="RoutineForm" component={RoutineFormScreen} />
       <Stack.Screen name="Premium" component={PremiumScreen} />
     </Stack.Navigator>
   );

--- a/src/screens/RoutineFormScreen.tsx
+++ b/src/screens/RoutineFormScreen.tsx
@@ -1,0 +1,334 @@
+import { useEffect, useState } from 'react';
+import { View, StyleSheet, ScrollView, TouchableOpacity } from 'react-native';
+import { Appbar, Text, TextInput, Button, Dialog, Portal, SegmentedButtons } from 'react-native-paper';
+import { Colors } from '../theme';
+import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { useCreateRoutine, useUpdateRoutine, useDeleteRoutine } from '../hooks/useRoutines';
+import { useCategories } from '../hooks/useCategories';
+import { SettingsStackParamList } from '../navigation/SettingsStack';
+import { LEVEL_OPTIONS } from '../constants/todo';
+
+type Nav = NativeStackNavigationProp<SettingsStackParamList, 'RoutineForm'>;
+type Route = RouteProp<SettingsStackParamList, 'RoutineForm'>;
+
+const DAY_OPTIONS = [
+  { value: '0', label: '일' },
+  { value: '1', label: '월' },
+  { value: '2', label: '화' },
+  { value: '3', label: '수' },
+  { value: '4', label: '목' },
+  { value: '5', label: '금' },
+  { value: '6', label: '토' },
+];
+
+export default function RoutineFormScreen() {
+  const navigation = useNavigation<Nav>();
+  const route = useRoute<Route>();
+  const routine = route.params?.routine;
+  const isEdit = !!routine?.id;
+
+  const { data: categories = [] } = useCategories();
+  const { mutate: createRoutine } = useCreateRoutine();
+  const { mutate: updateRoutine } = useUpdateRoutine();
+  const { mutate: deleteRoutine } = useDeleteRoutine();
+
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [categoryId, setCategoryId] = useState<number | null>(null);
+  const [repeatType, setRepeatType] = useState<'daily' | 'weekly' | 'monthly'>('daily');
+  const [selectedDays, setSelectedDays] = useState<Set<string>>(new Set());
+  const [selectedMonthDays, setSelectedMonthDays] = useState<Set<string>>(new Set());
+  const [urgency, setUrgency] = useState('0');
+  const [importance, setImportance] = useState('0');
+  const [deleteDialogVisible, setDeleteDialogVisible] = useState(false);
+
+  useEffect(() => {
+    if (routine) {
+      setTitle(routine.title);
+      setDescription(routine.description ?? '');
+      setCategoryId(routine.categoryId);
+      setRepeatType(routine.repeatType as 'daily' | 'weekly' | 'monthly');
+      if (routine.repeatType === 'weekly' && routine.repeatValue) {
+        setSelectedDays(new Set(routine.repeatValue.split(',')));
+      }
+      if (routine.repeatType === 'monthly' && routine.repeatValue) {
+        setSelectedMonthDays(new Set(routine.repeatValue.split(',')));
+      }
+      setUrgency(String(routine.urgency ?? 0));
+      setImportance(String(routine.importance ?? 0));
+    } else {
+      const defaultCategory = categories.find((c) => c.isDefault === 1);
+      if (defaultCategory) setCategoryId(defaultCategory.id);
+    }
+  }, [routine, categories]);
+
+  const toggleDay = (day: string) => {
+    setSelectedDays((prev) => {
+      const next = new Set(prev);
+      if (next.has(day)) next.delete(day);
+      else next.add(day);
+      return next;
+    });
+  };
+
+  const toggleMonthDay = (day: string) => {
+    setSelectedMonthDays((prev) => {
+      const next = new Set(prev);
+      if (next.has(day)) next.delete(day);
+      else next.add(day);
+      return next;
+    });
+  };
+
+  const getRepeatValue = () => {
+    if (repeatType === 'weekly') return Array.from(selectedDays).sort().join(',');
+    if (repeatType === 'monthly') return Array.from(selectedMonthDays).sort((a, b) => Number(a) - Number(b)).join(',');
+    return undefined;
+  };
+
+  const isValid = () => {
+    if (!title.trim()) return false;
+    if (!categoryId) return false;
+    if (repeatType === 'weekly' && selectedDays.size === 0) return false;
+    if (repeatType === 'monthly' && selectedMonthDays.size === 0) return false;
+    return true;
+  };
+
+  const handleSave = () => {
+    if (!isValid() || categoryId === null) return;
+    const data = {
+      categoryId,
+      title: title.trim(),
+      description: description.trim() || undefined,
+      repeatType,
+      repeatValue: getRepeatValue(),
+      urgency: Number(urgency),
+      importance: Number(importance),
+    };
+    if (isEdit && routine) {
+      updateRoutine({ id: routine.id, ...data });
+    } else {
+      createRoutine(data);
+    }
+    navigation.goBack();
+  };
+
+  const handleDelete = () => {
+    if (routine) deleteRoutine(routine.id);
+    navigation.goBack();
+  };
+
+  return (
+    <View style={styles.container}>
+      <Appbar.Header>
+        <Appbar.BackAction onPress={() => navigation.goBack()} />
+        <Appbar.Content title={isEdit ? '루틴 수정' : '새 루틴'} />
+        <Button
+          mode="contained"
+          onPress={handleSave}
+          disabled={!isValid()}
+          style={styles.saveButton}
+          labelStyle={styles.actionButtonLabel}
+        >
+          저장
+        </Button>
+      </Appbar.Header>
+
+      <ScrollView contentContainerStyle={styles.content}>
+        <TextInput
+          label="제목 *"
+          value={title}
+          onChangeText={setTitle}
+          mode="outlined"
+          style={styles.input}
+          keyboardAppearance="dark"
+        />
+        <TextInput
+          label="설명"
+          value={description}
+          onChangeText={setDescription}
+          mode="outlined"
+          multiline
+          numberOfLines={3}
+          keyboardAppearance="dark"
+          style={[styles.input, styles.descriptionInput]}
+        />
+
+        <Text variant="labelLarge" style={styles.label}>카테고리 *</Text>
+        <View style={styles.chipRow}>
+          {categories.map((cat) => (
+            <TouchableOpacity
+              key={cat.id}
+              style={[styles.chip, categoryId === cat.id && { borderColor: cat.color, borderWidth: 2 }]}
+              onPress={() => setCategoryId(cat.id)}
+            >
+              <View style={[styles.chipDot, { backgroundColor: cat.color }]} />
+              <Text variant="labelMedium" style={categoryId === cat.id ? { color: cat.color } : { color: Colors.textSecondary }}>
+                {cat.name}
+              </Text>
+            </TouchableOpacity>
+          ))}
+        </View>
+
+        <Text variant="labelLarge" style={styles.label}>반복 주기 *</Text>
+        <SegmentedButtons
+          value={repeatType}
+          onValueChange={(v) => setRepeatType(v as 'daily' | 'weekly' | 'monthly')}
+          buttons={[
+            { value: 'daily', label: '매일' },
+            { value: 'weekly', label: '매주' },
+            { value: 'monthly', label: '매월' },
+          ]}
+          style={styles.segmented}
+        />
+
+        {repeatType === 'weekly' && (
+          <>
+            <Text variant="labelMedium" style={styles.subLabel}>요일 선택 *</Text>
+            <View style={styles.chipRow}>
+              {DAY_OPTIONS.map((day) => (
+                <TouchableOpacity
+                  key={day.value}
+                  style={[styles.dayChip, selectedDays.has(day.value) && styles.dayChipSelected]}
+                  onPress={() => toggleDay(day.value)}
+                >
+                  <Text
+                    variant="labelMedium"
+                    style={selectedDays.has(day.value) ? styles.dayChipTextSelected : styles.dayChipText}
+                  >
+                    {day.label}
+                  </Text>
+                </TouchableOpacity>
+              ))}
+            </View>
+          </>
+        )}
+
+        {repeatType === 'monthly' && (
+          <>
+            <Text variant="labelMedium" style={styles.subLabel}>날짜 선택 *</Text>
+            <View style={styles.dayGrid}>
+              {Array.from({ length: 31 }, (_, i) => String(i + 1)).map((d) => (
+                <TouchableOpacity
+                  key={d}
+                  style={[styles.dayChip, selectedMonthDays.has(d) && styles.dayChipSelected]}
+                  onPress={() => toggleMonthDay(d)}
+                >
+                  <Text
+                    variant="labelMedium"
+                    style={selectedMonthDays.has(d) ? styles.dayChipTextSelected : styles.dayChipText}
+                  >
+                    {d}
+                  </Text>
+                </TouchableOpacity>
+              ))}
+              <TouchableOpacity
+                style={[styles.dayChipLast, selectedMonthDays.has('last') && styles.dayChipSelected]}
+                onPress={() => toggleMonthDay('last')}
+              >
+                <Text
+                  variant="labelMedium"
+                  style={selectedMonthDays.has('last') ? styles.dayChipTextSelected : styles.dayChipText}
+                >
+                  말일
+                </Text>
+              </TouchableOpacity>
+            </View>
+          </>
+        )}
+
+        <Text variant="labelLarge" style={styles.label}>긴급도</Text>
+        <SegmentedButtons
+          value={urgency}
+          onValueChange={setUrgency}
+          buttons={LEVEL_OPTIONS.map((o) => ({ value: o.value, label: o.label }))}
+          style={styles.segmented}
+        />
+
+        <Text variant="labelLarge" style={styles.label}>중요도</Text>
+        <SegmentedButtons
+          value={importance}
+          onValueChange={setImportance}
+          buttons={LEVEL_OPTIONS.map((o) => ({ value: o.value, label: o.label }))}
+          style={styles.segmented}
+        />
+
+        {isEdit && (
+          <Button
+            mode="outlined"
+            textColor="#B03A2E"
+            icon="delete-outline"
+            onPress={() => setDeleteDialogVisible(true)}
+            style={styles.deleteButton}
+            labelStyle={styles.actionButtonLabel}
+          >
+            삭제
+          </Button>
+        )}
+      </ScrollView>
+
+      <Portal>
+        <Dialog visible={deleteDialogVisible} onDismiss={() => setDeleteDialogVisible(false)}>
+          <Dialog.Title>루틴 삭제</Dialog.Title>
+          <Dialog.Content>
+            <Text>
+              <Text style={styles.bold}>"{routine?.title}"</Text> 루틴을 삭제할까요?
+            </Text>
+          </Dialog.Content>
+          <Dialog.Actions>
+            <Button onPress={() => setDeleteDialogVisible(false)}>취소</Button>
+            <Button textColor="#EA4335" onPress={handleDelete}>삭제</Button>
+          </Dialog.Actions>
+        </Dialog>
+      </Portal>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: Colors.background },
+  content: { padding: 20, paddingBottom: 40 },
+  input: { marginBottom: 16 },
+  descriptionInput: { minHeight: 80 },
+  label: { marginBottom: 8, marginTop: 4 },
+  subLabel: { marginBottom: 8, marginTop: 8, color: Colors.textSecondary },
+  segmented: { marginBottom: 16 },
+  chipRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 8, marginBottom: 16 },
+  dayGrid: { flexDirection: 'row', flexWrap: 'wrap', gap: 8, marginBottom: 16 },
+  chip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 20,
+    backgroundColor: Colors.surfaceVariant,
+    borderWidth: 2,
+    borderColor: 'transparent',
+  },
+  chipDot: { width: 8, height: 8, borderRadius: 4 },
+  dayChip: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: Colors.surfaceVariant,
+  },
+  dayChipLast: {
+    paddingHorizontal: 12,
+    height: 36,
+    borderRadius: 18,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: Colors.surfaceVariant,
+  },
+  dayChipSelected: { backgroundColor: Colors.primary },
+  dayChipText: { color: Colors.textSecondary },
+  dayChipTextSelected: { color: '#fff', fontWeight: '700' },
+  saveButton: { marginRight: 8, alignSelf: 'center' },
+  actionButtonLabel: { fontSize: 14 },
+  deleteButton: { marginTop: 8 },
+  bold: { fontWeight: 'bold' },
+});

--- a/src/screens/RoutineManagementScreen.tsx
+++ b/src/screens/RoutineManagementScreen.tsx
@@ -4,8 +4,11 @@ import { Colors } from '../theme';
 import DraggableFlatList, { RenderItemParams, ScaleDecorator } from 'react-native-draggable-flatlist';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { useMemo } from 'react';
 import { useRoutines, useReorderRoutines } from '../hooks/useRoutines';
+import { useCategories } from '../hooks/useCategories';
 import { SettingsStackParamList } from '../navigation/SettingsStack';
+import { LEVEL_LABELS } from '../constants/todo';
 
 type Nav = NativeStackNavigationProp<SettingsStackParamList, 'RoutineManagement'>;
 
@@ -47,28 +50,67 @@ function repeatDescription(routine: Routine): string {
   return REPEAT_LABELS[routine.repeatType] ?? routine.repeatType;
 }
 
+const URGENCY_COLOR = Colors.urgency;
+const IMPORTANCE_COLOR = Colors.importance;
+
 export default function RoutineManagementScreen() {
   const navigation = useNavigation<Nav>();
   const { data: routines = [] } = useRoutines();
+  const { data: categories = [] } = useCategories();
   const { mutate: reorderRoutines } = useReorderRoutines();
 
-  const renderItem = ({ item, drag, isActive }: RenderItemParams<Routine>) => (
-    <ScaleDecorator>
-      <TouchableOpacity
-        style={[styles.item, isActive && styles.itemDragging]}
-        onPress={() => navigation.navigate('RoutineForm', { routine: item })}
-        onLongPress={drag}
-        disabled={isActive}
-      >
-        <View style={styles.itemText}>
-          <Text variant="bodyLarge">{item.title}</Text>
-          <Text variant="bodySmall" style={styles.repeatText}>{repeatDescription(item)}</Text>
-        </View>
-        <Text style={styles.dragHandle}>☰</Text>
-      </TouchableOpacity>
-      <Divider />
-    </ScaleDecorator>
+  const categoryMap = useMemo(
+    () => new Map(categories.map((c) => [c.id, c])),
+    [categories],
   );
+
+  const renderItem = ({ item, drag, isActive }: RenderItemParams<Routine>) => {
+    const category = categoryMap.get(item.categoryId);
+    const urgencyLevel = item.urgency ?? 0;
+    const importanceLevel = item.importance ?? 0;
+
+    return (
+      <ScaleDecorator>
+        <TouchableOpacity
+          style={[styles.item, isActive && styles.itemDragging]}
+          onPress={() => navigation.navigate('RoutineForm', { routine: item })}
+          onLongPress={drag}
+          disabled={isActive}
+        >
+          <View style={styles.itemText}>
+            <Text variant="bodyLarge">{item.title}</Text>
+            <View style={styles.meta}>
+              {category && (
+                <View style={[styles.categoryDot, { backgroundColor: category.color }]} />
+              )}
+              {category && (
+                <Text variant="labelSmall" style={[styles.metaText, { color: category.color }]}>
+                  {category.name}
+                </Text>
+              )}
+              <Text variant="labelSmall" style={styles.metaText}>{repeatDescription(item)}</Text>
+              {urgencyLevel > 0 && (
+                <View style={[styles.badge, { backgroundColor: URGENCY_COLOR + '33' }]}>
+                  <Text style={[styles.badgeText, { color: URGENCY_COLOR }]}>
+                    긴급 {LEVEL_LABELS[urgencyLevel]}
+                  </Text>
+                </View>
+              )}
+              {importanceLevel > 0 && (
+                <View style={[styles.badge, { backgroundColor: IMPORTANCE_COLOR + '33' }]}>
+                  <Text style={[styles.badgeText, { color: IMPORTANCE_COLOR }]}>
+                    중요 {LEVEL_LABELS[importanceLevel]}
+                  </Text>
+                </View>
+              )}
+            </View>
+          </View>
+          <Text style={styles.dragHandle}>☰</Text>
+        </TouchableOpacity>
+        <Divider />
+      </ScaleDecorator>
+    );
+  };
 
   return (
     <View style={styles.container}>
@@ -110,7 +152,11 @@ const styles = StyleSheet.create({
   },
   itemDragging: { backgroundColor: Colors.surfaceVariant, elevation: 4 },
   itemText: { flex: 1 },
-  repeatText: { color: Colors.textSecondary, marginTop: 2 },
+  meta: { flexDirection: 'row', alignItems: 'center', gap: 6, marginTop: 4, flexWrap: 'wrap' },
+  categoryDot: { width: 8, height: 8, borderRadius: 4 },
+  metaText: { color: Colors.textSecondary },
+  badge: { paddingHorizontal: 6, paddingVertical: 2, borderRadius: 4 },
+  badgeText: { fontSize: 10, fontWeight: '600' },
   dragHandle: { color: Colors.textMuted, fontSize: 18 },
   fab: { position: 'absolute', right: 16, bottom: 16 },
   empty: { textAlign: 'center', marginTop: 60, color: Colors.textMuted },

--- a/src/screens/RoutineManagementScreen.tsx
+++ b/src/screens/RoutineManagementScreen.tsx
@@ -1,0 +1,117 @@
+import { View, StyleSheet, TouchableOpacity } from 'react-native';
+import { Appbar, Text, Divider, FAB } from 'react-native-paper';
+import { Colors } from '../theme';
+import DraggableFlatList, { RenderItemParams, ScaleDecorator } from 'react-native-draggable-flatlist';
+import { useNavigation } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { useRoutines, useReorderRoutines } from '../hooks/useRoutines';
+import { SettingsStackParamList } from '../navigation/SettingsStack';
+
+type Nav = NativeStackNavigationProp<SettingsStackParamList, 'RoutineManagement'>;
+
+type Routine = {
+  id: number;
+  categoryId: number;
+  title: string;
+  description?: string | null;
+  repeatType: string;
+  repeatValue?: string | null;
+  urgency: number | null;
+  importance: number | null;
+  sortOrder: number;
+  isActive: number;
+  createdAt: number;
+  updatedAt: number;
+};
+
+const REPEAT_LABELS: Record<string, string> = {
+  daily: '매일',
+  weekly: '매주',
+  monthly: '매월',
+};
+
+const DAY_NAMES = ['일', '월', '화', '수', '목', '금', '토'];
+
+function repeatDescription(routine: Routine): string {
+  if (routine.repeatType === 'daily') return '매일';
+  if (routine.repeatType === 'weekly' && routine.repeatValue) {
+    const days = routine.repeatValue.split(',').map((d) => DAY_NAMES[Number(d)]).join(', ');
+    return `매주 ${days}`;
+  }
+  if (routine.repeatType === 'monthly' && routine.repeatValue) {
+    const days = routine.repeatValue.split(',')
+      .map((d) => d === 'last' ? '말일' : `${d}일`)
+      .join(', ');
+    return `매월 ${days}`;
+  }
+  return REPEAT_LABELS[routine.repeatType] ?? routine.repeatType;
+}
+
+export default function RoutineManagementScreen() {
+  const navigation = useNavigation<Nav>();
+  const { data: routines = [] } = useRoutines();
+  const { mutate: reorderRoutines } = useReorderRoutines();
+
+  const renderItem = ({ item, drag, isActive }: RenderItemParams<Routine>) => (
+    <ScaleDecorator>
+      <TouchableOpacity
+        style={[styles.item, isActive && styles.itemDragging]}
+        onPress={() => navigation.navigate('RoutineForm', { routine: item })}
+        onLongPress={drag}
+        disabled={isActive}
+      >
+        <View style={styles.itemText}>
+          <Text variant="bodyLarge">{item.title}</Text>
+          <Text variant="bodySmall" style={styles.repeatText}>{repeatDescription(item)}</Text>
+        </View>
+        <Text style={styles.dragHandle}>☰</Text>
+      </TouchableOpacity>
+      <Divider />
+    </ScaleDecorator>
+  );
+
+  return (
+    <View style={styles.container}>
+      <Appbar.Header>
+        <Appbar.BackAction onPress={() => navigation.goBack()} />
+        <Appbar.Content title="루틴 관리" />
+      </Appbar.Header>
+
+      <DraggableFlatList
+        data={routines as Routine[]}
+        keyExtractor={(item) => String(item.id)}
+        onDragEnd={({ data }) => reorderRoutines(data.map((r) => r.id))}
+        renderItem={renderItem}
+        autoscrollThreshold={80}
+        autoscrollSpeed={200}
+        containerStyle={{ flex: 1 }}
+        ListEmptyComponent={
+          <Text style={styles.empty}>루틴이 없어요</Text>
+        }
+      />
+
+      <FAB
+        icon="plus"
+        style={styles.fab}
+        onPress={() => navigation.navigate('RoutineForm')}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: Colors.background },
+  item: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: 16,
+    gap: 12,
+    backgroundColor: Colors.background,
+  },
+  itemDragging: { backgroundColor: Colors.surfaceVariant, elevation: 4 },
+  itemText: { flex: 1 },
+  repeatText: { color: Colors.textSecondary, marginTop: 2 },
+  dragHandle: { color: Colors.textMuted, fontSize: 18 },
+  fab: { position: 'absolute', right: 16, bottom: 16 },
+  empty: { textAlign: 'center', marginTop: 60, color: Colors.textMuted },
+});

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -13,6 +13,7 @@ type NavigationProp = NativeStackNavigationProp<SettingsStackParamList, 'Setting
 
 const SETTINGS_ITEMS = [
   { key: 'CategoryManagement', label: '카테고리 관리', description: '카테고리 추가, 수정, 삭제' },
+  { key: 'RoutineManagement', label: '루틴 관리', description: '반복 루틴 추가, 수정, 삭제' },
 ] as const;
 
 const APP_INFO = [


### PR DESCRIPTION
## 이슈
Closes #64

## 변경 사항
- `src/hooks/useRoutines.ts` — 루틴 CRUD 훅 추가 (useRoutines, useCreateRoutine, useUpdateRoutine, useDeleteRoutine, useReorderRoutines, useToggleRoutineCompletion, useRoutinesToday)
- `src/screens/RoutineManagementScreen.tsx` — DraggableFlatList 루틴 목록 (카테고리, 반복 주기, 긴급도/중요도 표시)
- `src/screens/RoutineFormScreen.tsx` — 루틴 생성/수정 폼 (매일/매주 요일 선택/매월 날짜 복수 선택+말일 지원)
- `src/navigation/SettingsStack.tsx` — RoutineManagement, RoutineForm 라우트 추가
- `src/screens/SettingsScreen.tsx` — 루틴 관리 항목 추가

## 테스트
- [ ] 설정 탭 → 루틴 관리 항목 진입
- [ ] 루틴 생성: 제목 필수, 카테고리 선택, 반복 주기 설정 후 저장
- [ ] 반복 주기 — 매일 / 매주 요일 복수 선택 / 매월 날짜 복수 선택 + 말일
- [ ] 루틴 목록 드래그 순서 변경
- [ ] 루틴 수정 및 삭제