### PR TITLE
#87 미완료 탭 다중 선택 후 오늘하기/삭제 일괄 처리 기능 추가

### DIFF
--- a/src/components/TodoItem.tsx
+++ b/src/components/TodoItem.tsx
@@ -29,13 +29,18 @@ type Props = {
   onDrag?: () => void;
   isDragging?: boolean;
   forceCompleted?: boolean; // 오늘 탭: isCompleted=0이어도 체크된 것처럼 표시
+  showCheckbox?: boolean;   // 기본 false이면 선택 모드일 때만 체크박스 표시
+  isSelecting?: boolean;    // 다중 선택 모드
+  isSelected?: boolean;     // 선택됨 여부
 };
 
 const URGENCY_COLOR = Colors.urgency;
 const IMPORTANCE_COLOR = Colors.importance;
 
-export default function TodoItem({ todo, category, onToggle, onPress, onDrag, isDragging, forceCompleted }: Props) {
-  const showAsCompleted = todo.isCompleted === 1 || forceCompleted;
+export default function TodoItem({ todo, category, onToggle, onPress, onDrag, isDragging, forceCompleted, showCheckbox = true, isSelecting, isSelected }: Props) {
+  const showAsCompleted = !isSelecting && showCheckbox && (todo.isCompleted === 1 || forceCompleted);
+  const checkboxStatus = isSelecting ? (isSelected ? 'checked' : 'unchecked') : (showAsCompleted ? 'checked' : 'unchecked');
+  const checkboxVisible = isSelecting || showCheckbox;
   const pressStartX = useRef(0);
   const dueDateStr = todo.dueDate
     ? new Date(todo.dueDate).toLocaleDateString('ko-KR', { month: 'short', day: 'numeric' })
@@ -44,20 +49,28 @@ export default function TodoItem({ todo, category, onToggle, onPress, onDrag, is
   const urgencyLevel = todo.urgency ?? 0;
   const importanceLevel = todo.importance ?? 0;
 
+  const handlePress = (e: { nativeEvent: { pageX: number } }) => {
+    if (Math.abs(e.nativeEvent.pageX - pressStartX.current) < 10) {
+      isSelecting ? onToggle() : onPress();
+    }
+  };
+
   return (
     <View style={[styles.container, isDragging && styles.containerDragging]}>
-      <TouchableOpacity onPress={onToggle} activeOpacity={0.6} style={styles.checkboxArea}>
-        <Checkbox.Android
-          status={showAsCompleted ? 'checked' : 'unchecked'}
-          color={category?.color}
-        />
-      </TouchableOpacity>
+      {checkboxVisible && (
+        <TouchableOpacity onPress={onToggle} activeOpacity={0.6} style={styles.checkboxArea}>
+          <Checkbox.Android
+            status={checkboxStatus}
+            color={Colors.primary}
+          />
+        </TouchableOpacity>
+      )}
 
       <TouchableOpacity
         style={styles.content}
         onPressIn={(e) => { pressStartX.current = e.nativeEvent.pageX; }}
-        onPress={(e) => { if (Math.abs(e.nativeEvent.pageX - pressStartX.current) < 10) onPress(); }}
-        onLongPress={onDrag}
+        onPress={handlePress}
+        onLongPress={isSelecting ? undefined : onDrag}
         activeOpacity={0.7}
       >
         <Text
@@ -95,7 +108,7 @@ export default function TodoItem({ todo, category, onToggle, onPress, onDrag, is
         </View>
       </TouchableOpacity>
 
-      {onDrag && <Text style={styles.dragHandle}>☰</Text>}
+      {!isSelecting && onDrag && <Text style={styles.dragHandle}>☰</Text>}
     </View>
   );
 }

--- a/src/components/TodoTabCompleted.tsx
+++ b/src/components/TodoTabCompleted.tsx
@@ -67,6 +67,7 @@ export default function TodoTabCompleted() {
         <TodoItem
           todo={item.todo}
           category={categoryMap.get(item.todo.categoryId)}
+          showCheckbox={false}
           onToggle={() => toggleTodo({ id: item.todo.id, isCompleted: item.todo.isCompleted })}
           onPress={() => navigation.navigate('TodoForm', { todo: item.todo })}
         />

--- a/src/components/TodoTabCompleted.tsx
+++ b/src/components/TodoTabCompleted.tsx
@@ -1,5 +1,5 @@
 import { View, FlatList, StyleSheet } from 'react-native';
-import { Text, Divider, Button, Dialog, Portal } from 'react-native-paper';
+import { Text, Divider, Button, Dialog, Portal, FAB } from 'react-native-paper';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useMemo, useState } from 'react';
@@ -78,19 +78,6 @@ export default function TodoTabCompleted() {
 
   return (
     <View style={styles.container}>
-      {todos.length > 0 && (
-        <View style={styles.clearRow}>
-          <Button
-            icon="delete-sweep"
-            mode="text"
-            textColor={Colors.textMuted}
-            compact
-            onPress={() => setClearDialogVisible(true)}
-          >
-            전체 삭제
-          </Button>
-        </View>
-      )}
       <FlatList
         data={completedList}
         keyExtractor={(item) =>
@@ -102,6 +89,15 @@ export default function TodoTabCompleted() {
         }
         style={styles.list}
       />
+
+      {todos.length > 0 && (
+        <FAB
+          size="small"
+          icon="delete-sweep"
+          style={styles.fab}
+          onPress={() => setClearDialogVisible(true)}
+        />
+      )}
 
       <Portal>
         <Dialog visible={clearDialogVisible} onDismiss={() => setClearDialogVisible(false)}>
@@ -128,12 +124,10 @@ const styles = StyleSheet.create({
   container: { flex: 1 },
   list: { flex: 1 },
   empty: { textAlign: 'center', marginTop: 60, color: Colors.textMuted },
-  clearRow: {
-    alignItems: 'flex-end',
-    paddingHorizontal: 8,
-    paddingVertical: 4,
-    borderBottomWidth: 1,
-    borderBottomColor: Colors.tabBorder,
+  fab: {
+    position: 'absolute',
+    right: 16,
+    bottom: 16,
   },
   dateHeader: {
     paddingHorizontal: 16,

--- a/src/components/TodoTabOverdue.tsx
+++ b/src/components/TodoTabOverdue.tsx
@@ -1,11 +1,11 @@
-import { StyleSheet } from 'react-native';
-import { Text, Divider } from 'react-native-paper';
+import { useState, useMemo, useCallback } from 'react';
+import { View, StyleSheet } from 'react-native';
+import { Text, Divider, Button, FAB, Dialog, Portal, Snackbar } from 'react-native-paper';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import { useMemo } from 'react';
 import DraggableFlatList, { RenderItemParams, ScaleDecorator } from 'react-native-draggable-flatlist';
 import { Colors } from '../theme';
-import { useTodosOverdue, useToggleTodo, useReorderTodos } from '../hooks/useTodos';
+import { useTodosOverdue, useToggleTodo, useReorderTodos, useBulkMoveToToday, useBulkDeleteTodos } from '../hooks/useTodos';
 import { useCategories } from '../hooks/useCategories';
 import TodoItem from './TodoItem';
 import { TodoStackParamList } from '../navigation/TodoStack';
@@ -31,44 +31,171 @@ export default function TodoTabOverdue() {
   const { data: categories = [] } = useCategories();
   const { mutate: toggleTodo } = useToggleTodo();
   const { mutate: reorderTodos } = useReorderTodos();
+  const { mutate: bulkMoveToToday } = useBulkMoveToToday();
+  const { mutate: bulkDelete } = useBulkDeleteTodos();
+
+  const [isSelecting, setIsSelecting] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+  const [snackbarVisible, setSnackbarVisible] = useState(false);
+  const [snackbarMessage, setSnackbarMessage] = useState('');
 
   const categoryMap = useMemo(
     () => new Map(categories.map((c) => [c.id, c])),
-    [categories]
+    [categories],
   );
+
+  const toggleSelection = useCallback((id: number) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  const handleCancelSelect = () => {
+    setIsSelecting(false);
+    setSelectedIds(new Set());
+  };
+
+  const handleMoveToToday = () => {
+    if (selectedIds.size === 0) return;
+    const count = selectedIds.size;
+    bulkMoveToToday([...selectedIds]);
+    handleCancelSelect();
+    setSnackbarMessage(`${count}개 항목을 오늘 할 일로 이동했어요`);
+    setSnackbarVisible(true);
+  };
+
+  const handleDeleteConfirm = () => {
+    bulkDelete([...selectedIds]);
+    setShowDeleteDialog(false);
+    handleCancelSelect();
+  };
 
   const renderItem = ({ item, drag, isActive }: RenderItemParams<Todo>) => (
     <ScaleDecorator>
       <TodoItem
         todo={item}
         category={categoryMap.get(item.categoryId)}
-        onToggle={() => toggleTodo({ id: item.id, isCompleted: item.isCompleted })}
-        onPress={() => navigation.navigate('TodoForm', { todo: item })}
+        showCheckbox={false}
+        onToggle={
+          isSelecting
+            ? () => toggleSelection(item.id)
+            : () => toggleTodo({ id: item.id, isCompleted: item.isCompleted })
+        }
+        onPress={() => {
+          if (isSelecting) toggleSelection(item.id);
+          else navigation.navigate('TodoForm', { todo: item });
+        }}
         onDrag={drag}
         isDragging={isActive}
+        isSelecting={isSelecting}
+        isSelected={selectedIds.has(item.id)}
       />
     </ScaleDecorator>
   );
 
   return (
-    <DraggableFlatList
-      data={todos as Todo[]}
-      keyExtractor={(item) => String(item.id)}
-      ItemSeparatorComponent={() => <Divider />}
-      ListEmptyComponent={
-        <Text style={styles.empty}>미완료 항목이 없어요</Text>
-      }
-      renderItem={renderItem}
-      onDragEnd={({ data }) => reorderTodos(data.map((t) => t.id))}
-      activationDistance={20}
-      autoscrollThreshold={80}
-      autoscrollSpeed={200}
-      containerStyle={styles.list}
-    />
+    <View style={styles.container}>
+      <DraggableFlatList
+        data={todos as Todo[]}
+        keyExtractor={(item) => String(item.id)}
+        ItemSeparatorComponent={() => <Divider />}
+        ListEmptyComponent={
+          <Text style={styles.empty}>미완료 항목이 없어요</Text>
+        }
+        renderItem={renderItem}
+        onDragEnd={({ data }) => reorderTodos(data.map((t) => t.id))}
+        activationDistance={isSelecting ? 9999 : 20}
+        autoscrollThreshold={80}
+        autoscrollSpeed={200}
+        containerStyle={styles.list}
+      />
+
+      {/* 선택 모드 액션 */}
+      {isSelecting ? (
+        <View style={styles.actionColumn}>
+          <FAB
+            size="small"
+            icon="calendar-today"
+            style={[styles.fabAction, selectedIds.size === 0 && styles.fabDisabled]}
+            onPress={handleMoveToToday}
+            disabled={selectedIds.size === 0}
+          />
+          <FAB
+            size="small"
+            icon="delete-outline"
+            style={[styles.fabAction, styles.fabDanger, selectedIds.size === 0 && styles.fabDisabled]}
+            color={Colors.danger}
+            onPress={() => selectedIds.size > 0 && setShowDeleteDialog(true)}
+            disabled={selectedIds.size === 0}
+          />
+          <FAB
+            size="small"
+            icon="close"
+            style={styles.fabAction}
+            onPress={handleCancelSelect}
+          />
+        </View>
+      ) : (
+        <FAB
+          size="small"
+          icon="checkbox-multiple-outline"
+          style={styles.fab}
+          onPress={() => setIsSelecting(true)}
+        />
+      )}
+
+      <Portal>
+        <Dialog visible={showDeleteDialog} onDismiss={() => setShowDeleteDialog(false)}>
+          <Dialog.Title>선택 항목 삭제</Dialog.Title>
+          <Dialog.Content>
+            <Text>{selectedIds.size}개 항목을 삭제하시겠습니까?</Text>
+          </Dialog.Content>
+          <Dialog.Actions>
+            <Button onPress={() => setShowDeleteDialog(false)}>취소</Button>
+            <Button textColor={Colors.danger} onPress={handleDeleteConfirm}>삭제</Button>
+          </Dialog.Actions>
+        </Dialog>
+      </Portal>
+
+      <Snackbar
+        visible={snackbarVisible}
+        onDismiss={() => setSnackbarVisible(false)}
+        duration={2500}
+        style={styles.snackbar}
+      >
+        {snackbarMessage}
+      </Snackbar>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
+  container: { flex: 1 },
   list: { flex: 1 },
   empty: { textAlign: 'center', marginTop: 60, color: Colors.textMuted },
+  snackbar: { marginBottom: 80 },
+  fab: {
+    position: 'absolute',
+    right: 16,
+    bottom: 16,
+  },
+  actionColumn: {
+    position: 'absolute',
+    right: 16,
+    bottom: 16,
+    flexDirection: 'column',
+    alignItems: 'center',
+    gap: 12,
+  },
+  fabAction: {},
+  fabDanger: {
+    backgroundColor: Colors.surfaceVariant,
+  },
+  fabDisabled: {
+    opacity: 0.4,
+  },
 });

--- a/src/db/seed.ts
+++ b/src/db/seed.ts
@@ -21,7 +21,7 @@ import { eq } from 'drizzle-orm';
 import { db } from './index';
 import { categories, todos, todoCompletions, appSettings } from './schema';
 
-const SEED_KEY = 'seed_v3';
+const SEED_KEY = 'seed_v5';
 
 // 카테고리별 하루 완료 확률 (0~1) — 다양한 패턴 연출
 const CATEGORY_FREQUENCY: Record<string, number> = {
@@ -147,8 +147,41 @@ export async function runDevSeed() {
     db.insert(todoCompletions).values(completionValues.slice(i, i + BATCH)).run();
   }
 
+  // 미완료 탭 확인용 — 기한이 지난 미완료 할 일 생성
+  const OVERDUE_TODO_TITLES: Record<string, string[]> = {
+    업무: ['분기 보고서 작성', '클라이언트 미팅 준비', '계약서 검토'],
+    개인: ['세금 신고', '보험 갱신', '치과 예약'],
+    운동: ['PT 예약', '러닝화 구매'],
+    학습: ['온라인 강의 완료', '자격증 신청'],
+    쇼핑: ['냉장고 정리', '청소 용품 구매'],
+    미분류: ['차 점검 예약', '공과금 납부'],
+  };
+
+  const overdueDaysAgo = [1, 3, 5, 7, 14, 21];
+  for (const daysAgo of overdueDaysAgo) {
+    const dueDate = new Date(today);
+    dueDate.setDate(dueDate.getDate() - daysAgo);
+    dueDate.setHours(0, 0, 0, 0);
+
+    for (const cat of allCategories) {
+      const titles = OVERDUE_TODO_TITLES[cat.name] ?? OVERDUE_TODO_TITLES['미분류'];
+      const title = titles[daysAgo % titles.length];
+      db.insert(todos).values({
+        categoryId: cat.id,
+        title: `[미완료] ${title}`,
+        dueDate: dueDate.getTime(),
+        urgency: Math.floor(Math.random() * 3),
+        importance: Math.floor(Math.random() * 3),
+        sortOrder: -9997,
+        isCompleted: 0,
+        createdAt: now,
+        updatedAt: now,
+      }).run();
+    }
+  }
+
   // 완료 플래그 저장
   db.insert(appSettings).values({ key: SEED_KEY, value: '1' }).run();
 
-  console.log(`[seed] todo ${completedTodoValues.length}개, completion ${completionValues.length}개 생성 완료`);
+  console.log(`[seed] todo ${completedTodoValues.length}개, completion ${completionValues.length}개, 미완료 ${overdueDaysAgo.length * allCategories.length}개 생성 완료`);
 }

--- a/src/hooks/useTodos.ts
+++ b/src/hooks/useTodos.ts
@@ -318,3 +318,32 @@ export const useReorderTodos = () => {
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['todos'] }),
   });
 };
+
+export const useBulkMoveToToday = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (ids: number[]) => {
+      const todayMidnight = dayjs().startOf('day').valueOf();
+      const now = Date.now();
+      for (const id of ids) {
+        await db.update(todos).set({ dueDate: todayMidnight, updatedAt: now })
+          .where(eq(todos.id, id)).run();
+      }
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['todos'] }),
+  });
+};
+
+export const useBulkDeleteTodos = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (ids: number[]) => {
+      const now = Date.now();
+      for (const id of ids) {
+        await db.update(todos).set({ isDeleted: 1, deletedAt: now, updatedAt: now })
+          .where(eq(todos.id, id)).run();
+      }
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['todos'] }),
+  });
+};

--- a/src/screens/TodoScreen.tsx
+++ b/src/screens/TodoScreen.tsx
@@ -100,6 +100,7 @@ export default function TodoScreen() {
 
       {showFab && (
         <FAB
+          size="small"
           icon="plus"
           style={[styles.fab, !isPremium && styles.fabWithAd]}
           onPress={() => navigation.navigate('TodoForm')}


### PR DESCRIPTION
## 이슈
Closes #87

## 변경 사항
- `TodoTabOverdue`: 상단 바 제거, FAB 기반 선택 모드로 전환
  - 평소: 우측 하단에 `checkbox-multiple-outline` 소형 FAB
  - 선택 모드: 세로 배치 FAB (오늘하기 `calendar-today` / 삭제 `delete-outline` / 취소 `close`)
  - 오늘하기 실행 후 Snackbar 알림 표시
- `TodoItem`: `showCheckbox`, `isSelecting`, `isSelected` prop 추가
  - 미완료/완료 탭은 기본적으로 체크박스 숨김 (`showCheckbox={false}`)
  - 체크박스 색상 `Colors.primary`로 통일
  - 완료 아이템 취소선 제거
- `useTodos`: `useBulkMoveToToday`, `useBulkDeleteTodos` 훅 추가
- `TodoScreen`: FAB `size="small"`로 통일
- `seed`: seed_v5, 미완료 테스트 데이터 추가

## 테스트
- [ ] 미완료 탭 FAB 탭 → 선택 모드 진입 확인
- [ ] 항목 선택 후 오늘하기 → 할 일 탭으로 이동 및 Snackbar 표시 확인
- [ ] 항목 선택 후 삭제 → 다이얼로그 확인 후 삭제 확인
- [ ] 취소 → 선택 모드 종료 및 선택 초기화 확인
- [ ] 오늘/할 일 FAB 크기 통일 확인