### PR TITLE
#82 오늘 탭 카테고리별 컬러 프로그레스 바 추가

### DIFF
--- a/src/components/TodayProgressBar.tsx
+++ b/src/components/TodayProgressBar.tsx
@@ -1,0 +1,120 @@
+import { View, StyleSheet } from 'react-native';
+import { Text } from 'react-native-paper';
+import { Colors } from '../theme';
+
+// hex 색상의 채도를 낮춰 반환 (amount: 0~1, 낮출수록 무채색에 가까워짐)
+function desaturate(hex: string, amount: number): string {
+  const r = parseInt(hex.slice(1, 3), 16) / 255;
+  const g = parseInt(hex.slice(3, 5), 16) / 255;
+  const b = parseInt(hex.slice(5, 7), 16) / 255;
+
+  const max = Math.max(r, g, b), min = Math.min(r, g, b);
+  const l = (max + min) / 2;
+  let h = 0, s = 0;
+
+  if (max !== min) {
+    const d = max - min;
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    switch (max) {
+      case r: h = ((g - b) / d + (g < b ? 6 : 0)) / 6; break;
+      case g: h = ((b - r) / d + 2) / 6; break;
+      case b: h = ((r - g) / d + 4) / 6; break;
+    }
+  }
+
+  const newS = Math.max(0, s - amount);
+
+  const hue2rgb = (p: number, q: number, t: number) => {
+    if (t < 0) t += 1;
+    if (t > 1) t -= 1;
+    if (t < 1 / 6) return p + (q - p) * 6 * t;
+    if (t < 1 / 2) return q;
+    if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
+    return p;
+  };
+
+  const q = l < 0.5 ? l * (1 + newS) : l + newS - l * newS;
+  const p = 2 * l - q;
+  const nr = Math.round(hue2rgb(p, q, h + 1 / 3) * 255);
+  const ng = Math.round(hue2rgb(p, q, h) * 255);
+  const nb = Math.round(hue2rgb(p, q, h - 1 / 3) * 255);
+
+  return `#${nr.toString(16).padStart(2, '0')}${ng.toString(16).padStart(2, '0')}${nb.toString(16).padStart(2, '0')}`;
+}
+
+type Segment = {
+  categoryId: number;
+  color: string;
+  count: number;
+};
+
+type Props = {
+  segments: Segment[];   // 카테고리별 완료 수
+  totalCompleted: number;
+  total: number;
+};
+
+export default function TodayProgressBar({ segments, totalCompleted, total }: Props) {
+  if (total === 0) return null;
+
+  const uncompleted = total - totalCompleted;
+  const percent = Math.round((totalCompleted / total) * 100);
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.bar}>
+        {segments.map((seg, i) => {
+          const isLast = i === segments.length - 1;
+          return (
+            <View
+              key={seg.categoryId}
+              style={[
+                styles.segment,
+                { flex: seg.count, backgroundColor: desaturate(seg.color, 0.2) },
+                isLast && uncompleted > 0 && styles.segmentRoundedEnd,
+              ]}
+            />
+          );
+        })}
+        {uncompleted > 0 && (
+          <View style={[styles.segment, { flex: uncompleted, backgroundColor: Colors.surfaceVariant }]} />
+        )}
+        <Text style={styles.percentLabel}>{percent}%</Text>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    paddingHorizontal: 16,
+    paddingTop: 16,
+    paddingBottom: 10,
+    backgroundColor: Colors.background,
+    gap: 6,
+  },
+  bar: {
+    flexDirection: 'row',
+    height: 20,
+    borderRadius: 6,
+    overflow: 'hidden',
+    backgroundColor: Colors.surfaceVariant,
+    alignItems: 'center',
+  },
+  segment: {
+    height: '100%',
+  },
+  segmentRoundedEnd: {
+    borderTopRightRadius: 6,
+    borderBottomRightRadius: 6,
+  },
+  percentLabel: {
+    position: 'absolute',
+    width: '100%',
+    textAlign: 'center',
+    fontSize: 11,
+    fontWeight: '700',
+    color: '#fff',
+    letterSpacing: 0.3,
+  },
+});

--- a/src/components/TodoTabToday.tsx
+++ b/src/components/TodoTabToday.tsx
@@ -11,6 +11,7 @@ import { useRoutinesToday, useToggleRoutineCompletion } from '../hooks/useRoutin
 import { useCategories } from '../hooks/useCategories';
 import TodoItem from './TodoItem';
 import RoutineItem from './RoutineItem';
+import TodayProgressBar from './TodayProgressBar';
 import { TodoStackParamList } from '../navigation/TodoStack';
 
 type Nav = NativeStackNavigationProp<TodoStackParamList, 'TodoList'>;
@@ -45,6 +46,28 @@ export default function TodoTabToday() {
     [categories],
   );
 
+  const progressData = useMemo(() => {
+    const countMap = new Map<number, number>();
+    for (const r of routines) {
+      if (r.isCompletedToday) {
+        countMap.set(r.categoryId, (countMap.get(r.categoryId) ?? 0) + 1);
+      }
+    }
+    for (const t of todos) {
+      if (completedIds.has(t.id)) {
+        countMap.set(t.categoryId, (countMap.get(t.categoryId) ?? 0) + 1);
+      }
+    }
+    const segments = [...countMap.entries()].map(([categoryId, count]) => ({
+      categoryId,
+      color: categoryMap.get(categoryId)?.color ?? Colors.textMuted,
+      count,
+    }));
+    const totalCompleted = segments.reduce((sum, s) => sum + s.count, 0);
+    const total = routines.length + todos.length;
+    return { segments, totalCompleted, total };
+  }, [routines, todos, completedIds, categoryMap]);
+
   const renderTodoItem = ({ item, drag, isActive }: RenderItemParams<Todo>) => (
     <ScaleDecorator>
       <TodoItem
@@ -62,6 +85,12 @@ export default function TodoTabToday() {
   const isEmpty = routines.length === 0 && todos.length === 0;
 
   return (
+    <View style={styles.container}>
+      <TodayProgressBar
+        segments={progressData.segments}
+        totalCompleted={progressData.totalCompleted}
+        total={progressData.total}
+      />
     <DraggableFlatList
       data={todos as Todo[]}
       keyExtractor={(item) => `todo-${item.id}`}
@@ -105,10 +134,12 @@ export default function TodoTabToday() {
         </>
       }
     />
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
+  container: { flex: 1 },
   list: { flex: 1 },
   sectionLabel: {
     color: Colors.textSecondary,


### PR DESCRIPTION
## 이슈
Closes #82

## 변경 사항
- `TodayProgressBar.tsx` 신규 컴포넌트 추가 — 카테고리별 완료 수를 집계해 단일 바에 색상 비율로 표시, 미완료 구간은 dimmed 처리, 바 내부에 달성률(%) 오버레이
- `TodoTabToday.tsx` — 헤더와 리스트 사이 고정 영역에 TodayProgressBar 배치 (스크롤 영향 없음), 카테고리별 완료 집계 로직 추가

## 테스트
- [ ] 오늘 탭 진입 시 프로그레스 바가 헤더 아래 고정 영역에 표시되는지 확인
- [ ] 항목 완료 토글 시 카테고리 색상 세그먼트와 퍼센트가 즉시 반영되는지 확인
- [ ] 오늘 항목이 없을 때 프로그레스 바가 표시되지 않는지 확인
- [ ] 전체 완료(100%) 시 바 전체가 채워지고 양 끝이 둥글게 표시되는지 확인