### PR TITLE
#72 [Phase 2] 화면 헤더 통합 및 설정 정리

### DIFF
--- a/.claude/phase-map.json
+++ b/.claude/phase-map.json
@@ -6,14 +6,14 @@
       "title": "Drawer 내비게이션 구조 구축",
       "issueNumber": 71,
       "branch": "feature/issue-71/drawer-navigation-setup",
-      "status": "in_progress"
+      "status": "done"
     },
     {
       "number": 2,
       "title": "화면 헤더 통합 및 설정 정리",
       "issueNumber": 72,
       "branch": "feature/issue-72/screen-header-and-settings-cleanup",
-      "status": "pending"
+      "status": "in_progress"
     }
   ]
 }

--- a/.claude/skills/apply/skill.md
+++ b/.claude/skills/apply/skill.md
@@ -1,5 +1,5 @@
 ---
-name: ship
+name: apply
 description: 변경 사항 분석 → 커밋 메시지 자동 선택 → 커밋 → 푸시 → PR 생성까지 한 번에 처리
 tools: Bash
 ---

--- a/.claude/skills/task/skill.md
+++ b/.claude/skills/task/skill.md
@@ -1,8 +1,8 @@
 ---
-name: phase-dev
-description: 플랜을 단계별 이슈로 분리 → 단계별 구현 → 사용자 검증 후 PR. /phase-dev init으로 시작, /phase-dev [n]으로 단계 진행.
+name: task
+description: 플랜을 단계별 이슈로 분리 → 단계별 구현 → 사용자 검증 후 PR. /task init으로 시작, /task next로 다음 단계 진행.
 tools: Bash, Read, Write, Glob, Edit
-argument-hint: "[init | 단계번호]"
+argument-hint: "[init | next | 단계번호 | status | done]"
 ---
 
 ## 역할
@@ -47,15 +47,16 @@ argument-hint: "[init | 단계번호]"
 
 ---
 
-### `$ARGUMENTS`가 숫자이거나, phase-map이 있고 인자가 없을 때 → 단계 구현 모드
+### `$ARGUMENTS`가 숫자, `next`, 또는 비어있고 phase-map이 있을 때 → 단계 구현 모드
 
 1. `.claude/phase-map.json`을 읽어.
-   - 인자가 숫자면 해당 단계, 없으면 `status: "pending"`인 첫 번째 단계를 선택
+   - 인자가 숫자면 해당 단계 선택
+   - 인자가 `next` 또는 없으면 현재 `in_progress` 단계를 `"done"`으로 먼저 업데이트 후, `status: "pending"`인 첫 번째 단계를 선택
 
 2. 이전 단계가 `"done"` 또는 1단계면 진행. 아니면:
    ```
    이전 단계가 아직 완료되지 않았습니다.
-   검증이 끝났으면 /suggest-commit → /commit-push → /pr 을 실행해 주세요.
+   검증이 끝났으면 /apply 를 실행해 주세요.
    ```
    로 안내하고 중단.
 
@@ -80,12 +81,10 @@ argument-hint: "[init | 단계번호]"
    {이 단계에서 확인해야 할 항목들을 체크리스트로}
 
    검증이 완료되면:
-   1. /suggest-commit
-   2. /commit-push {메시지}
-   3. /pr
+   /apply
 
-   PR 머지 후 다음 단계: /phase-dev {N+1}
-   (마지막 단계라면 /phase-dev done)
+   PR 머지 후 다음 단계: /task next
+   (마지막 단계라면 /task done)
    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    ```
 
@@ -119,9 +118,8 @@ Phase  제목                  이슈  브랜치              상태
 
 ---
 
-## 단계 완료 처리 (`/pr` 실행 후 자동이 아닌, 수동으로 기록)
-PR이 머지되면 `.claude/phase-map.json`에서 해당 단계를 `"done"`으로 수동 업데이트하거나,
-다음 단계(`/phase-dev [n+1]`) 실행 시 자동으로 이전 단계를 `"done"` 처리.
+## 단계 완료 처리
+`/task next` 실행 시 자동으로 현재 `in_progress` 단계를 `"done"` 처리 후 다음 pending 단계 시작.
 
 ---
 

--- a/src/components/DrawerContent.tsx
+++ b/src/components/DrawerContent.tsx
@@ -5,11 +5,6 @@ import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { Colors } from '../theme';
 
 export default function DrawerContent(props: DrawerContentComponentProps) {
-  const navigate = (screen: string) => {
-    props.navigation.navigate('SettingsMain', { screen });
-    props.navigation.closeDrawer();
-  };
-
   return (
     <DrawerContentScrollView
       {...props}
@@ -27,7 +22,10 @@ export default function DrawerContent(props: DrawerContentComponentProps) {
           icon={({ color, size }) => (
             <MaterialCommunityIcons name="tag-outline" size={size} color={color} />
           )}
-          onPress={() => navigate('CategoryManagement')}
+          onPress={() => {
+            props.navigation.navigate('CategoryDrawer');
+            props.navigation.closeDrawer();
+          }}
         />
         <DrawerItem
           label="루틴 관리"
@@ -35,7 +33,10 @@ export default function DrawerContent(props: DrawerContentComponentProps) {
           icon={({ color, size }) => (
             <MaterialCommunityIcons name="repeat" size={size} color={color} />
           )}
-          onPress={() => navigate('RoutineManagement')}
+          onPress={() => {
+            props.navigation.navigate('RoutineDrawer');
+            props.navigation.closeDrawer();
+          }}
         />
       </View>
     </DrawerContentScrollView>

--- a/src/navigation/CategoryStack.tsx
+++ b/src/navigation/CategoryStack.tsx
@@ -1,0 +1,26 @@
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import CategoryManagementScreen from '../screens/CategoryManagementScreen';
+import CategoryFormScreen from '../screens/CategoryFormScreen';
+
+export type CategoryStackParamList = {
+  CategoryManagement: undefined;
+  CategoryForm: {
+    category?: {
+      id: number;
+      name: string;
+      description?: string | null;
+      color: string;
+    };
+  } | undefined;
+};
+
+const Stack = createNativeStackNavigator<CategoryStackParamList>();
+
+export default function CategoryStack() {
+  return (
+    <Stack.Navigator screenOptions={{ headerShown: false, animation: 'slide_from_right' }}>
+      <Stack.Screen name="CategoryManagement" component={CategoryManagementScreen} />
+      <Stack.Screen name="CategoryForm" component={CategoryFormScreen} />
+    </Stack.Navigator>
+  );
+}

--- a/src/navigation/DrawerNavigator.tsx
+++ b/src/navigation/DrawerNavigator.tsx
@@ -1,12 +1,15 @@
 import { createDrawerNavigator } from '@react-navigation/drawer';
 import { NavigatorScreenParams } from '@react-navigation/native';
 import TabNavigator from './TabNavigator';
-import SettingsStack from './SettingsStack';
+import SettingsStack, { SettingsStackParamList } from './SettingsStack';
+import CategoryStack, { CategoryStackParamList } from './CategoryStack';
+import RoutineStack, { RoutineStackParamList } from './RoutineStack';
 import DrawerContent from '../components/DrawerContent';
-import { SettingsStackParamList } from './SettingsStack';
 
 export type DrawerParamList = {
   Main: undefined;
+  CategoryDrawer: NavigatorScreenParams<CategoryStackParamList> | undefined;
+  RoutineDrawer: NavigatorScreenParams<RoutineStackParamList> | undefined;
   SettingsMain: NavigatorScreenParams<SettingsStackParamList> | undefined;
 };
 
@@ -19,10 +22,16 @@ export default function DrawerNavigator() {
       screenOptions={{
         headerShown: false,
         drawerType: 'front',
+        swipeEnabled: false,
       }}
     >
-      <Drawer.Screen name="Main" component={TabNavigator} />
-      <Drawer.Screen name="SettingsMain" component={SettingsStack} options={{ unmountOnBlur: true }} />
+      <Drawer.Screen name="Main" component={TabNavigator} options={{ swipeEnabled: true }} />
+      {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+      <Drawer.Screen name="CategoryDrawer" component={CategoryStack} options={{ unmountOnBlur: true } as any} />
+      {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+      <Drawer.Screen name="RoutineDrawer" component={RoutineStack} options={{ unmountOnBlur: true } as any} />
+      {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+      <Drawer.Screen name="SettingsMain" component={SettingsStack} options={{ unmountOnBlur: true } as any} />
     </Drawer.Navigator>
   );
 }

--- a/src/navigation/DrawerNavigator.tsx
+++ b/src/navigation/DrawerNavigator.tsx
@@ -22,7 +22,7 @@ export default function DrawerNavigator() {
       }}
     >
       <Drawer.Screen name="Main" component={TabNavigator} />
-      <Drawer.Screen name="SettingsMain" component={SettingsStack} />
+      <Drawer.Screen name="SettingsMain" component={SettingsStack} options={{ unmountOnBlur: true }} />
     </Drawer.Navigator>
   );
 }

--- a/src/navigation/RoutineStack.tsx
+++ b/src/navigation/RoutineStack.tsx
@@ -1,0 +1,34 @@
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import RoutineManagementScreen from '../screens/RoutineManagementScreen';
+import RoutineFormScreen from '../screens/RoutineFormScreen';
+
+export type RoutineStackParamList = {
+  RoutineManagement: undefined;
+  RoutineForm: {
+    routine?: {
+      id: number;
+      categoryId: number;
+      title: string;
+      description?: string | null;
+      repeatType: string;
+      repeatValue?: string | null;
+      urgency: number | null;
+      importance: number | null;
+      sortOrder: number;
+      isActive: number;
+      createdAt: number;
+      updatedAt: number;
+    };
+  } | undefined;
+};
+
+const Stack = createNativeStackNavigator<RoutineStackParamList>();
+
+export default function RoutineStack() {
+  return (
+    <Stack.Navigator screenOptions={{ headerShown: false, animation: 'slide_from_right' }}>
+      <Stack.Screen name="RoutineManagement" component={RoutineManagementScreen} />
+      <Stack.Screen name="RoutineForm" component={RoutineFormScreen} />
+    </Stack.Navigator>
+  );
+}

--- a/src/navigation/SettingsStack.tsx
+++ b/src/navigation/SettingsStack.tsx
@@ -1,39 +1,9 @@
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import SettingsScreen from '../screens/SettingsScreen';
-import CategoryManagementScreen from '../screens/CategoryManagementScreen';
-import CategoryFormScreen from '../screens/CategoryFormScreen';
-import RoutineManagementScreen from '../screens/RoutineManagementScreen';
-import RoutineFormScreen from '../screens/RoutineFormScreen';
 import PremiumScreen from '../screens/PremiumScreen';
 
 export type SettingsStackParamList = {
   SettingsHome: undefined;
-  CategoryManagement: undefined;
-  CategoryForm: {
-    category?: {
-      id: number;
-      name: string;
-      description?: string | null;
-      color: string;
-    };
-  } | undefined;
-  RoutineManagement: undefined;
-  RoutineForm: {
-    routine?: {
-      id: number;
-      categoryId: number;
-      title: string;
-      description?: string | null;
-      repeatType: string;
-      repeatValue?: string | null;
-      urgency: number | null;
-      importance: number | null;
-      sortOrder: number;
-      isActive: number;
-      createdAt: number;
-      updatedAt: number;
-    };
-  } | undefined;
   Premium: undefined;
 };
 
@@ -43,10 +13,6 @@ export default function SettingsStack() {
   return (
     <Stack.Navigator screenOptions={{ headerShown: false, animation: 'slide_from_right' }}>
       <Stack.Screen name="SettingsHome" component={SettingsScreen} />
-      <Stack.Screen name="CategoryManagement" component={CategoryManagementScreen} />
-      <Stack.Screen name="CategoryForm" component={CategoryFormScreen} />
-      <Stack.Screen name="RoutineManagement" component={RoutineManagementScreen} />
-      <Stack.Screen name="RoutineForm" component={RoutineFormScreen} />
       <Stack.Screen name="Premium" component={PremiumScreen} />
     </Stack.Navigator>
   );

--- a/src/screens/CategoryFormScreen.tsx
+++ b/src/screens/CategoryFormScreen.tsx
@@ -5,11 +5,11 @@ import { Colors } from '../theme';
 import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useCreateCategory, useUpdateCategory, useDeleteCategory, useCategories } from '../hooks/useCategories';
-import { SettingsStackParamList } from '../navigation/SettingsStack';
+import { CategoryStackParamList } from '../navigation/CategoryStack';
 import { generateRandomColor } from '../constants/colors';
 
-type Nav = NativeStackNavigationProp<SettingsStackParamList, 'CategoryForm'>;
-type Route = RouteProp<SettingsStackParamList, 'CategoryForm'>;
+type Nav = NativeStackNavigationProp<CategoryStackParamList, 'CategoryForm'>;
+type Route = RouteProp<CategoryStackParamList, 'CategoryForm'>;
 
 export default function CategoryFormScreen() {
   const navigation = useNavigation<Nav>();

--- a/src/screens/CategoryManagementScreen.tsx
+++ b/src/screens/CategoryManagementScreen.tsx
@@ -5,9 +5,9 @@ import DraggableFlatList, { RenderItemParams, ScaleDecorator } from 'react-nativ
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useCategories, useReorderCategories } from '../hooks/useCategories';
-import { SettingsStackParamList } from '../navigation/SettingsStack';
+import { CategoryStackParamList } from '../navigation/CategoryStack';
 
-type Nav = NativeStackNavigationProp<SettingsStackParamList, 'CategoryManagement'>;
+type Nav = NativeStackNavigationProp<CategoryStackParamList, 'CategoryManagement'>;
 
 type Category = {
   id: number;

--- a/src/screens/RecordScreen.tsx
+++ b/src/screens/RecordScreen.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { View, ScrollView, StyleSheet } from 'react-native';
 import { Appbar, Text, IconButton } from 'react-native-paper';
+import { useNavigation, DrawerActions } from '@react-navigation/native';
 import { Colors } from '../theme';
 import { useCategories } from '../hooks/useCategories';
 import { useEarliestCompletionYear } from '../hooks/useCompletions';
@@ -10,6 +11,7 @@ import BannerAdView from '../components/BannerAdView';
 const CURRENT_YEAR = new Date().getFullYear();
 
 export default function RecordScreen() {
+  const navigation = useNavigation();
   const [year, setYear] = useState(CURRENT_YEAR);
   const { data: categories = [] } = useCategories();
   const { data: earliestYear = CURRENT_YEAR } = useEarliestCompletionYear();
@@ -17,20 +19,26 @@ export default function RecordScreen() {
   return (
     <View style={styles.container}>
       <Appbar.Header>
+        <Appbar.Action icon="menu" onPress={() => navigation.dispatch(DrawerActions.openDrawer())} />
+        <Appbar.Content title="CheckCheck" titleStyle={{ fontWeight: '700' }} />
+        <Appbar.Action icon="cog-outline" onPress={() => navigation.navigate('SettingsMain' as never)} />
+      </Appbar.Header>
+
+      <View style={styles.yearRow}>
         <IconButton
           icon="chevron-left"
           iconColor={year <= earliestYear ? Colors.textMuted : Colors.text}
           disabled={year <= earliestYear}
           onPress={() => setYear((y) => y - 1)}
         />
-        <Appbar.Content title={String(year)} titleStyle={styles.yearTitle} />
+        <Text style={styles.yearText}>{year}</Text>
         <IconButton
           icon="chevron-right"
           iconColor={year >= CURRENT_YEAR ? Colors.textMuted : Colors.text}
           disabled={year >= CURRENT_YEAR}
           onPress={() => setYear((y) => y + 1)}
         />
-      </Appbar.Header>
+      </View>
 
       <ScrollView contentContainerStyle={styles.content}>
         {categories.map((category) => (
@@ -57,7 +65,16 @@ export default function RecordScreen() {
 
 const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: Colors.background },
-  yearTitle: { textAlign: 'center', fontWeight: '700', fontSize: 18 },
+  yearRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 4,
+    backgroundColor: Colors.surface,
+    borderBottomWidth: 1,
+    borderBottomColor: Colors.border,
+  },
+  yearText: { color: Colors.text, fontWeight: '700', fontSize: 16, minWidth: 40, textAlign: 'center' },
   content: { paddingVertical: 8 },
   section: {
     paddingHorizontal: 2,

--- a/src/screens/RoutineFormScreen.tsx
+++ b/src/screens/RoutineFormScreen.tsx
@@ -6,11 +6,11 @@ import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useCreateRoutine, useUpdateRoutine, useDeleteRoutine } from '../hooks/useRoutines';
 import { useCategories } from '../hooks/useCategories';
-import { SettingsStackParamList } from '../navigation/SettingsStack';
+import { RoutineStackParamList } from '../navigation/RoutineStack';
 import { LEVEL_OPTIONS } from '../constants/todo';
 
-type Nav = NativeStackNavigationProp<SettingsStackParamList, 'RoutineForm'>;
-type Route = RouteProp<SettingsStackParamList, 'RoutineForm'>;
+type Nav = NativeStackNavigationProp<RoutineStackParamList, 'RoutineForm'>;
+type Route = RouteProp<RoutineStackParamList, 'RoutineForm'>;
 
 const DAY_OPTIONS = [
   { value: '0', label: '일' },

--- a/src/screens/RoutineManagementScreen.tsx
+++ b/src/screens/RoutineManagementScreen.tsx
@@ -7,10 +7,10 @@ import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useMemo } from 'react';
 import { useRoutines, useReorderRoutines } from '../hooks/useRoutines';
 import { useCategories } from '../hooks/useCategories';
-import { SettingsStackParamList } from '../navigation/SettingsStack';
+import { RoutineStackParamList } from '../navigation/RoutineStack';
 import { LEVEL_LABELS } from '../constants/todo';
 
-type Nav = NativeStackNavigationProp<SettingsStackParamList, 'RoutineManagement'>;
+type Nav = NativeStackNavigationProp<RoutineStackParamList, 'RoutineManagement'>;
 
 type Routine = {
   id: number;

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -1,20 +1,14 @@
 import { View, StyleSheet, TouchableOpacity, Alert } from 'react-native';
 import { Appbar, Text, Divider } from 'react-native-paper';
 import { Colors } from '../theme';
-import { useNavigation, CommonActions } from '@react-navigation/native';
+import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import { useEffect } from 'react';
 import { SettingsStackParamList } from '../navigation/SettingsStack';
 import Constants from 'expo-constants';
 import { usePremiumStore } from '../stores/premiumStore';
 import { savePremiumStatus } from '../hooks/usePremiumStatus';
 
 type NavigationProp = NativeStackNavigationProp<SettingsStackParamList, 'SettingsHome'>;
-
-const SETTINGS_ITEMS = [
-  { key: 'CategoryManagement', label: '카테고리 관리', description: '카테고리 추가, 수정, 삭제' },
-  { key: 'RoutineManagement', label: '루틴 관리', description: '반복 루틴 추가, 수정, 삭제' },
-] as const;
 
 const APP_INFO = [
   { label: '앱 이름', value: Constants.expoConfig?.name ?? 'checkcheck' },
@@ -26,40 +20,12 @@ export default function SettingsScreen() {
   const navigation = useNavigation<NavigationProp>();
   const isPremium = usePremiumStore((s) => s.isPremium);
 
-  useEffect(() => {
-    const parentNav = navigation.getParent();
-    if (!parentNav) return;
-    return parentNav.addListener('focus', () => {
-      navigation.setOptions({ animation: 'none' });
-      navigation.dispatch(CommonActions.reset({ index: 0, routes: [{ name: 'SettingsHome' }] }));
-      requestAnimationFrame(() => navigation.setOptions({ animation: 'default' }));
-    });
-  }, [navigation]);
-
   return (
     <View style={styles.container}>
       <Appbar.Header>
+        <Appbar.BackAction onPress={() => navigation.goBack()} />
         <Appbar.Content title="설정" />
       </Appbar.Header>
-
-      <Text variant="labelSmall" style={styles.sectionLabel}>일반</Text>
-      <View style={styles.section}>
-        {SETTINGS_ITEMS.map((item, index) => (
-          <View key={item.key}>
-            <TouchableOpacity
-              style={styles.item}
-              onPress={() => navigation.navigate(item.key)}
-            >
-              <View>
-                <Text variant="bodyLarge">{item.label}</Text>
-                <Text variant="bodySmall" style={styles.description}>{item.description}</Text>
-              </View>
-              <Text style={styles.arrow}>›</Text>
-            </TouchableOpacity>
-            {index < SETTINGS_ITEMS.length - 1 && <Divider />}
-          </View>
-        ))}
-      </View>
 
       <Text variant="labelSmall" style={styles.sectionLabel}>프리미엄</Text>
       <View style={styles.section}>

--- a/src/screens/TodoScreen.tsx
+++ b/src/screens/TodoScreen.tsx
@@ -1,8 +1,7 @@
 import { StyleSheet, View, useWindowDimensions } from 'react-native';
-import { FAB } from 'react-native-paper';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Appbar, FAB } from 'react-native-paper';
 import { TabView, TabBar } from 'react-native-tab-view';
-import { useNavigation, useIsFocused, CommonActions } from '@react-navigation/native';
+import { useNavigation, useIsFocused, CommonActions, DrawerActions } from '@react-navigation/native';
 import { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useState, useEffect } from 'react';
@@ -16,7 +15,6 @@ import TodoTabToday from '../components/TodoTabToday';
 import TodoTabList from '../components/TodoTabList';
 import TodoTabOverdue from '../components/TodoTabOverdue';
 import TodoTabCompleted from '../components/TodoTabCompleted';
-
 
 type Nav = NativeStackNavigationProp<TodoStackParamList, 'TodoList'>;
 
@@ -40,7 +38,6 @@ const renderScene = ({ route }: { route: { key: string } }) => {
 export default function TodoScreen() {
   const navigation = useNavigation<Nav>();
   const layout = useWindowDimensions();
-  const insets = useSafeAreaInsets();
   const [tabIndex, setTabIndex] = useState(0);
   const isPremium = usePremiumStore((s) => s.isPremium);
   const isFocused = useIsFocused();
@@ -75,7 +72,13 @@ export default function TodoScreen() {
   const showFab = tabIndex === 0 || tabIndex === 1;
 
   return (
-    <View style={[styles.container, { paddingTop: insets.top }]}>
+    <View style={styles.container}>
+      <Appbar.Header>
+        <Appbar.Action icon="menu" onPress={() => navigation.dispatch(DrawerActions.openDrawer())} />
+        <Appbar.Content title="CheckCheck" titleStyle={{ fontWeight: '700' }} />
+        <Appbar.Action icon="cog-outline" onPress={() => navigation.navigate('SettingsMain' as never)} />
+      </Appbar.Header>
+
       <TabView
         navigationState={{ index: tabIndex, routes: ROUTES }}
         renderScene={renderScene}


### PR DESCRIPTION
## 이슈
Closes #72

## 변경 사항
- `TodoScreen.tsx` — Appbar.Header 추가 (☰ menu / CheckCheck 볼드 / ⚙ cog-outline)
- `RecordScreen.tsx` — 헤더를 할 일 탭과 동일하게 통일, 연도 컨트롤을 헤더 아래 별도 행으로 분리
- `SettingsScreen.tsx` — 카테고리/루틴 항목 제거, back 버튼 추가, 불필요한 parent focus 리스너 제거
- `DrawerNavigator.tsx` — SettingsMain에 `unmountOnBlur: true` 추가 (설정 스택 상태 초기화 보장)
- 스킬 이름 변경: `phase-dev` → `task`, `ship` → `apply`

## 테스트
- [ ] 할 일 / 기록 탭 헤더 동일하게 [☰ CheckCheck ⚙] 노출 확인
- [ ] 로고 볼드체 적용 확인
- [ ] 기록 탭 연도 컨트롤이 헤더 아래 별도 행으로 표시 확인
- [ ] ⚙ 탭 → 설정 홈(프리미엄/앱 정보) 노출 확인 (카테고리/루틴 항목 없음)
- [ ] Drawer → 카테고리 관리 → back → 루틴 관리 이동 시 스택 꼬임 없음 확인
- [ ] 카테고리 관리에서 back 누르면 설정 홈으로 이동 (루틴 관리 페이지로 가지 않음)