### PR TITLE
#91 [Phase 1] 무한 스크롤 훅 및 RecordStack 네비게이션 기반 세팅

### DIFF
--- a/.claude/phase-map.json
+++ b/.claude/phase-map.json
@@ -1,19 +1,26 @@
 {
-  "planFile": "crispy-rolling-barto.md",
+  "planFile": "shimmying-snuggling-cat.md",
   "phases": [
     {
       "number": 1,
-      "title": "Drawer 내비게이션 구조 구축",
-      "issueNumber": 71,
-      "branch": "feature/issue-71/drawer-navigation-setup",
-      "status": "done"
+      "title": "무한 스크롤 훅 및 RecordStack 네비게이션 기반 세팅",
+      "issueNumber": 91,
+      "branch": "feature/issue-91/record-stack-and-infinite-hook",
+      "status": "in_progress"
     },
     {
       "number": 2,
-      "title": "화면 헤더 통합 및 설정 정리",
-      "issueNumber": 72,
-      "branch": "feature/issue-72/screen-header-and-settings-cleanup",
-      "status": "in_progress"
+      "title": "기록 화면 카테고리 탭 연결 및 CategoryCompletedScreen 구현",
+      "issueNumber": 92,
+      "branch": "feature/issue-92/category-completed-screen",
+      "status": "pending"
+    },
+    {
+      "number": 3,
+      "title": "할 일 화면 완료 탭 제거 및 TodoTabCompleted 삭제",
+      "issueNumber": 93,
+      "branch": "feature/issue-93/remove-completed-tab",
+      "status": "pending"
     }
   ]
 }

--- a/src/hooks/useTodos.ts
+++ b/src/hooks/useTodos.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { and, asc, desc, eq, gte, isNull, lt, or } from 'drizzle-orm';
 import dayjs from 'dayjs';
 import { db } from '../db';
@@ -76,6 +76,28 @@ export const useTodosCompleted = () =>
         .where(and(eq(todos.isCompleted, 1), eq(todos.isDeleted, 0)))
         .orderBy(desc(todos.completedAt))
         .all(),
+  });
+
+const PAGE_SIZE = 30;
+
+/** 기록 화면: 카테고리별 완료 항목, 최신순 무한 스크롤 */
+export const useTodosCompletedByCategory = (categoryId: number) =>
+  useInfiniteQuery({
+    queryKey: ['todos', 'completed', categoryId],
+    queryFn: ({ pageParam }: { pageParam: number }) =>
+      db.select().from(todos)
+        .where(and(
+          eq(todos.categoryId, categoryId),
+          eq(todos.isCompleted, 1),
+          eq(todos.isDeleted, 0),
+        ))
+        .orderBy(desc(todos.completedAt))
+        .limit(PAGE_SIZE)
+        .offset(pageParam * PAGE_SIZE)
+        .all(),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage, allPages) =>
+      lastPage.length < PAGE_SIZE ? undefined : allPages.length,
   });
 
 /** 오늘 탭 전용: 오늘 완료 체크된 todoId Set */

--- a/src/navigation/RecordStack.tsx
+++ b/src/navigation/RecordStack.tsx
@@ -1,0 +1,23 @@
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import RecordScreen from '../screens/RecordScreen';
+import CategoryCompletedScreen from '../screens/CategoryCompletedScreen';
+
+export type RecordStackParamList = {
+  RecordHome: undefined;
+  CategoryCompleted: {
+    categoryId: number;
+    categoryName: string;
+    categoryColor: string;
+  };
+};
+
+const Stack = createNativeStackNavigator<RecordStackParamList>();
+
+export default function RecordStack() {
+  return (
+    <Stack.Navigator screenOptions={{ headerShown: false, animation: 'slide_from_right' }}>
+      <Stack.Screen name="RecordHome" component={RecordScreen} />
+      <Stack.Screen name="CategoryCompleted" component={CategoryCompletedScreen} />
+    </Stack.Navigator>
+  );
+}

--- a/src/navigation/TabNavigator.tsx
+++ b/src/navigation/TabNavigator.tsx
@@ -1,7 +1,7 @@
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import TodoStack from './TodoStack';
-import RecordScreen from '../screens/RecordScreen';
+import RecordStack from './RecordStack';
 
 const Tab = createBottomTabNavigator();
 
@@ -26,7 +26,7 @@ export default function TabNavigator() {
       />
       <Tab.Screen
         name="기록"
-        component={RecordScreen}
+        component={RecordStack}
         options={{
           tabBarIcon: ({ color, size }: IconProps) => (
             <MaterialCommunityIcons name="view-grid-outline" size={size} color={color} />

--- a/src/screens/CategoryCompletedScreen.tsx
+++ b/src/screens/CategoryCompletedScreen.tsx
@@ -1,0 +1,134 @@
+import { View, FlatList, ActivityIndicator, StyleSheet } from 'react-native';
+import { Appbar, Text, Divider } from 'react-native-paper';
+import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { useMemo } from 'react';
+import dayjs from 'dayjs';
+import { Colors } from '../theme';
+import { useTodosCompletedByCategory, useToggleTodo } from '../hooks/useTodos';
+import { useCategories } from '../hooks/useCategories';
+import TodoItem from '../components/TodoItem';
+import { toDateKey, formatDateLabel } from '../utils/date';
+import { RecordStackParamList } from '../navigation/RecordStack';
+import { TodoStackParamList } from '../navigation/TodoStack';
+
+type Nav = NativeStackNavigationProp<TodoStackParamList, 'TodoList'>;
+type Route = RouteProp<RecordStackParamList, 'CategoryCompleted'>;
+
+type Todo = {
+  id: number;
+  title: string;
+  description?: string | null;
+  dueDate?: number | null;
+  urgency?: number | null;
+  importance?: number | null;
+  isCompleted: number;
+  completedAt?: number | null;
+  categoryId: number;
+  sortOrder: number;
+};
+
+type ListItem =
+  | { type: 'header'; label: string; key: string }
+  | { type: 'todo'; todo: Todo };
+
+function buildCompletedList(todos: Todo[]): ListItem[] {
+  const result: ListItem[] = [];
+  let lastKey = '';
+  for (const todo of todos) {
+    const key = toDateKey(todo.completedAt);
+    if (key !== lastKey) {
+      result.push({ type: 'header', label: formatDateLabel(todo.completedAt), key });
+      lastKey = key;
+    }
+    result.push({ type: 'todo', todo });
+  }
+  return result;
+}
+
+export default function CategoryCompletedScreen() {
+  const navigation = useNavigation<Nav>();
+  const route = useRoute<Route>();
+  const { categoryId, categoryName, categoryColor } = route.params;
+
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useTodosCompletedByCategory(categoryId);
+  const { data: categories = [] } = useCategories();
+  const { mutate: toggleTodo } = useToggleTodo();
+
+  const categoryMap = useMemo(
+    () => new Map(categories.map((c) => [c.id, c])),
+    [categories],
+  );
+
+  const flatTodos = useMemo(
+    () => (data?.pages.flat() ?? []) as Todo[],
+    [data],
+  );
+
+  const listItems = useMemo(() => buildCompletedList(flatTodos), [flatTodos]);
+
+  const renderItem = ({ item }: { item: ListItem }) => {
+    if (item.type === 'header') {
+      return <Text style={styles.dateHeader}>{item.label}</Text>;
+    }
+    return (
+      <>
+        <TodoItem
+          todo={item.todo}
+          category={categoryMap.get(item.todo.categoryId)}
+          showCheckbox={false}
+          onToggle={() => toggleTodo({ id: item.todo.id, isCompleted: item.todo.isCompleted })}
+          onPress={() => {}}
+        />
+        <Divider />
+      </>
+    );
+  };
+
+  return (
+    <View style={styles.container}>
+      <Appbar.Header style={styles.header}>
+        <Appbar.BackAction onPress={() => navigation.goBack()} />
+        <View style={[styles.dot, { backgroundColor: categoryColor }]} />
+        <Appbar.Content title={categoryName} titleStyle={{ fontWeight: '700' }} />
+      </Appbar.Header>
+
+      <FlatList
+        data={listItems}
+        keyExtractor={(item) =>
+          item.type === 'header' ? `header-${item.key}` : `todo-${item.todo.id}`
+        }
+        renderItem={renderItem}
+        onEndReached={() => { if (hasNextPage) fetchNextPage(); }}
+        onEndReachedThreshold={0.3}
+        ListFooterComponent={
+          isFetchingNextPage ? (
+            <ActivityIndicator style={styles.footer} color={Colors.primary} />
+          ) : null
+        }
+        ListEmptyComponent={
+          <Text style={styles.empty}>완료된 항목이 없어요</Text>
+        }
+        style={styles.list}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: Colors.background },
+  header: { height: 72 },
+  dot: { width: 10, height: 10, borderRadius: 5, marginRight: 4 },
+  list: { flex: 1 },
+  empty: { textAlign: 'center', marginTop: 60, color: Colors.textMuted },
+  footer: { paddingVertical: 16 },
+  dateHeader: {
+    paddingHorizontal: 16,
+    paddingTop: 20,
+    paddingBottom: 6,
+    fontSize: 12,
+    fontWeight: '600',
+    color: Colors.textMuted,
+  },
+});


### PR DESCRIPTION
## 이슈
Closes #91

## 변경 사항
- `src/hooks/useTodos.ts`: `useTodosCompletedByCategory(categoryId)` useInfiniteQuery 훅 추가 (PAGE_SIZE=30, offset 페이지네이션)
- `src/navigation/RecordStack.tsx`: 신규 생성 — RecordHome + CategoryCompleted 라우트 포함
- `src/navigation/TabNavigator.tsx`: 기록 탭을 RecordScreen에서 RecordStack으로 교체
- `src/screens/CategoryCompletedScreen.tsx`: 신규 생성 — 무한 스크롤, 날짜 그룹 헤더, TodoItem 렌더 포함

## 테스트
- [ ] 앱 실행 시 기록 탭이 정상 표시되는지 확인
- [ ] TypeScript 컴파일 오류 없는지 확인
- [ ] 기록 탭 → 기록 화면이 이전과 동일하게 동작하는지 확인