### PR TITLE
#75 UI/UX 사용성 개선 - 헤더 높이, 탭 스와이프, Drawer 너비, 내비게이션 지연

### DIFF
--- a/src/components/DrawerContent.tsx
+++ b/src/components/DrawerContent.tsx
@@ -1,27 +1,39 @@
-import { View, StyleSheet } from 'react-native';
-import { DrawerContentScrollView, DrawerItem, DrawerContentComponentProps } from '@react-navigation/drawer';
+import { View, ScrollView, StyleSheet, TouchableOpacity } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { DrawerContentComponentProps } from '@react-navigation/drawer';
 import { Text } from 'react-native-paper';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { Colors } from '../theme';
 
+function DrawerItem({ label, icon, onPress }: {
+  label: string;
+  icon: string;
+  onPress: () => void;
+}) {
+  return (
+    <TouchableOpacity style={styles.item} onPress={onPress} activeOpacity={0.7}>
+      <MaterialCommunityIcons name={icon as any} size={22} color={Colors.text} style={styles.itemIcon} />
+      <Text variant="bodyLarge" style={styles.itemLabel}>{label}</Text>
+    </TouchableOpacity>
+  );
+}
+
 export default function DrawerContent(props: DrawerContentComponentProps) {
   return (
-    <DrawerContentScrollView
-      {...props}
-      contentContainerStyle={styles.container}
-    >
-      <View style={styles.header}>
+    <View style={styles.container}>
+      <SafeAreaView edges={['top']} style={styles.header}>
         <Text variant="titleLarge" style={styles.appName}>CheckCheck</Text>
-      </View>
+      </SafeAreaView>
 
-      <View style={styles.section}>
+      <ScrollView
+        style={styles.scrollView}
+        contentContainerStyle={styles.scrollContent}
+        showsVerticalScrollIndicator={false}
+      >
         <Text variant="labelSmall" style={styles.sectionLabel}>관리</Text>
         <DrawerItem
           label="카테고리 관리"
-          labelStyle={styles.itemLabel}
-          icon={({ color, size }) => (
-            <MaterialCommunityIcons name="tag-outline" size={size} color={color} />
-          )}
+          icon="tag-outline"
           onPress={() => {
             props.navigation.navigate('CategoryDrawer');
             props.navigation.closeDrawer();
@@ -29,17 +41,14 @@ export default function DrawerContent(props: DrawerContentComponentProps) {
         />
         <DrawerItem
           label="루틴 관리"
-          labelStyle={styles.itemLabel}
-          icon={({ color, size }) => (
-            <MaterialCommunityIcons name="repeat" size={size} color={color} />
-          )}
+          icon="repeat"
           onPress={() => {
             props.navigation.navigate('RoutineDrawer');
             props.navigation.closeDrawer();
           }}
         />
-      </View>
-    </DrawerContentScrollView>
+      </ScrollView>
+    </View>
   );
 }
 
@@ -52,12 +61,20 @@ const styles = StyleSheet.create({
     borderBottomColor: Colors.border,
   },
   appName: { color: Colors.primary, fontWeight: '700' },
-  section: { paddingTop: 8 },
+  scrollView: { flex: 1 },
+  scrollContent: { paddingTop: 8, paddingBottom: 24 },
   sectionLabel: {
     color: Colors.textSecondary,
     marginHorizontal: 16,
     marginTop: 12,
     marginBottom: 4,
   },
+  item: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+  },
+  itemIcon: { marginRight: 12 },
   itemLabel: { color: Colors.text },
 });

--- a/src/components/TodoItem.tsx
+++ b/src/components/TodoItem.tsx
@@ -1,4 +1,5 @@
 import { View, StyleSheet, TouchableOpacity } from 'react-native';
+import { useRef } from 'react';
 import { Text, Checkbox } from 'react-native-paper';
 import { Colors } from '../theme';
 import { LEVEL_LABELS } from '../constants/todo';
@@ -35,6 +36,7 @@ const IMPORTANCE_COLOR = Colors.importance;
 
 export default function TodoItem({ todo, category, onToggle, onPress, onDrag, isDragging, forceCompleted }: Props) {
   const showAsCompleted = todo.isCompleted === 1 || forceCompleted;
+  const pressStartX = useRef(0);
   const dueDateStr = todo.dueDate
     ? new Date(todo.dueDate).toLocaleDateString('ko-KR', { month: 'short', day: 'numeric' })
     : null;
@@ -51,7 +53,13 @@ export default function TodoItem({ todo, category, onToggle, onPress, onDrag, is
         />
       </TouchableOpacity>
 
-      <TouchableOpacity style={styles.content} onPress={onPress} onLongPress={onDrag} activeOpacity={0.7}>
+      <TouchableOpacity
+        style={styles.content}
+        onPressIn={(e) => { pressStartX.current = e.nativeEvent.pageX; }}
+        onPress={(e) => { if (Math.abs(e.nativeEvent.pageX - pressStartX.current) < 10) onPress(); }}
+        onLongPress={onDrag}
+        activeOpacity={0.7}
+      >
         <Text
           variant="bodyLarge"
           style={[styles.titleText, showAsCompleted && styles.completed]}

--- a/src/components/TodoTabList.tsx
+++ b/src/components/TodoTabList.tsx
@@ -60,6 +60,7 @@ export default function TodoTabList() {
       }
       renderItem={renderItem}
       onDragEnd={({ data }) => reorderTodos(data.map((t) => t.id))}
+      activationDistance={20}
       autoscrollThreshold={80}
       autoscrollSpeed={200}
       containerStyle={styles.list}

--- a/src/components/TodoTabOverdue.tsx
+++ b/src/components/TodoTabOverdue.tsx
@@ -60,6 +60,7 @@ export default function TodoTabOverdue() {
       }
       renderItem={renderItem}
       onDragEnd={({ data }) => reorderTodos(data.map((t) => t.id))}
+      activationDistance={20}
       autoscrollThreshold={80}
       autoscrollSpeed={200}
       containerStyle={styles.list}

--- a/src/components/TodoTabToday.tsx
+++ b/src/components/TodoTabToday.tsx
@@ -68,6 +68,7 @@ export default function TodoTabToday() {
       ItemSeparatorComponent={() => <Divider />}
       renderItem={renderTodoItem}
       onDragEnd={({ data }) => reorderTodos(data.map((t) => t.id))}
+      activationDistance={20}
       autoscrollThreshold={80}
       autoscrollSpeed={200}
       containerStyle={styles.list}

--- a/src/hooks/useTodos.ts
+++ b/src/hooks/useTodos.ts
@@ -116,13 +116,21 @@ export const useTodayToggle = () => {
   });
 };
 
-/** 기한 체크: 기한이 지난 항목 중 완료 기록 있으면 isCompleted=1로 마이그레이션 */
-export const runDueDateCheck = async () => {
+/** 기한 체크: 기한이 지난 항목 중 완료 기록 있으면 isCompleted=1로 마이그레이션.
+ *  하루 1회만 실행 (JS 스레드 동기 SQLite 블로킹 최소화) */
+let _lastDueDateCheckDate = '';
+
+export const runDueDateCheck = async (): Promise<boolean> => {
+  const today = dayjs().format('YYYY-MM-DD');
+  if (_lastDueDateCheckDate === today) return false;
+  _lastDueDateCheckDate = today;
+
   const todayStart = dayjs().startOf('day').valueOf();
   const overdueTodos = db.select().from(todos)
     .where(and(eq(todos.isCompleted, 0), eq(todos.isDeleted, 0), lt(todos.dueDate, todayStart)))
     .all();
 
+  let changed = false;
   for (const todo of overdueTodos) {
     const completion = db.select().from(todoCompletions)
       .where(eq(todoCompletions.todoId, todo.id))
@@ -134,8 +142,10 @@ export const runDueDateCheck = async () => {
         completedAt: now,
         updatedAt: now,
       }).where(eq(todos.id, todo.id)).run();
+      changed = true;
     }
   }
+  return changed;
 };
 
 export const useCreateTodo = () => {

--- a/src/navigation/DrawerNavigator.tsx
+++ b/src/navigation/DrawerNavigator.tsx
@@ -23,15 +23,13 @@ export default function DrawerNavigator() {
         headerShown: false,
         drawerType: 'front',
         swipeEnabled: false,
+        drawerStyle: { width: '62%' },
       }}
     >
-      <Drawer.Screen name="Main" component={TabNavigator} options={{ swipeEnabled: true }} />
-      {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-      <Drawer.Screen name="CategoryDrawer" component={CategoryStack} options={{ unmountOnBlur: true } as any} />
-      {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-      <Drawer.Screen name="RoutineDrawer" component={RoutineStack} options={{ unmountOnBlur: true } as any} />
-      {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-      <Drawer.Screen name="SettingsMain" component={SettingsStack} options={{ unmountOnBlur: true } as any} />
+      <Drawer.Screen name="Main" component={TabNavigator} />
+      <Drawer.Screen name="CategoryDrawer" component={CategoryStack} />
+      <Drawer.Screen name="RoutineDrawer" component={RoutineStack} />
+      <Drawer.Screen name="SettingsMain" component={SettingsStack} />
     </Drawer.Navigator>
   );
 }

--- a/src/screens/CategoryManagementScreen.tsx
+++ b/src/screens/CategoryManagementScreen.tsx
@@ -106,5 +106,5 @@ const styles = StyleSheet.create({
   },
   description: { color: Colors.textSecondary, marginTop: 2 },
   dragHandle: { color: Colors.textMuted, fontSize: 18 },
-  fab: { position: 'absolute', right: 16, bottom: 16 },
+  fab: { position: 'absolute', right: 16, bottom: 48 },
 });

--- a/src/screens/RecordScreen.tsx
+++ b/src/screens/RecordScreen.tsx
@@ -18,7 +18,7 @@ export default function RecordScreen() {
 
   return (
     <View style={styles.container}>
-      <Appbar.Header>
+      <Appbar.Header style={styles.header}>
         <Appbar.Action icon="menu" onPress={() => navigation.dispatch(DrawerActions.openDrawer())} />
         <Appbar.Content title="CheckCheck" titleStyle={{ fontWeight: '700' }} />
         <Appbar.Action icon="cog-outline" onPress={() => navigation.navigate('SettingsMain' as never)} />
@@ -65,6 +65,7 @@ export default function RecordScreen() {
 
 const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: Colors.background },
+  header: { height: 72 },
   yearRow: {
     flexDirection: 'row',
     alignItems: 'center',

--- a/src/screens/RoutineManagementScreen.tsx
+++ b/src/screens/RoutineManagementScreen.tsx
@@ -158,6 +158,6 @@ const styles = StyleSheet.create({
   badge: { paddingHorizontal: 6, paddingVertical: 2, borderRadius: 4 },
   badgeText: { fontSize: 10, fontWeight: '600' },
   dragHandle: { color: Colors.textMuted, fontSize: 18 },
-  fab: { position: 'absolute', right: 16, bottom: 16 },
+  fab: { position: 'absolute', right: 16, bottom: 48 },
   empty: { textAlign: 'center', marginTop: 60, color: Colors.textMuted },
 });

--- a/src/screens/TodoScreen.tsx
+++ b/src/screens/TodoScreen.tsx
@@ -73,7 +73,7 @@ export default function TodoScreen() {
 
   return (
     <View style={styles.container}>
-      <Appbar.Header>
+      <Appbar.Header style={styles.header}>
         <Appbar.Action icon="menu" onPress={() => navigation.dispatch(DrawerActions.openDrawer())} />
         <Appbar.Content title="CheckCheck" titleStyle={{ fontWeight: '700' }} />
         <Appbar.Action icon="cog-outline" onPress={() => navigation.navigate('SettingsMain' as never)} />
@@ -111,6 +111,7 @@ export default function TodoScreen() {
 
 const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: Colors.background },
+  header: { height: 72 },
   tabBar: { backgroundColor: Colors.surface },
   indicator: { backgroundColor: Colors.primary },
   fab: { position: 'absolute', right: 16, bottom: 16 },

--- a/src/screens/TodoScreen.tsx
+++ b/src/screens/TodoScreen.tsx
@@ -1,4 +1,4 @@
-import { StyleSheet, View, useWindowDimensions } from 'react-native';
+import { StyleSheet, View, useWindowDimensions, InteractionManager } from 'react-native';
 import { Appbar, FAB } from 'react-native-paper';
 import { TabView, TabBar } from 'react-native-tab-view';
 import { useNavigation, useIsFocused, CommonActions, DrawerActions } from '@react-navigation/native';
@@ -57,16 +57,16 @@ export default function TodoScreen() {
 
   useEffect(() => {
     if (!isFocused) return;
-    runDueDateCheck().then(() => {
-      queryClient.invalidateQueries({ queryKey: ['todos'] });
+    const task = InteractionManager.runAfterInteractions(() => {
+      runDueDateCheck().then((changed) => {
+        if (changed) queryClient.invalidateQueries({ queryKey: ['todos'] });
+      });
     });
+    return () => task.cancel();
   }, [isFocused, queryClient]);
 
   const handleTabIndexChange = (index: number) => {
     setTabIndex(index);
-    runDueDateCheck().then(() => {
-      queryClient.invalidateQueries({ queryKey: ['todos'] });
-    });
   };
 
   const showFab = tabIndex === 0 || tabIndex === 1;


### PR DESCRIPTION
## 이슈
Closes #75

## 변경 사항
- `TodoScreen`, `RecordScreen` — Appbar.Header 높이 64→72dp 증가
- `DrawerNavigator` — `drawerStyle.width: '62%'`로 너비 약 30% 축소, `swipeEnabled: false` 전체 적용 (Drawer-TabView 제스처 충돌 제거), `unmountOnBlur` 제거 (내비게이션 지연 개선)
- `TodoTabToday`, `TodoTabList`, `TodoTabOverdue` — `DraggableFlatList`에 `activationDistance={20}` 추가 (탭 스와이프와 드래그 제스처 분리)
- `TodoItem` — 스와이프 종료 시 오탭 방지: `pressStartX` ref로 수평 이동 거리 추적, 10px 초과 시 `onPress` 무시

## 테스트
- [ ] 헤더 영역이 이전보다 높게 표시되는지 확인
- [ ] 탭 간 스와이프 이동 (오늘↔할 일↔미완료↔완료) 정상 동작 확인
- [ ] 스와이프 후 아이템 수정 페이지로 이동하지 않는지 확인
- [ ] Drawer 너비가 이전보다 좁아졌는지 확인
- [ ] ☰ 버튼으로 Drawer 정상 열림 확인
- [ ] 카테고리/루틴/설정 페이지 전환 속도 확인
- [ ] 드래그 정렬 정상 동작 확인