### PR TITLE
#92 [Phase 2] 기록 화면 카테고리 탭 연결 및 CategoryCompletedScreen 구현

### DIFF
--- a/.claude/phase-map.json
+++ b/.claude/phase-map.json
@@ -6,14 +6,14 @@
       "title": "무한 스크롤 훅 및 RecordStack 네비게이션 기반 세팅",
       "issueNumber": 91,
       "branch": "feature/issue-91/record-stack-and-infinite-hook",
-      "status": "in_progress"
+      "status": "done"
     },
     {
       "number": 2,
       "title": "기록 화면 카테고리 탭 연결 및 CategoryCompletedScreen 구현",
       "issueNumber": 92,
       "branch": "feature/issue-92/category-completed-screen",
-      "status": "pending"
+      "status": "in_progress"
     },
     {
       "number": 3,

--- a/src/components/TodoItem.tsx
+++ b/src/components/TodoItem.tsx
@@ -30,6 +30,7 @@ type Props = {
   isDragging?: boolean;
   forceCompleted?: boolean; // 오늘 탭: isCompleted=0이어도 체크된 것처럼 표시
   showCheckbox?: boolean;   // 기본 false이면 선택 모드일 때만 체크박스 표시
+  showDescription?: boolean; // 설명 표시 (최대 2줄, 말줄임)
   isSelecting?: boolean;    // 다중 선택 모드
   isSelected?: boolean;     // 선택됨 여부
 };
@@ -37,7 +38,7 @@ type Props = {
 const URGENCY_COLOR = Colors.urgency;
 const IMPORTANCE_COLOR = Colors.importance;
 
-export default function TodoItem({ todo, category, onToggle, onPress, onDrag, isDragging, forceCompleted, showCheckbox = true, isSelecting, isSelected }: Props) {
+export default function TodoItem({ todo, category, onToggle, onPress, onDrag, isDragging, forceCompleted, showCheckbox = true, showDescription, isSelecting, isSelected }: Props) {
   const showAsCompleted = !isSelecting && showCheckbox && (todo.isCompleted === 1 || forceCompleted);
   const checkboxStatus = isSelecting ? (isSelected ? 'checked' : 'unchecked') : (showAsCompleted ? 'checked' : 'unchecked');
   const checkboxVisible = isSelecting || showCheckbox;
@@ -79,6 +80,16 @@ export default function TodoItem({ todo, category, onToggle, onPress, onDrag, is
         >
           {todo.title}
         </Text>
+        {showDescription && !!todo.description && (
+          <Text
+            variant="bodySmall"
+            style={styles.descriptionText}
+            numberOfLines={2}
+            ellipsizeMode="tail"
+          >
+            {todo.description}
+          </Text>
+        )}
         <View style={styles.meta}>
           {category && (
             <View style={[styles.categoryDot, { backgroundColor: category.color }]} />
@@ -128,6 +139,7 @@ const styles = StyleSheet.create({
   content: { flex: 1, marginLeft: 4, paddingVertical: 4 },
   titleText: { flexShrink: 1 },
   completed: { textDecorationLine: 'line-through', color: Colors.textMuted },
+  descriptionText: { color: Colors.textSecondary, marginTop: 2 },
   meta: { flexDirection: 'row', alignItems: 'center', gap: 6, marginTop: 4, flexWrap: 'wrap' },
   categoryDot: { width: 8, height: 8, borderRadius: 4 },
   metaText: { color: Colors.textSecondary },

--- a/src/components/TodoTabList.tsx
+++ b/src/components/TodoTabList.tsx
@@ -44,6 +44,7 @@ export default function TodoTabList() {
         todo={item}
         category={categoryMap.get(item.categoryId)}
         forceCompleted={completedIds.has(item.id)}
+        showDescription
         onToggle={() => toggleTodo(item.id)}
         onPress={() => navigation.navigate('TodoForm', { todo: item })}
         onDrag={drag}

--- a/src/components/TodoTabOverdue.tsx
+++ b/src/components/TodoTabOverdue.tsx
@@ -80,6 +80,7 @@ export default function TodoTabOverdue() {
         todo={item}
         category={categoryMap.get(item.categoryId)}
         showCheckbox={false}
+        showDescription
         onToggle={
           isSelecting
             ? () => toggleSelection(item.id)

--- a/src/components/TodoTabToday.tsx
+++ b/src/components/TodoTabToday.tsx
@@ -74,6 +74,7 @@ export default function TodoTabToday() {
         todo={item}
         category={categoryMap.get(item.categoryId)}
         forceCompleted={completedIds.has(item.id)}
+        showDescription
         onToggle={() => todayToggle(item.id)}
         onPress={() => navigation.navigate('TodoForm', { todo: item })}
         onDrag={drag}

--- a/src/db/seed.ts
+++ b/src/db/seed.ts
@@ -21,7 +21,7 @@ import { eq } from 'drizzle-orm';
 import { db } from './index';
 import { categories, todos, todoCompletions, appSettings } from './schema';
 
-const SEED_KEY = 'seed_v6';
+const SEED_KEY = 'seed_v7';
 
 // 카테고리별 하루 완료 확률 (0~1) — 다양한 패턴 연출
 const CATEGORY_FREQUENCY: Record<string, number> = {
@@ -84,8 +84,53 @@ export async function runDevSeed() {
     미분류: ['메모 정리', '사진 백업', '앱 업데이트'],
   };
 
+  const COMPLETED_TODO_DESCRIPTIONS: Record<string, string[]> = {
+    업무: [
+      '3분기 목표 대비 달성률 정리, 주요 지표 시각화 포함',
+      '팀원 5명 참석, 다음 스프린트 우선순위 결정',
+      'PR #42 리뷰 완료, 성능 관련 코멘트 2건 남김',
+      '경영진 보고용 주간 실적 요약 작성 및 제출',
+      '받은 편지함 50건 처리, 중요 건 5건 별도 분류',
+      '팀 전체 현황 공유, 블로커 이슈 2건 논의',
+    ],
+    개인: [
+      '원자 습관 3장까지 완독, 핵심 내용 메모',
+      '오늘 있었던 일 3가지 기록, 감사한 점 작성',
+      '거실·주방 청소 완료, 분리수거 처리',
+      '오랜만에 통화, 다음 달 만남 약속',
+      '넷플릭스로 감상, 리뷰 메모 남김',
+      '파스타 직접 만들기, 레시피 저장해둠',
+    ],
+    운동: [
+      '한강 코스 완주, 페이스 5:30/km 유지',
+      '하체 위주 루틴, 스쿼트 100개 달성',
+      '기상 직후 15분 전신 스트레칭',
+      '공원 코스 12km, 날씨 맑아서 쾌적했음',
+      '수영장 25m × 20랩 완료',
+      '요가 매트 꺼내서 40분 플로우 진행',
+    ],
+    학습: [
+      '프로그래머스 Level 2 문제 2개 풀이, 시간복잡도 분석',
+      '단어 50개 복습, 틀린 것 15개 재암기',
+      '인프런 강의 2강 수강, 실습 코드 따라치기',
+      '이번 주 읽은 챕터 요약 정리 완료',
+      '오늘 배운 것 정리해서 노션에 업로드',
+      '기능 구현 3시간, 커밋 메시지 작성까지 완료',
+    ],
+    쇼핑: [
+      '주간 식재료 구매, 채소·단백질 위주로 담음',
+      '화장지, 세제, 샴푸 등 재고 보충',
+      '쿠팡에서 주문 완료, 내일 도착 예정',
+    ],
+    미분류: [
+      '노션 받은 받침함 정리, 불필요한 페이지 삭제',
+      '갤러리 정리 및 구글 포토 백업 완료',
+      'iOS 17.4 업데이트 설치 완료',
+    ],
+  };
+
   const completedTodoValues: {
-    categoryId: number; title: string; sortOrder: number;
+    categoryId: number; title: string; description: string | null; sortOrder: number;
     isCompleted: number; completedAt: number; createdAt: number; updatedAt: number;
   }[] = [];
 
@@ -96,14 +141,18 @@ export async function runDevSeed() {
 
     for (const cat of allCategories) {
       const titles = COMPLETED_TODO_TITLES[cat.name] ?? COMPLETED_TODO_TITLES['미분류'];
+      const descriptions = COMPLETED_TODO_DESCRIPTIONS[cat.name] ?? COMPLETED_TODO_DESCRIPTIONS['미분류'];
       // 날짜마다 0~3개 랜덤 생성
       const count = Math.floor(Math.random() * 4);
-      const shuffled = [...titles].sort(() => Math.random() - 0.5).slice(0, count);
-      for (const title of shuffled) {
+      const shuffled = [...titles.keys()].sort(() => Math.random() - 0.5).slice(0, count);
+      for (const idx of shuffled) {
         const offset = Math.floor(Math.random() * 8 * 60 * 60 * 1000); // 최대 8시간 내 랜덤
+        // 절반 확률로 설명 포함
+        const description = Math.random() > 0.5 ? descriptions[idx % descriptions.length] : null;
         completedTodoValues.push({
           categoryId: cat.id,
-          title,
+          title: titles[idx],
+          description,
           sortOrder: -9998,
           isCompleted: 1,
           completedAt: ts + offset,

--- a/src/screens/CategoryCompletedScreen.tsx
+++ b/src/screens/CategoryCompletedScreen.tsx
@@ -3,16 +3,13 @@ import { Appbar, Text, Divider } from 'react-native-paper';
 import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useMemo } from 'react';
-import dayjs from 'dayjs';
 import { Colors } from '../theme';
 import { useTodosCompletedByCategory, useToggleTodo } from '../hooks/useTodos';
-import { useCategories } from '../hooks/useCategories';
 import TodoItem from '../components/TodoItem';
 import { toDateKey, formatDateLabel } from '../utils/date';
 import { RecordStackParamList } from '../navigation/RecordStack';
-import { TodoStackParamList } from '../navigation/TodoStack';
 
-type Nav = NativeStackNavigationProp<TodoStackParamList, 'TodoList'>;
+type Nav = NativeStackNavigationProp<RecordStackParamList, 'CategoryCompleted'>;
 type Route = RouteProp<RecordStackParamList, 'CategoryCompleted'>;
 
 type Todo = {
@@ -53,13 +50,7 @@ export default function CategoryCompletedScreen() {
 
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useTodosCompletedByCategory(categoryId);
-  const { data: categories = [] } = useCategories();
   const { mutate: toggleTodo } = useToggleTodo();
-
-  const categoryMap = useMemo(
-    () => new Map(categories.map((c) => [c.id, c])),
-    [categories],
-  );
 
   const flatTodos = useMemo(
     () => (data?.pages.flat() ?? []) as Todo[],
@@ -76,8 +67,8 @@ export default function CategoryCompletedScreen() {
       <>
         <TodoItem
           todo={item.todo}
-          category={categoryMap.get(item.todo.categoryId)}
           showCheckbox={false}
+          showDescription
           onToggle={() => toggleTodo({ id: item.todo.id, isCompleted: item.todo.isCompleted })}
           onPress={() => {}}
         />
@@ -90,8 +81,14 @@ export default function CategoryCompletedScreen() {
     <View style={styles.container}>
       <Appbar.Header style={styles.header}>
         <Appbar.BackAction onPress={() => navigation.goBack()} />
-        <View style={[styles.dot, { backgroundColor: categoryColor }]} />
-        <Appbar.Content title={categoryName} titleStyle={{ fontWeight: '700' }} />
+        <Appbar.Content
+          title={
+            <View style={styles.titleRow}>
+              <View style={[styles.dot, { backgroundColor: categoryColor }]} />
+              <Text style={styles.titleText}>{categoryName}</Text>
+            </View>
+          }
+        />
       </Appbar.Header>
 
       <FlatList
@@ -100,8 +97,8 @@ export default function CategoryCompletedScreen() {
           item.type === 'header' ? `header-${item.key}` : `todo-${item.todo.id}`
         }
         renderItem={renderItem}
-        onEndReached={() => { if (hasNextPage) fetchNextPage(); }}
-        onEndReachedThreshold={0.3}
+        onEndReached={() => { if (hasNextPage && !isFetchingNextPage) fetchNextPage(); }}
+        onEndReachedThreshold={0.5}
         ListFooterComponent={
           isFetchingNextPage ? (
             <ActivityIndicator style={styles.footer} color={Colors.primary} />
@@ -119,7 +116,9 @@ export default function CategoryCompletedScreen() {
 const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: Colors.background },
   header: { height: 72 },
-  dot: { width: 10, height: 10, borderRadius: 5, marginRight: 4 },
+  titleRow: { flexDirection: 'row', alignItems: 'center', gap: 8 },
+  dot: { width: 10, height: 10, borderRadius: 5 },
+  titleText: { fontWeight: '700', fontSize: 18, color: Colors.text },
   list: { flex: 1 },
   empty: { textAlign: 'center', marginTop: 60, color: Colors.textMuted },
   footer: { paddingVertical: 16 },

--- a/src/screens/RecordScreen.tsx
+++ b/src/screens/RecordScreen.tsx
@@ -1,17 +1,21 @@
 import { useState } from 'react';
 import { View, ScrollView, StyleSheet } from 'react-native';
-import { Appbar, Text, IconButton } from 'react-native-paper';
+import { Appbar, Text, IconButton, TouchableRipple } from 'react-native-paper';
 import { useNavigation, DrawerActions } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { Colors } from '../theme';
 import { useCategories } from '../hooks/useCategories';
 import { useEarliestCompletionYear } from '../hooks/useCompletions';
 import ContributionGrid from '../components/ContributionGrid';
 import BannerAdView from '../components/BannerAdView';
+import { RecordStackParamList } from '../navigation/RecordStack';
+
+type Nav = NativeStackNavigationProp<RecordStackParamList, 'RecordHome'>;
 
 const CURRENT_YEAR = new Date().getFullYear();
 
 export default function RecordScreen() {
-  const navigation = useNavigation();
+  const navigation = useNavigation<Nav>();
   const [year, setYear] = useState(CURRENT_YEAR);
   const { data: categories = [] } = useCategories();
   const { data: earliestYear = CURRENT_YEAR } = useEarliestCompletionYear();
@@ -43,17 +47,32 @@ export default function RecordScreen() {
       <ScrollView contentContainerStyle={styles.content}>
         {categories.map((category) => (
           <View key={category.id} style={styles.section}>
-            <View style={styles.sectionHeader}>
-              <View style={[styles.dot, { backgroundColor: category.color }]} />
-              <Text variant="titleSmall" style={styles.categoryName}>
-                {category.name}
-              </Text>
-              {category.description ? (
-                <Text variant="bodySmall" style={styles.categoryDesc} numberOfLines={1} ellipsizeMode="tail">
-                  {category.description}
+            <TouchableRipple
+              onPress={() => navigation.navigate('CategoryCompleted', {
+                categoryId: category.id,
+                categoryName: category.name,
+                categoryColor: category.color,
+              })}
+              rippleColor={Colors.surfaceVariant}
+            >
+              <View style={styles.sectionHeader}>
+                <View style={[styles.dot, { backgroundColor: category.color }]} />
+                <Text variant="titleSmall" style={styles.categoryName}>
+                  {category.name}
                 </Text>
-              ) : null}
-            </View>
+                {category.description ? (
+                  <Text variant="bodySmall" style={styles.categoryDesc} numberOfLines={1} ellipsizeMode="tail">
+                    {category.description}
+                  </Text>
+                ) : null}
+                <IconButton
+                  icon="chevron-right"
+                  size={16}
+                  iconColor={Colors.textMuted}
+                  style={styles.chevron}
+                />
+              </View>
+            </TouchableRipple>
             <ContributionGrid categoryId={category.id} color={category.color} year={year} />
           </View>
         ))}
@@ -87,7 +106,9 @@ const styles = StyleSheet.create({
     gap: 8,
     marginBottom: 10,
     paddingHorizontal: 12,
+    paddingVertical: 4,
   },
+  chevron: { marginLeft: 'auto', margin: 0 },
   dot: { width: 10, height: 10, borderRadius: 5 },
   categoryName: { color: Colors.text },
   categoryDesc: { color: Colors.textMuted, flexShrink: 1 },


### PR DESCRIPTION
## 이슈
Closes #92

## 변경 사항
- `src/screens/RecordScreen.tsx`: 카테고리 헤더를 TouchableRipple로 감싸 CategoryCompleted 화면으로 navigate, chevron-right 아이콘 추가
- `src/screens/CategoryCompletedScreen.tsx`: 무한 스크롤 완료 목록 화면 구현 (날짜 그룹 헤더, 로딩 인디케이터, 빈 상태 메시지)
- `src/components/TodoItem.tsx`: `showDescription` prop 추가 — 제목 아래 설명 최대 2줄 표시
- `src/components/TodoTabList/Today/Overdue.tsx`: `showDescription` 활성화
- `src/db/seed.ts`: 완료 항목에 설명 데이터 추가 (seed_v7), 50% 확률로 설명 포함

## 테스트
- [ ] 기록 화면 카테고리 헤더 탭 → CategoryCompleted 화면 이동 확인
- [ ] CategoryCompleted: 해당 카테고리 완료 항목만 최신순 표시
- [ ] 무한 스크롤: 스크롤 하단 도달 시 다음 페이지 로드
- [ ] 완료 항목에 설명이 최대 2줄로 표시되고 이상은 말줄임표 처리
- [ ] 오늘/할 일/미완료 탭에서도 설명 표시 확인
- [ ] `DELETE FROM app_settings WHERE key = 'seed_v6';` 실행 후 앱 재시작으로 seed_v7 확인