### PR TITLE
#65 [Phase 4] 오늘 탭 루틴 연동

### DIFF
--- a/.claude/phase-map.json
+++ b/.claude/phase-map.json
@@ -20,14 +20,14 @@
       "title": "루틴 관리",
       "issueNumber": 64,
       "branch": "feature/issue-64/routine-management",
-      "status": "in_progress"
+      "status": "done"
     },
     {
       "number": 4,
       "title": "오늘 탭 루틴 연동",
       "issueNumber": 65,
       "branch": "feature/issue-65/today-tab-routine-integration",
-      "status": "pending"
+      "status": "in_progress"
     }
   ]
 }

--- a/App.tsx
+++ b/App.tsx
@@ -1,8 +1,8 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient, QueryClientProvider, focusManager } from '@tanstack/react-query';
 import { NavigationContainer } from '@react-navigation/native';
 import { StatusBar } from 'expo-status-bar';
 import { useEffect, useState } from 'react';
-import { View, ActivityIndicator } from 'react-native';
+import { View, ActivityIndicator, AppState, AppStateStatus } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { PaperProvider } from 'react-native-paper';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
@@ -14,6 +14,12 @@ import TabNavigator from './src/navigation/TabNavigator';
 import { AppTheme, NavTheme } from './src/theme';
 
 const queryClient = new QueryClient();
+
+// 앱이 포그라운드로 돌아올 때 TanStack Query 자동 갱신
+function onAppStateChange(status: AppStateStatus) {
+  focusManager.setFocused(status === 'active');
+}
+AppState.addEventListener('change', onAppStateChange);
 
 export default function App() {
   const [ready, setReady] = useState(false);

--- a/src/components/RoutineItem.tsx
+++ b/src/components/RoutineItem.tsx
@@ -1,0 +1,93 @@
+import { View, StyleSheet, TouchableOpacity } from 'react-native';
+import { Text, Checkbox } from 'react-native-paper';
+import { Colors } from '../theme';
+import { LEVEL_LABELS } from '../constants/todo';
+
+type Category = {
+  id: number;
+  name: string;
+  color: string;
+};
+
+type Props = {
+  routineId: number;
+  title: string;
+  urgency?: number | null;
+  importance?: number | null;
+  category?: Category;
+  isCompletedToday: boolean;
+  onToggle: () => void;
+};
+
+const URGENCY_COLOR = Colors.urgency;
+const IMPORTANCE_COLOR = Colors.importance;
+
+export default function RoutineItem({ routineId: _, title, urgency, importance, category, isCompletedToday, onToggle }: Props) {
+  const urgencyLevel = urgency ?? 0;
+  const importanceLevel = importance ?? 0;
+
+  return (
+    <View style={styles.container}>
+      <TouchableOpacity onPress={onToggle} activeOpacity={0.6} style={styles.checkboxArea}>
+        <Checkbox.Android
+          status={isCompletedToday ? 'checked' : 'unchecked'}
+          color={category?.color}
+        />
+      </TouchableOpacity>
+
+      <View style={styles.content}>
+        <Text
+          variant="bodyLarge"
+          style={[styles.titleText, isCompletedToday && styles.completed]}
+        >
+          {title}
+        </Text>
+        <View style={styles.meta}>
+          {category && (
+            <View style={[styles.categoryDot, { backgroundColor: category.color }]} />
+          )}
+          {category && (
+            <Text variant="labelSmall" style={[styles.metaText, { color: category.color }]}>
+              {category.name}
+            </Text>
+          )}
+          <Text variant="labelSmall" style={[styles.metaText, styles.routineTag]}>루틴</Text>
+          {urgencyLevel > 0 && (
+            <View style={[styles.badge, { backgroundColor: URGENCY_COLOR + '33' }]}>
+              <Text style={[styles.badgeText, { color: URGENCY_COLOR }]}>
+                긴급 {LEVEL_LABELS[urgencyLevel]}
+              </Text>
+            </View>
+          )}
+          {importanceLevel > 0 && (
+            <View style={[styles.badge, { backgroundColor: IMPORTANCE_COLOR + '33' }]}>
+              <Text style={[styles.badgeText, { color: IMPORTANCE_COLOR }]}>
+                중요 {LEVEL_LABELS[importanceLevel]}
+              </Text>
+            </View>
+          )}
+        </View>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 6,
+    paddingHorizontal: 16,
+    backgroundColor: Colors.background,
+  },
+  checkboxArea: { padding: 4 },
+  content: { flex: 1, marginLeft: 4, paddingVertical: 4 },
+  titleText: { flexShrink: 1 },
+  completed: { textDecorationLine: 'line-through', color: Colors.textMuted },
+  meta: { flexDirection: 'row', alignItems: 'center', gap: 6, marginTop: 4, flexWrap: 'wrap' },
+  categoryDot: { width: 8, height: 8, borderRadius: 4 },
+  metaText: { color: Colors.textSecondary },
+  routineTag: { color: Colors.primary },
+  badge: { paddingHorizontal: 6, paddingVertical: 2, borderRadius: 4 },
+  badgeText: { fontSize: 10, fontWeight: '600' },
+});

--- a/src/components/TodoTabToday.tsx
+++ b/src/components/TodoTabToday.tsx
@@ -1,13 +1,16 @@
-import { StyleSheet } from 'react-native';
+import { View, StyleSheet } from 'react-native';
 import { Text, Divider } from 'react-native-paper';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useMemo } from 'react';
 import DraggableFlatList, { RenderItemParams, ScaleDecorator } from 'react-native-draggable-flatlist';
+import dayjs from 'dayjs';
 import { Colors } from '../theme';
 import { useTodosToday, useTodayCompletionIds, useTodayToggle, useReorderTodos } from '../hooks/useTodos';
+import { useRoutinesToday, useToggleRoutineCompletion } from '../hooks/useRoutines';
 import { useCategories } from '../hooks/useCategories';
 import TodoItem from './TodoItem';
+import RoutineItem from './RoutineItem';
 import { TodoStackParamList } from '../navigation/TodoStack';
 
 type Nav = NativeStackNavigationProp<TodoStackParamList, 'TodoList'>;
@@ -29,16 +32,20 @@ export default function TodoTabToday() {
   const navigation = useNavigation<Nav>();
   const { data: todos = [] } = useTodosToday();
   const { data: completedIds = new Set<number>() } = useTodayCompletionIds();
+  const { data: routines = [] } = useRoutinesToday();
   const { data: categories = [] } = useCategories();
   const { mutate: todayToggle } = useTodayToggle();
   const { mutate: reorderTodos } = useReorderTodos();
+  const { mutate: toggleRoutine } = useToggleRoutineCompletion();
+
+  const today = dayjs().format('YYYY-MM-DD');
 
   const categoryMap = useMemo(
     () => new Map(categories.map((c) => [c.id, c])),
-    [categories]
+    [categories],
   );
 
-  const renderItem = ({ item, drag, isActive }: RenderItemParams<Todo>) => (
+  const renderTodoItem = ({ item, drag, isActive }: RenderItemParams<Todo>) => (
     <ScaleDecorator>
       <TodoItem
         todo={item}
@@ -52,24 +59,62 @@ export default function TodoTabToday() {
     </ScaleDecorator>
   );
 
+  const isEmpty = routines.length === 0 && todos.length === 0;
+
   return (
     <DraggableFlatList
       data={todos as Todo[]}
-      keyExtractor={(item) => String(item.id)}
+      keyExtractor={(item) => `todo-${item.id}`}
       ItemSeparatorComponent={() => <Divider />}
-      ListEmptyComponent={
-        <Text style={styles.empty}>오늘 할 일이 없어요</Text>
-      }
-      renderItem={renderItem}
+      renderItem={renderTodoItem}
       onDragEnd={({ data }) => reorderTodos(data.map((t) => t.id))}
       autoscrollThreshold={80}
       autoscrollSpeed={200}
       containerStyle={styles.list}
+      ListHeaderComponent={
+        <>
+          {routines.length > 0 && (
+            <>
+              <Text variant="labelSmall" style={styles.sectionLabel}>루틴</Text>
+              {routines.map((routine, index) => (
+                <View key={`routine-${routine.id}`}>
+                  <RoutineItem
+                    routineId={routine.id}
+                    title={routine.title}
+                    urgency={routine.urgency}
+                    importance={routine.importance}
+                    category={categoryMap.get(routine.categoryId)}
+                    isCompletedToday={routine.isCompletedToday}
+                    onToggle={() => toggleRoutine({ routineId: routine.id, date: today })}
+                  />
+                  {index < routines.length - 1 && <Divider />}
+                </View>
+              ))}
+              {todos.length > 0 && (
+                <>
+                  <Divider style={styles.sectionDivider} />
+                  <Text variant="labelSmall" style={styles.sectionLabel}>할 일</Text>
+                </>
+              )}
+            </>
+          )}
+          {isEmpty && (
+            <Text style={styles.empty}>오늘 할 일이 없어요</Text>
+          )}
+        </>
+      }
     />
   );
 }
 
 const styles = StyleSheet.create({
   list: { flex: 1 },
+  sectionLabel: {
+    color: Colors.textSecondary,
+    marginHorizontal: 16,
+    marginTop: 12,
+    marginBottom: 4,
+  },
+  sectionDivider: { marginTop: 8, backgroundColor: Colors.surfaceVariant },
   empty: { textAlign: 'center', marginTop: 60, color: Colors.textMuted },
 });

--- a/src/hooks/useRoutines.ts
+++ b/src/hooks/useRoutines.ts
@@ -50,7 +50,10 @@ export const useCreateRoutine = () => {
         updatedAt: now,
       }).run();
     },
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['routines'] }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['routines'] });
+      queryClient.invalidateQueries({ queryKey: ['routinesToday'] });
+    },
   });
 };
 
@@ -87,7 +90,10 @@ export const useUpdateRoutine = () => {
         updatedAt: Date.now(),
       }).where(eq(routines.id, id)).run();
     },
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['routines'] }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['routines'] });
+      queryClient.invalidateQueries({ queryKey: ['routinesToday'] });
+    },
   });
 };
 
@@ -100,7 +106,10 @@ export const useDeleteRoutine = () => {
         updatedAt: Date.now(),
       }).where(eq(routines.id, id)).run();
     },
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['routines'] }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['routines'] });
+      queryClient.invalidateQueries({ queryKey: ['routinesToday'] });
+    },
   });
 };
 
@@ -112,7 +121,10 @@ export const useReorderRoutines = () => {
         await db.update(routines).set({ sortOrder: i }).where(eq(routines.id, orderedIds[i])).run();
       }
     },
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['routines'] }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['routines'] });
+      queryClient.invalidateQueries({ queryKey: ['routinesToday'] });
+    },
   });
 };
 

--- a/src/screens/TodoFormScreen.tsx
+++ b/src/screens/TodoFormScreen.tsx
@@ -13,8 +13,11 @@ import { LEVEL_OPTIONS } from '../constants/todo';
 type Nav = NativeStackNavigationProp<TodoStackParamList, 'TodoForm'>;
 type Route = RouteProp<TodoStackParamList, 'TodoForm'>;
 
-const today = new Date();
-today.setHours(0, 0, 0, 0);
+function getTodayMidnight() {
+  const d = new Date();
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
 
 export default function TodoFormScreen() {
   const navigation = useNavigation<Nav>();
@@ -29,7 +32,7 @@ export default function TodoFormScreen() {
 
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
-  const [dueDate, setDueDate] = useState<Date>(new Date(today));
+  const [dueDate, setDueDate] = useState<Date>(getTodayMidnight);
   const [showDatePicker, setShowDatePicker] = useState(false);
   const [deleteDialogVisible, setDeleteDialogVisible] = useState(false);
 
@@ -41,7 +44,7 @@ export default function TodoFormScreen() {
   useEffect(() => {
     setTitle(todo?.title ?? '');
     setDescription(todo?.description ?? '');
-    setDueDate(todo?.dueDate ? new Date(todo.dueDate) : new Date(today));
+    setDueDate(todo?.dueDate ? new Date(todo.dueDate) : getTodayMidnight());
     setUrgency(String(todo?.urgency ?? 0));
     setImportance(String(todo?.importance ?? 0));
     setCategoryId(todo?.categoryId ?? (categories[0]?.id ?? null));
@@ -52,7 +55,7 @@ export default function TodoFormScreen() {
     const data = {
       title: title.trim(),
       description: description.trim() || undefined,
-      dueDate: dueDate.getTime(),
+      dueDate: new Date(dueDate.getFullYear(), dueDate.getMonth(), dueDate.getDate()).getTime(),
       urgency: Number(urgency),
       importance: Number(importance),
       categoryId,
@@ -127,7 +130,10 @@ export default function TodoFormScreen() {
             locale="ko"
             textColor="#F2F2F7"
             onChange={(_, date) => {
-              if (date) setDueDate(date);
+              if (date) {
+                const midnight = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+                setDueDate(midnight);
+              }
             }}
           />
         )}


### PR DESCRIPTION
## 이슈
Closes #65

## 변경 사항
- `src/components/RoutineItem.tsx` — 루틴 아이템 컴포넌트 신규 추가 (체크박스, 취소선, 카테고리/긴급도/중요도 표시)
- `src/components/TodoTabToday.tsx` — 루틴 섹션 + 할 일 섹션 통합 (오늘 해당 루틴 필터, 완료 체크 시 routine_completions 기록)
- `src/hooks/useRoutines.ts` — 모든 루틴 뮤테이션에 `['routinesToday']` 캐시 무효화 추가 (변경 즉시 오늘 탭 반영)
- `src/screens/TodoFormScreen.tsx` — dueDate 기본값 모듈 레벨 고정 → 렌더 시 계산으로 변경, DateTimePicker 반환값 로컬 자정 정규화
- `App.tsx` — AppState 리스너로 앱 포그라운드 복귀 시 TanStack Query 자동 갱신

## 테스트
- [ ] 오늘 탭 상단에 루틴 섹션 표시 (오늘 해당 루틴만)
- [ ] 루틴 체크 → 취소선, 다시 체크 해제 가능
- [ ] 루틴 수정(반복 주기 변경) 후 오늘 탭 즉시 반영
- [ ] 새 할 일 등록 시 오늘 탭에 정상 노출
- [ ] 앱 백그라운드 → 포그라운드 복귀 시 데이터 갱신