### PR TITLE
#89 완료 탭 기간 필터 추가 및 리스트 비우기 제거

### DIFF
--- a/src/components/TodoTabCompleted.tsx
+++ b/src/components/TodoTabCompleted.tsx
@@ -1,10 +1,11 @@
 import { View, FlatList, StyleSheet } from 'react-native';
-import { Text, Divider, Button, Dialog, Portal } from 'react-native-paper';
+import { Text, Divider, Button, Menu } from 'react-native-paper';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useMemo, useState } from 'react';
 import { Colors } from '../theme';
-import { useTodosCompleted, useToggleTodo, useClearCompleted } from '../hooks/useTodos';
+import dayjs from 'dayjs';
+import { useTodosCompleted, useToggleTodo } from '../hooks/useTodos';
 import { useCategories } from '../hooks/useCategories';
 import TodoItem from './TodoItem';
 import { toDateKey, formatDateLabel } from '../utils/date';
@@ -43,20 +44,34 @@ function buildCompletedList(todos: Todo[]): ListItem[] {
   return result;
 }
 
+type PeriodValue = '1m' | '6m' | '12m';
+const PERIOD_OPTIONS: { value: PeriodValue; label: string; days: number }[] = [
+  { value: '1m', label: '1개월', days: 30 },
+  { value: '6m', label: '6개월', days: 180 },
+  { value: '12m', label: '12개월', days: 365 },
+];
+
 export default function TodoTabCompleted() {
   const navigation = useNavigation<Nav>();
-  const [clearDialogVisible, setClearDialogVisible] = useState(false);
-  const { data: todos = [] } = useTodosCompleted();
+  const [period, setPeriod] = useState<PeriodValue>('1m');
+  const [menuVisible, setMenuVisible] = useState(false);
+
+  const { data: allTodos = [] } = useTodosCompleted();
   const { data: categories = [] } = useCategories();
   const { mutate: toggleTodo } = useToggleTodo();
-  const { mutate: clearCompleted } = useClearCompleted();
 
   const categoryMap = useMemo(
     () => new Map(categories.map((c) => [c.id, c])),
-    [categories]
+    [categories],
   );
 
-  const completedList = buildCompletedList(todos as Todo[]);
+  const todos = useMemo(() => {
+    const days = PERIOD_OPTIONS.find((o) => o.value === period)?.days ?? 1;
+    const cutoff = dayjs().subtract(days, 'day').startOf('day').valueOf();
+    return (allTodos as Todo[]).filter((t) => t.completedAt != null && t.completedAt >= cutoff);
+  }, [allTodos, period]);
+
+  const completedList = buildCompletedList(todos);
 
   const renderItem = ({ item }: { item: ListItem }) => {
     if (item.type === 'header') {
@@ -67,6 +82,7 @@ export default function TodoTabCompleted() {
         <TodoItem
           todo={item.todo}
           category={categoryMap.get(item.todo.categoryId)}
+          showCheckbox={false}
           onToggle={() => toggleTodo({ id: item.todo.id, isCompleted: item.todo.isCompleted })}
           onPress={() => navigation.navigate('TodoForm', { todo: item.todo })}
         />
@@ -77,19 +93,35 @@ export default function TodoTabCompleted() {
 
   return (
     <View style={styles.container}>
-      {todos.length > 0 && (
-        <View style={styles.clearRow}>
-          <Button
-            icon="delete-sweep"
-            mode="text"
-            textColor={Colors.textMuted}
-            compact
-            onPress={() => setClearDialogVisible(true)}
-          >
-            전체 삭제
-          </Button>
-        </View>
-      )}
+      <View style={styles.filterRow}>
+        <Menu
+          visible={menuVisible}
+          onDismiss={() => setMenuVisible(false)}
+          anchor={
+            <Button
+              mode="text"
+              compact
+              icon="chevron-down"
+              contentStyle={styles.filterBtnContent}
+              labelStyle={styles.filterBtnLabel}
+              onPress={() => setMenuVisible(true)}
+            >
+              {PERIOD_OPTIONS.find((o) => o.value === period)?.label}
+            </Button>
+          }
+          anchorPosition="bottom"
+        >
+          {PERIOD_OPTIONS.map((opt) => (
+            <Menu.Item
+              key={opt.value}
+              title={opt.label}
+              titleStyle={period === opt.value ? styles.menuItemActive : undefined}
+              onPress={() => { setPeriod(opt.value); setMenuVisible(false); }}
+            />
+          ))}
+        </Menu>
+      </View>
+
       <FlatList
         data={completedList}
         keyExtractor={(item) =>
@@ -101,39 +133,24 @@ export default function TodoTabCompleted() {
         }
         style={styles.list}
       />
-
-      <Portal>
-        <Dialog visible={clearDialogVisible} onDismiss={() => setClearDialogVisible(false)}>
-          <Dialog.Title>완료 목록 비우기</Dialog.Title>
-          <Dialog.Content>
-            <Text>완료된 할 일이 목록에서 삭제됩니다.{'\n'}완료 기록은 기록 탭에 유지됩니다.</Text>
-          </Dialog.Content>
-          <Dialog.Actions>
-            <Button onPress={() => setClearDialogVisible(false)}>취소</Button>
-            <Button
-              textColor={Colors.danger}
-              onPress={() => { clearCompleted(); setClearDialogVisible(false); }}
-            >
-              비우기
-            </Button>
-          </Dialog.Actions>
-        </Dialog>
-      </Portal>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
   container: { flex: 1 },
-  list: { flex: 1 },
-  empty: { textAlign: 'center', marginTop: 60, color: Colors.textMuted },
-  clearRow: {
+  filterRow: {
     alignItems: 'flex-end',
     paddingHorizontal: 8,
     paddingVertical: 4,
-    borderBottomWidth: 1,
-    borderBottomColor: Colors.tabBorder,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: Colors.border,
   },
+  filterBtnContent: { flexDirection: 'row-reverse' },
+  filterBtnLabel: { fontSize: 13, color: Colors.textSecondary },
+  menuItemActive: { color: Colors.primary },
+  list: { flex: 1 },
+  empty: { textAlign: 'center', marginTop: 60, color: Colors.textMuted },
   dateHeader: {
     paddingHorizontal: 16,
     paddingTop: 20,

--- a/src/db/seed.ts
+++ b/src/db/seed.ts
@@ -21,7 +21,7 @@ import { eq } from 'drizzle-orm';
 import { db } from './index';
 import { categories, todos, todoCompletions, appSettings } from './schema';
 
-const SEED_KEY = 'seed_v3';
+const SEED_KEY = 'seed_v6';
 
 // 카테고리별 하루 완료 확률 (0~1) — 다양한 패턴 연출
 const CATEGORY_FREQUENCY: Record<string, number> = {
@@ -74,7 +74,7 @@ export async function runDevSeed() {
     if (result) seedTodoIds[cat.id] = result.id;
   }
 
-  // 완료 탭 확인용 — 최근 30일에 걸쳐 다양한 날짜의 완료 todo 생성
+  // 완료 탭 확인용 — 최근 400일에 걸쳐 다양한 날짜의 완료 todo 생성 (1/6/12개월 필터 테스트)
   const COMPLETED_TODO_TITLES: Record<string, string[]> = {
     업무: ['기획서 작성', '팀 미팅 참석', '코드 리뷰', '보고서 제출', '이메일 정리', '주간 회의'],
     개인: ['독서 30분', '일기 쓰기', '방 청소', '친구 연락', '영화 보기', '요리하기'],
@@ -89,7 +89,7 @@ export async function runDevSeed() {
     isCompleted: number; completedAt: number; createdAt: number; updatedAt: number;
   }[] = [];
 
-  for (let daysAgo = 0; daysAgo <= 30; daysAgo++) {
+  for (let daysAgo = 0; daysAgo <= 400; daysAgo++) {
     const date = new Date(today);
     date.setDate(date.getDate() - daysAgo);
     const ts = date.getTime() + 9 * 60 * 60 * 1000; // 오전 9시 기준

--- a/src/hooks/useTodos.ts
+++ b/src/hooks/useTodos.ts
@@ -67,7 +67,7 @@ export const useTodosOverdue = () => {
   });
 };
 
-/** 완료 탭: 완료된 항목, 최신순 */
+/** 완료 탭: 완료된 항목 전체, 최신순 */
 export const useTodosCompleted = () =>
   useQuery({
     queryKey: ['todos', 'completed'],

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -22,6 +22,5 @@ export function formatDateLabel(ts: number | null | undefined): string {
 
   if (d.isSame(today)) return '오늘';
   if (d.isSame(today.subtract(1, 'day'))) return '어제';
-  if (d.year() === today.year()) return d.format('M월 D일');
   return d.format('YYYY년 M월 D일');
 }


### PR DESCRIPTION
## 이슈
Closes #89

## 변경 사항
- `TodoTabCompleted`: 리스트 비우기(FAB + Dialog) 제거
- 우측 상단 드롭다운 필터 추가: 1개월 / 6개월 / 12개월 (기본값 1개월)
- 클라이언트 `useMemo` 필터링으로 즉각적인 UI 반응
- `useTodosCompleted` 파라미터 제거 — 전체 완료 목록을 단일 캐시로 관리
- `formatDateLabel` 항상 연도 포함 표시 (`YYYY년 M월 D일`)
- seed_v6: 완료 todo 생성 범위 30일 → 400일로 확장

## 테스트
- [ ] 완료 탭 진입 시 기본 1개월 필터 적용 확인
- [ ] 드롭다운에서 6개월/12개월 선택 시 목록 즉시 변경 확인
- [ ] 날짜 헤더에 연도 포함 표시 확인
- [ ] 리스트 비우기 버튼 제거 확인