### PR TITLE
#97 [Phase 1] RootNavigator 기반 세팅 및 설정 탭 추가

### DIFF
--- a/.claude/phase-map.json
+++ b/.claude/phase-map.json
@@ -1,26 +1,27 @@
 {
   "planFile": "shimmying-snuggling-cat.md",
+  "mainIssueNumber": 97,
   "phases": [
     {
       "number": 1,
-      "title": "무한 스크롤 훅 및 RecordStack 네비게이션 기반 세팅",
-      "issueNumber": 91,
-      "branch": "feature/issue-91/record-stack-and-infinite-hook",
-      "status": "done"
+      "title": "RootNavigator 기반 세팅 및 설정 탭 추가",
+      "issueNumber": 98,
+      "branch": "feature/issue-97/root-navigator-setup",
+      "status": "in_progress"
     },
     {
       "number": 2,
-      "title": "기록 화면 카테고리 탭 연결 및 CategoryCompletedScreen 구현",
-      "issueNumber": 92,
-      "branch": "feature/issue-92/category-completed-screen",
-      "status": "done"
+      "title": "헤더 3-dot 메뉴 구현",
+      "issueNumber": 99,
+      "branch": "feature/issue-97/header-three-dot-menu",
+      "status": "pending"
     },
     {
       "number": 3,
-      "title": "할 일 화면 완료 탭 제거 및 TodoTabCompleted 삭제",
-      "issueNumber": 93,
-      "branch": "feature/issue-93/remove-completed-tab",
-      "status": "in_progress"
+      "title": "Drawer 제거 및 관련 파일 정리",
+      "issueNumber": 100,
+      "branch": "feature/issue-97/remove-drawer",
+      "status": "pending"
     }
   ]
 }

--- a/.claude/skills/task/skill.md
+++ b/.claude/skills/task/skill.md
@@ -22,28 +22,38 @@ argument-hint: "[init | next | 단계번호 | status | done]"
    - 단계 제목은 한국어로 간결하게 (예: "기반 세팅", "광고 배너 구현", "인앱 구매 구현")
    - 각 단계에 포함되는 플랜 항목 명시
 
-3. 각 단계별로 GitHub 이슈를 순서대로 생성해 (`gh issue create`):
+3. **메인 이슈 먼저 생성** (`gh issue create`):
+   - 제목: 플랜 전체를 아우르는 기능 제목 (예: "내비게이션 구조 개편")
+   - 본문: 배경/목적 + 전체 단계 목록 (체크리스트 형식)
+   - `[Phase N] {제목}` 형식으로 각 서브 이슈를 예고
+   - 생성된 이슈 번호를 `mainIssueNumber`로 저장
+
+4. **각 단계별 서브 이슈 생성** (`gh issue create`):
    - 제목: `[Phase N] {단계 제목}` 형식
+   - 본문 첫 줄: `Part of #{{mainIssueNumber}}` (메인 이슈 연결)
    - 본문: 해당 단계의 구현 항목 체크리스트
    - CLAUDE.md 프로젝트 컨벤션 준수
 
-4. `.claude/phase-map.json`에 저장:
+5. `.claude/phase-map.json`에 저장:
    ```json
    {
      "planFile": "{플랜 파일명}",
+     "mainIssueNumber": {메인이슈번호},
      "phases": [
        {
          "number": 1,
          "title": "{단계 제목}",
-         "issueNumber": {이슈번호},
-         "branch": "feature/issue-{번호}/{kebab-title}",
+         "issueNumber": {서브이슈번호},
+         "branch": "feature/issue-{메인번호}/{kebab-title}",
          "status": "pending"
        }
      ]
    }
    ```
+   - 브랜치명은 메인 이슈 번호 기준으로 생성 (`feature/issue-{mainIssueNumber}/...`)
+   - 커밋 prefix도 메인 이슈 번호 기준 (`feat: #{mainIssueNumber}`)
 
-5. 1단계 구현 시작 (아래 "단계 구현" 참고)
+6. 1단계 구현 시작 (아래 "단계 구현" 참고)
 
 ---
 
@@ -124,7 +134,20 @@ Phase  제목                  이슈  브랜치              상태
 ---
 
 ## Git/GitHub 컨벤션
-- 브랜치: `feature/issue-{번호}/{kebab-case-title}`
-- 커밋 prefix: `feat: #{번호}`
+- 브랜치: `feature/issue-{mainIssueNumber}/{kebab-case-title}` (메인 이슈 번호 기준)
+- 커밋 prefix: `feat: #{mainIssueNumber}` (메인 이슈 번호 기준)
 - PR 타겟: 항상 `develop`
-- 이슈 제목에 `[Phase N]` 접두사 포함
+- PR 본문에 서브 이슈 `Closes #{subIssueNumber}` 포함
+
+## 이슈 구조 예시
+
+```
+메인 이슈 #100: 내비게이션 구조 개편
+  ├── 서브 이슈 #101: [Phase 1] RootNavigator 기반 세팅  (Part of #100)
+  ├── 서브 이슈 #102: [Phase 2] 3-dot 메뉴 구현          (Part of #100)
+  └── 서브 이슈 #103: [Phase 3] Drawer 제거 및 정리      (Part of #100)
+
+브랜치: feature/issue-100/navigation-restructure
+커밋:   feat: #100 RootNavigator 기반 세팅
+PR:     Closes #101
+```

--- a/App.tsx
+++ b/App.tsx
@@ -11,7 +11,7 @@ import MobileAds from 'react-native-google-mobile-ads';
 import { initDb } from './src/db';
 import { loadPremiumStatus } from './src/hooks/usePremiumStatus';
 import { configurePurchases } from './src/screens/PremiumScreen';
-import DrawerNavigator from './src/navigation/DrawerNavigator';
+import RootNavigator from './src/navigation/RootNavigator';
 import { AppTheme, NavTheme } from './src/theme';
 
 // JS 로드 직후 스플래시를 자동으로 숨기지 않도록 유지
@@ -63,7 +63,7 @@ export default function App() {
           <PaperProvider theme={AppTheme}>
             <NavigationContainer theme={NavTheme}>
               <StatusBar style="light" />
-              <DrawerNavigator />
+              <RootNavigator />
             </NavigationContainer>
           </PaperProvider>
         </SafeAreaProvider>

--- a/src/navigation/RootNavigator.tsx
+++ b/src/navigation/RootNavigator.tsx
@@ -1,0 +1,23 @@
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { NavigatorScreenParams } from '@react-navigation/native';
+import TabNavigator from './TabNavigator';
+import CategoryStack, { CategoryStackParamList } from './CategoryStack';
+import RoutineStack, { RoutineStackParamList } from './RoutineStack';
+
+export type RootStackParamList = {
+  Main: undefined;
+  CategoryRoot: NavigatorScreenParams<CategoryStackParamList>;
+  RoutineRoot: NavigatorScreenParams<RoutineStackParamList>;
+};
+
+const Stack = createNativeStackNavigator<RootStackParamList>();
+
+export default function RootNavigator() {
+  return (
+    <Stack.Navigator screenOptions={{ headerShown: false, animation: 'slide_from_right' }}>
+      <Stack.Screen name="Main" component={TabNavigator} />
+      <Stack.Screen name="CategoryRoot" component={CategoryStack} />
+      <Stack.Screen name="RoutineRoot" component={RoutineStack} />
+    </Stack.Navigator>
+  );
+}

--- a/src/navigation/TabNavigator.tsx
+++ b/src/navigation/TabNavigator.tsx
@@ -2,6 +2,7 @@ import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import TodoStack from './TodoStack';
 import RecordStack from './RecordStack';
+import SettingsStack from './SettingsStack';
 
 const Tab = createBottomTabNavigator();
 
@@ -30,6 +31,15 @@ export default function TabNavigator() {
         options={{
           tabBarIcon: ({ color, size }: IconProps) => (
             <MaterialCommunityIcons name="view-grid-outline" size={size} color={color} />
+          ),
+        }}
+      />
+      <Tab.Screen
+        name="설정"
+        component={SettingsStack}
+        options={{
+          tabBarIcon: ({ color, size }: IconProps) => (
+            <MaterialCommunityIcons name="cog-outline" size={size} color={color} />
           ),
         }}
       />


### PR DESCRIPTION
## 이슈
Closes #98
Part of #97

## 변경 사항
- `src/navigation/RootNavigator.tsx`: 신규 생성 — Main / CategoryRoot / RoutineRoot 라우트
- `App.tsx`: DrawerNavigator → RootNavigator 교체
- `src/navigation/TabNavigator.tsx`: 설정 탭(SettingsStack, cog-outline) 추가

## 테스트
- [ ] 앱 정상 실행 확인
- [ ] 하단 탭 3개(할 일 / 기록 / 설정) 표시 확인
- [ ] 설정 탭 탭 시 설정 화면 정상 진입
- [ ] 할 일 / 기록 탭 기존 동작 이상 없는지 확인