### PR TITLE
#71 [Phase 1] Drawer 내비게이션 구조 구축

### DIFF
--- a/.claude/phase-map.json
+++ b/.claude/phase-map.json
@@ -3,31 +3,17 @@
   "phases": [
     {
       "number": 1,
-      "title": "DB 스키마 확장 및 기한 필수화",
-      "issueNumber": 62,
-      "branch": "feature/issue-62/db-schema-extension-and-due-date-required",
-      "status": "done"
+      "title": "Drawer 내비게이션 구조 구축",
+      "issueNumber": 71,
+      "branch": "feature/issue-71/drawer-navigation-setup",
+      "status": "in_progress"
     },
     {
       "number": 2,
-      "title": "할 일 탭 UI 개편",
-      "issueNumber": 63,
-      "branch": "feature/issue-63/todo-tab-ui-refactor",
-      "status": "done"
-    },
-    {
-      "number": 3,
-      "title": "루틴 관리",
-      "issueNumber": 64,
-      "branch": "feature/issue-64/routine-management",
-      "status": "done"
-    },
-    {
-      "number": 4,
-      "title": "오늘 탭 루틴 연동",
-      "issueNumber": 65,
-      "branch": "feature/issue-65/today-tab-routine-integration",
-      "status": "in_progress"
+      "title": "화면 헤더 통합 및 설정 정리",
+      "issueNumber": 72,
+      "branch": "feature/issue-72/screen-header-and-settings-cleanup",
+      "status": "pending"
     }
   ]
 }

--- a/.claude/skills/ship/skill.md
+++ b/.claude/skills/ship/skill.md
@@ -1,0 +1,65 @@
+---
+name: ship
+description: 변경 사항 분석 → 커밋 메시지 자동 선택 → 커밋 → 푸시 → PR 생성까지 한 번에 처리
+tools: Bash
+---
+
+변경 사항을 분석해서 커밋 메시지를 자동으로 선택한 뒤, 커밋 → 푸시 → PR 생성까지 한 번에 처리해.
+
+1. 아래 명령어를 병렬 실행해서 현재 상태를 파악해:
+   - `git status`
+   - `git diff HEAD`
+   - `git branch --show-current`
+   - `git log --oneline -5`
+
+2. 브랜치명에서 이슈 번호를 추출해 (패턴: `{형태}/issue-{번호}/{내용}`):
+   - 번호가 있으면 `gh issue view {번호}` 로 이슈 제목과 본문을 가져와.
+   - 형태 매핑: feature→feat, bugfix→fix, refactor→refactor, chore→chore
+
+3. 변경 사항을 분석해서 **가장 적절한 커밋 메시지 1개를 자동 선택**해:
+   - 형식: `{형태}: #{번호} {한국어 동사구}` (예: `feat: #10 Drawer 내비게이션 구조 추가`)
+   - 변경 사항이 없으면 "커밋할 변경 사항이 없습니다." 안내 후 중단
+
+4. `git add -A` 로 모든 변경 사항을 스테이징해.
+
+5. 아래 형식으로 커밋해 (HEREDOC 사용):
+   ```
+   git commit -m "$(cat <<'EOF'
+   {커밋 메시지}
+
+   Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+   EOF
+   )"
+   ```
+
+6. `git push -u origin {브랜치명}` 으로 푸시해.
+
+7. PR 본문을 작성하고 `gh pr create --base develop --title "..." --body "..."` 로 PR을 생성해 (HEREDOC 사용):
+   - 제목: `#{이슈번호} {이슈 제목}` (이슈 없으면 커밋 메시지 기반 한국어 제목)
+   - 본문 형식:
+     ```
+     ## 이슈
+     Closes #{이슈번호}
+
+     ## 변경 사항
+     - ...
+
+     ## 테스트
+     - [ ] ...
+     ```
+   - 이슈가 없으면 `## 이슈` 섹션 생략
+
+8. 결과를 아래 형식으로 출력해:
+   ```
+   ✅ 커밋: {커밋 메시지}
+   ✅ 푸시: {브랜치명} → origin/{브랜치명}
+   ✅ PR: {PR URL}
+
+   타겟: {브랜치명} → develop
+   ```
+
+주의사항:
+- `--no-verify` 옵션 절대 사용 안 함
+- force push 금지
+- PR 제목은 반드시 `#{이슈번호}`로 시작 (이슈 있을 때)
+- 타겟 브랜치는 항상 `develop`

--- a/App.tsx
+++ b/App.tsx
@@ -10,7 +10,7 @@ import MobileAds from 'react-native-google-mobile-ads';
 import { initDb } from './src/db';
 import { loadPremiumStatus } from './src/hooks/usePremiumStatus';
 import { configurePurchases } from './src/screens/PremiumScreen';
-import TabNavigator from './src/navigation/TabNavigator';
+import DrawerNavigator from './src/navigation/DrawerNavigator';
 import { AppTheme, NavTheme } from './src/theme';
 
 const queryClient = new QueryClient();
@@ -48,7 +48,7 @@ export default function App() {
           <PaperProvider theme={AppTheme}>
             <NavigationContainer theme={NavTheme}>
               <StatusBar style="light" />
-              <TabNavigator />
+              <DrawerNavigator />
             </NavigationContainer>
           </PaperProvider>
         </SafeAreaProvider>

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@react-native-community/datetimepicker": "8.4.4",
         "@react-navigation/bottom-tabs": "^7.15.9",
+        "@react-navigation/drawer": "^7.9.8",
         "@react-navigation/native": "^7.2.2",
         "@react-navigation/native-stack": "^7.14.10",
         "@tanstack/react-query": "^5.96.2",
@@ -4061,6 +4062,27 @@
       },
       "peerDependencies": {
         "react": ">= 18.2.0"
+      }
+    },
+    "node_modules/@react-navigation/drawer": {
+      "version": "7.9.8",
+      "resolved": "https://registry.npmjs.org/@react-navigation/drawer/-/drawer-7.9.8.tgz",
+      "integrity": "sha512-mSR5tgMaq5rtPQdpXL0ijzll8MSCGzpaflATitdyRZWEF29qS1XfQ2YHc0m4B/V4HyVQtaF7euEF5f7NMrc87w==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-navigation/elements": "^2.9.14",
+        "color": "^4.2.3",
+        "react-native-drawer-layout": "^4.2.2",
+        "use-latest-callback": "^0.2.4"
+      },
+      "peerDependencies": {
+        "@react-navigation/native": "^7.2.2",
+        "react": ">= 18.2.0",
+        "react-native": "*",
+        "react-native-gesture-handler": ">= 2.0.0",
+        "react-native-reanimated": ">= 2.0.0",
+        "react-native-safe-area-context": ">= 4.0.0",
+        "react-native-screens": ">= 4.0.0"
       }
     },
     "node_modules/@react-navigation/elements": {
@@ -8914,6 +8936,22 @@
         "react-native": ">=0.64.0",
         "react-native-gesture-handler": ">=2.0.0",
         "react-native-reanimated": ">=2.8.0"
+      }
+    },
+    "node_modules/react-native-drawer-layout": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/react-native-drawer-layout/-/react-native-drawer-layout-4.2.2.tgz",
+      "integrity": "sha512-UG/PTTeyyr43KahbgoGyXri8LMO5USHY3/RUpeKBKwCc7xLVGnDLOVNSRrJw0dDc7YmPbmAyJ4oxp8nKboKKuw==",
+      "license": "MIT",
+      "dependencies": {
+        "color": "^4.2.3",
+        "use-latest-callback": "^0.2.4"
+      },
+      "peerDependencies": {
+        "react": ">= 18.2.0",
+        "react-native": "*",
+        "react-native-gesture-handler": ">= 2.0.0",
+        "react-native-reanimated": ">= 2.0.0"
       }
     },
     "node_modules/react-native-gesture-handler": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@react-native-community/datetimepicker": "8.4.4",
     "@react-navigation/bottom-tabs": "^7.15.9",
+    "@react-navigation/drawer": "^7.9.8",
     "@react-navigation/native": "^7.2.2",
     "@react-navigation/native-stack": "^7.14.10",
     "@tanstack/react-query": "^5.96.2",

--- a/src/components/DrawerContent.tsx
+++ b/src/components/DrawerContent.tsx
@@ -1,0 +1,62 @@
+import { View, StyleSheet } from 'react-native';
+import { DrawerContentScrollView, DrawerItem, DrawerContentComponentProps } from '@react-navigation/drawer';
+import { Text } from 'react-native-paper';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
+import { Colors } from '../theme';
+
+export default function DrawerContent(props: DrawerContentComponentProps) {
+  const navigate = (screen: string) => {
+    props.navigation.navigate('SettingsMain', { screen });
+    props.navigation.closeDrawer();
+  };
+
+  return (
+    <DrawerContentScrollView
+      {...props}
+      contentContainerStyle={styles.container}
+    >
+      <View style={styles.header}>
+        <Text variant="titleLarge" style={styles.appName}>CheckCheck</Text>
+      </View>
+
+      <View style={styles.section}>
+        <Text variant="labelSmall" style={styles.sectionLabel}>관리</Text>
+        <DrawerItem
+          label="카테고리 관리"
+          labelStyle={styles.itemLabel}
+          icon={({ color, size }) => (
+            <MaterialCommunityIcons name="tag-outline" size={size} color={color} />
+          )}
+          onPress={() => navigate('CategoryManagement')}
+        />
+        <DrawerItem
+          label="루틴 관리"
+          labelStyle={styles.itemLabel}
+          icon={({ color, size }) => (
+            <MaterialCommunityIcons name="repeat" size={size} color={color} />
+          )}
+          onPress={() => navigate('RoutineManagement')}
+        />
+      </View>
+    </DrawerContentScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: Colors.surface },
+  header: {
+    paddingHorizontal: 20,
+    paddingVertical: 24,
+    borderBottomWidth: 1,
+    borderBottomColor: Colors.border,
+  },
+  appName: { color: Colors.primary, fontWeight: '700' },
+  section: { paddingTop: 8 },
+  sectionLabel: {
+    color: Colors.textSecondary,
+    marginHorizontal: 16,
+    marginTop: 12,
+    marginBottom: 4,
+  },
+  itemLabel: { color: Colors.text },
+});

--- a/src/navigation/DrawerNavigator.tsx
+++ b/src/navigation/DrawerNavigator.tsx
@@ -1,0 +1,28 @@
+import { createDrawerNavigator } from '@react-navigation/drawer';
+import { NavigatorScreenParams } from '@react-navigation/native';
+import TabNavigator from './TabNavigator';
+import SettingsStack from './SettingsStack';
+import DrawerContent from '../components/DrawerContent';
+import { SettingsStackParamList } from './SettingsStack';
+
+export type DrawerParamList = {
+  Main: undefined;
+  SettingsMain: NavigatorScreenParams<SettingsStackParamList> | undefined;
+};
+
+const Drawer = createDrawerNavigator<DrawerParamList>();
+
+export default function DrawerNavigator() {
+  return (
+    <Drawer.Navigator
+      drawerContent={(props) => <DrawerContent {...props} />}
+      screenOptions={{
+        headerShown: false,
+        drawerType: 'front',
+      }}
+    >
+      <Drawer.Screen name="Main" component={TabNavigator} />
+      <Drawer.Screen name="SettingsMain" component={SettingsStack} />
+    </Drawer.Navigator>
+  );
+}

--- a/src/navigation/TabNavigator.tsx
+++ b/src/navigation/TabNavigator.tsx
@@ -2,7 +2,6 @@ import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import TodoStack from './TodoStack';
 import RecordScreen from '../screens/RecordScreen';
-import SettingsStack from './SettingsStack';
 
 const Tab = createBottomTabNavigator();
 
@@ -31,15 +30,6 @@ export default function TabNavigator() {
         options={{
           tabBarIcon: ({ color, size }: IconProps) => (
             <MaterialCommunityIcons name="view-grid-outline" size={size} color={color} />
-          ),
-        }}
-      />
-      <Tab.Screen
-        name="설정"
-        component={SettingsStack}
-        options={{
-          tabBarIcon: ({ color, size }: IconProps) => (
-            <MaterialCommunityIcons name="cog-outline" size={size} color={color} />
           ),
         }}
       />


### PR DESCRIPTION
## 이슈
Closes #71

## 변경 사항
- `@react-navigation/drawer` 패키지 설치
- `src/navigation/DrawerNavigator.tsx` 신규 — DrawerParamList 타입 정의, Main(TabNavigator) + SettingsMain(SettingsStack) 구성
- `src/components/DrawerContent.tsx` 신규 — 앱 로고, 카테고리/루틴 관리 메뉴 항목 (DrawerContentScrollView + DrawerItem)
- `App.tsx` — TabNavigator → DrawerNavigator로 교체
- `src/navigation/TabNavigator.tsx` — 설정 탭 제거, 할 일 + 기록 2개 탭만 유지
- `.claude/skills/ship/` 신규 — suggest-commit → commit-push → PR 한 번에 처리하는 스킬

## 테스트
- [ ] 앱 실행 시 하단 탭 2개(할 일, 기록)만 노출 확인
- [ ] 엣지 스와이프로 Drawer가 왼쪽에서 슬라이드 인 확인
- [ ] Drawer에 카테고리 관리, 루틴 관리 항목 노출 확인
- [ ] 기존 기능(서브탭, 루틴 CRUD, 할 일 CRUD) 회귀 없음 확인