### PR TITLE
#81 할 일 등록/수정 시 오늘 이전 날짜 선택 제한

### DIFF
--- a/src/screens/TodoFormScreen.tsx
+++ b/src/screens/TodoFormScreen.tsx
@@ -129,6 +129,7 @@ export default function TodoFormScreen() {
             display="spinner"
             locale="ko"
             textColor="#F2F2F7"
+            minimumDate={getTodayMidnight()}
             onChange={(_, date) => {
               if (date) {
                 const midnight = new Date(date.getFullYear(), date.getMonth(), date.getDate());


### PR DESCRIPTION
## 이슈
Closes #81

## 변경 사항
- `TodoFormScreen.tsx`: DateTimePicker에 `minimumDate={getTodayMidnight()}` 추가 — 신규 등록 및 수정 모두 오늘 이전 날짜 선택 불가. 수정 시 기존 기한이 과거여도 현재 값은 유지되며, 피커를 열어 변경할 때만 오늘 이후로 제한

## 테스트
- [ ] 새 할 일 등록 시 오늘 이전 날짜가 피커에서 선택 불가한지 확인
- [ ] 기존 할 일 수정 시 오늘 이전 날짜가 선택 불가한지 확인
- [ ] 기한이 과거인 항목 수정 시 기존 날짜가 그대로 표시되는지 확인