### PR TITLE
#77 기록 화면 미분류 카테고리 ContributionGrid 셀 미표시 버그 수정

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -93,12 +93,6 @@ export const initDb = async () => {
     );
   `);
 
-  // migration: remove stale completion records for uncompleted/deleted todos
-  // (bug: toggle-back did not delete todoCompletions until fixed)
-  sqlite.execSync(`
-    DELETE FROM todo_completions
-    WHERE todo_id IN (SELECT id FROM todos WHERE is_completed = 0 OR is_deleted = 1);
-  `);
 
   db = drizzle(sqlite, { schema });
 

--- a/src/hooks/useCompletions.ts
+++ b/src/hooks/useCompletions.ts
@@ -1,24 +1,31 @@
 import { useQuery } from '@tanstack/react-query';
 import { eq, and, gte, lte, sql } from 'drizzle-orm';
 import { db } from '../db';
-import { todoCompletions, todos } from '../db/schema';
+import { todoCompletions, todos, routineCompletions, routines } from '../db/schema';
+
+const CURRENT_YEAR = new Date().getFullYear();
 
 export const useEarliestCompletionYear = () =>
   useQuery({
     queryKey: ['completions', 'earliest-year'],
     queryFn: () => {
-      const row = db
+      const todoRow = db
         .select({ minDate: sql<string>`min(${todoCompletions.completedDate})` })
         .from(todoCompletions)
         .get();
-      if (!row?.minDate) return CURRENT_YEAR;
-      return parseInt(row.minDate.slice(0, 4), 10);
+      const routineRow = db
+        .select({ minDate: sql<string>`min(${routineCompletions.completedDate})` })
+        .from(routineCompletions)
+        .get();
+
+      const dates = [todoRow?.minDate, routineRow?.minDate].filter(Boolean) as string[];
+      if (dates.length === 0) return CURRENT_YEAR;
+      const earliest = dates.sort()[0];
+      return parseInt(earliest.slice(0, 4), 10);
     },
   });
 
-const CURRENT_YEAR = new Date().getFullYear();
-
-// 특정 카테고리 + 년도 범위의 날짜별 완료 수 반환
+// 특정 카테고리 + 년도 범위의 날짜별 완료 수 반환 (todo + routine 합산)
 // { '2026-01-03': 2, '2026-01-05': 1, ... }
 export const useCompletionsByCategory = (categoryId: number, year: number) =>
   useQuery({
@@ -27,7 +34,7 @@ export const useCompletionsByCategory = (categoryId: number, year: number) =>
       const startDate = `${year}-01-01`;
       const endDate = `${year}-12-31`;
 
-      const rows = db
+      const todoRows = db
         .select({
           completedDate: todoCompletions.completedDate,
           count: sql<number>`count(*)`,
@@ -44,9 +51,29 @@ export const useCompletionsByCategory = (categoryId: number, year: number) =>
         .groupBy(todoCompletions.completedDate)
         .all();
 
+      const routineRows = db
+        .select({
+          completedDate: routineCompletions.completedDate,
+          count: sql<number>`count(*)`,
+        })
+        .from(routineCompletions)
+        .innerJoin(routines, eq(routineCompletions.routineId, routines.id))
+        .where(
+          and(
+            eq(routines.categoryId, categoryId),
+            gte(routineCompletions.completedDate, startDate),
+            lte(routineCompletions.completedDate, endDate)
+          )
+        )
+        .groupBy(routineCompletions.completedDate)
+        .all();
+
       const map: Record<string, number> = {};
-      for (const row of rows) {
-        map[row.completedDate] = row.count;
+      for (const row of todoRows) {
+        map[row.completedDate] = (map[row.completedDate] ?? 0) + row.count;
+      }
+      for (const row of routineRows) {
+        map[row.completedDate] = (map[row.completedDate] ?? 0) + row.count;
       }
       return map;
     },

--- a/src/hooks/useRoutines.ts
+++ b/src/hooks/useRoutines.ts
@@ -152,6 +152,7 @@ export const useToggleRoutineCompletion = () => {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['routineCompletions'] });
       queryClient.invalidateQueries({ queryKey: ['routinesToday'] });
+      queryClient.invalidateQueries({ queryKey: ['completions'], exact: false });
     },
   });
 };


### PR DESCRIPTION
## 이슈
Closes #77

## 변경 사항
- `useCompletions.ts`: `useCompletionsByCategory`가 `todo_completions`만 집계하던 것을 `routine_completions`도 합산하도록 수정
- `useCompletions.ts`: `useEarliestCompletionYear`도 루틴 완료 이력 포함해 최솟값 계산
- `useRoutines.ts`: 루틴 완료 토글 시 `completions` 쿼리 캐시 무효화 추가
- `db/index.ts`: 불필요해진 마이그레이션 쿼리(미완료 todo의 completion 레코드 삭제) 제거

## 테스트
- [ ] 루틴이 있는 카테고리의 기록 화면에서 완료 이력 셀 정상 표시 확인
- [ ] 할 일 완료 이력과 루틴 완료 이력이 같은 날짜에 합산되어 표시되는지 확인
- [ ] 루틴 완료 토글 시 기록 화면 셀이 즉시 반영되는지 확인