### PR TITLE
#84 오늘 탭과 할 일 탭 완료 상태 미동기화 버그 수정

### DIFF
--- a/src/components/TodoTabList.tsx
+++ b/src/components/TodoTabList.tsx
@@ -5,7 +5,7 @@ import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useMemo } from 'react';
 import DraggableFlatList, { RenderItemParams, ScaleDecorator } from 'react-native-draggable-flatlist';
 import { Colors } from '../theme';
-import { useTodosList, useToggleTodo, useReorderTodos } from '../hooks/useTodos';
+import { useTodosList, useTodayCompletionIds, useTodayToggle, useReorderTodos } from '../hooks/useTodos';
 import { useCategories } from '../hooks/useCategories';
 import TodoItem from './TodoItem';
 import { TodoStackParamList } from '../navigation/TodoStack';
@@ -28,8 +28,9 @@ type Todo = {
 export default function TodoTabList() {
   const navigation = useNavigation<Nav>();
   const { data: todos = [] } = useTodosList();
+  const { data: completedIds = new Set<number>() } = useTodayCompletionIds();
   const { data: categories = [] } = useCategories();
-  const { mutate: toggleTodo } = useToggleTodo();
+  const { mutate: toggleTodo } = useTodayToggle();
   const { mutate: reorderTodos } = useReorderTodos();
 
   const categoryMap = useMemo(
@@ -42,7 +43,8 @@ export default function TodoTabList() {
       <TodoItem
         todo={item}
         category={categoryMap.get(item.categoryId)}
-        onToggle={() => toggleTodo({ id: item.id, isCompleted: item.isCompleted })}
+        forceCompleted={completedIds.has(item.id)}
+        onToggle={() => toggleTodo(item.id)}
         onPress={() => navigation.navigate('TodoForm', { todo: item })}
         onDrag={drag}
         isDragging={isActive}

--- a/src/hooks/useTodos.ts
+++ b/src/hooks/useTodos.ts
@@ -111,13 +111,16 @@ export const useTodayToggle = () => {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['todayCompletionIds'] });
+      queryClient.invalidateQueries({ queryKey: ['todos', 'list'] });
       queryClient.invalidateQueries({ queryKey: ['completions'], exact: false });
     },
   });
 };
 
-/** 기한 체크: 기한이 지난 항목 중 완료 기록 있으면 isCompleted=1로 마이그레이션.
- *  하루 1회만 실행 (JS 스레드 동기 SQLite 블로킹 최소화) */
+/** 기한/완료 체크: 아래 두 조건 중 하나라도 해당하면 isCompleted=1로 이동.
+ *  1. 기한이 지난 항목 중 완료 기록이 있는 경우
+ *  2. 기한에 관계없이 이전 날짜에 완료 기록된 항목 (어제 이전에 체크한 항목)
+ *  앱 포그라운드 진입 및 탭 포커스 시 실행, 하루 1회만 실제 처리 */
 let _lastDueDateCheckDate = '';
 
 export const runDueDateCheck = async (): Promise<boolean> => {
@@ -126,11 +129,13 @@ export const runDueDateCheck = async (): Promise<boolean> => {
   _lastDueDateCheckDate = today;
 
   const todayStart = dayjs().startOf('day').valueOf();
+  let changed = false;
+
+  // 1. 기한이 지난 항목 중 완료 기록 있는 경우
   const overdueTodos = db.select().from(todos)
     .where(and(eq(todos.isCompleted, 0), eq(todos.isDeleted, 0), lt(todos.dueDate, todayStart)))
     .all();
 
-  let changed = false;
   for (const todo of overdueTodos) {
     const completion = db.select().from(todoCompletions)
       .where(eq(todoCompletions.todoId, todo.id))
@@ -145,6 +150,29 @@ export const runDueDateCheck = async (): Promise<boolean> => {
       changed = true;
     }
   }
+
+  // 2. 이전 날짜에 체크된 항목 (오늘 이전 completedDate 기록이 있는 미완료 항목)
+  const prevCompletions = db.select({ todoId: todoCompletions.todoId })
+    .from(todoCompletions)
+    .where(lt(todoCompletions.completedDate, today))
+    .all();
+
+  const prevIds = [...new Set(prevCompletions.map((r) => r.todoId))];
+  for (const id of prevIds) {
+    const todo = db.select().from(todos)
+      .where(and(eq(todos.id, id), eq(todos.isCompleted, 0), eq(todos.isDeleted, 0)))
+      .get();
+    if (todo) {
+      const now = Date.now();
+      await db.update(todos).set({
+        isCompleted: 1,
+        completedAt: now,
+        updatedAt: now,
+      }).where(eq(todos.id, id)).run();
+      changed = true;
+    }
+  }
+
   return changed;
 };
 
@@ -244,6 +272,7 @@ export const useToggleTodo = () => {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['todos'] });
+      queryClient.invalidateQueries({ queryKey: ['todayCompletionIds'] });
       queryClient.invalidateQueries({ queryKey: ['completions'], exact: false });
     },
   });


### PR DESCRIPTION
## 이슈
Closes #84

## 변경 사항
- `TodoTabList.tsx`: `useToggleTodo` → `useTodayToggle` 교체 — 체크 시 `isCompleted` 변경 없이 `todoCompletions`만 기록, 취소선+체크 표시 유지. `useTodayCompletionIds` 추가로 오늘 탭과 동일한 체크 상태 표시
- `useTodos.ts` `useTodayToggle` onSuccess: `todos.list` 캐시 무효화 추가 (오늘 탭 → 할 일 탭 동기화)
- `useTodos.ts` `useToggleTodo` onSuccess: `todayCompletionIds` 캐시 무효화 추가 (할 일 탭 → 오늘 탭 동기화)
- `useTodos.ts` `runDueDateCheck` 확장: 이전 날짜(`completedDate < today`)에 체크된 미완료 항목도 `isCompleted=1`로 이동 — 앱 오픈/탭 포커스 시 자동 처리

## 테스트
- [ ] 오늘 탭에서 체크 시 할 일 탭에도 취소선+체크 표시 동기화 확인
- [ ] 할 일 탭에서 체크 시 오늘 탭에도 취소선+체크 표시 동기화 확인
- [ ] 할 일 탭 체크 후 다음 날 앱 재실행 시 해당 항목이 완료 탭으로 이동되는지 확인