### PR TITLE
#99 [Phase 2] 헤더 3-dot 메뉴 구현

### DIFF
--- a/.claude/phase-map.json
+++ b/.claude/phase-map.json
@@ -7,14 +7,14 @@
       "title": "RootNavigator 기반 세팅 및 설정 탭 추가",
       "issueNumber": 98,
       "branch": "feature/issue-97/root-navigator-setup",
-      "status": "in_progress"
+      "status": "done"
     },
     {
       "number": 2,
       "title": "헤더 3-dot 메뉴 구현",
       "issueNumber": 99,
       "branch": "feature/issue-97/header-three-dot-menu",
-      "status": "pending"
+      "status": "in_progress"
     },
     {
       "number": 3,

--- a/.claude/skills/merge/skill.md
+++ b/.claude/skills/merge/skill.md
@@ -1,0 +1,84 @@
+---
+name: merge
+description: PR을 머지하고 브랜치 삭제 후 타겟 브랜치로 복귀 및 pull 처리. PR 번호 없으면 가장 오래된 PR, "all"이면 전체 머지.
+tools: Bash
+argument-hint: "[PR번호 | all]"
+---
+
+PR을 머지하고 브랜치를 정리한 뒤 타겟 브랜치로 복귀해.
+
+## 실행 흐름
+
+### 1. 머지 대상 결정
+
+`$ARGUMENTS`에 따라:
+
+- **PR 번호** (예: `101`): 해당 PR을 머지
+- **`all`**: 열린 PR 전체를 생성 순서대로 순차 머지
+- **비어있음**: 가장 오래된(번호 가장 작은) 열린 PR을 머지
+
+대상 PR 목록 조회:
+```bash
+gh pr list --state open --json number,title,baseRefName,headRefName --jq 'sort_by(.number)'
+```
+
+PR이 없으면:
+```
+머지할 PR이 없습니다.
+```
+안내 후 중단.
+
+### 2. 각 PR에 대해 순서대로 처리
+
+각 PR마다:
+
+**a. PR 정보 조회**
+```bash
+gh pr view {number} --json number,title,baseRefName,headRefName,state
+```
+
+**b. 머지 실행** (squash 머지)
+```bash
+gh pr merge {number} --squash --delete-branch
+```
+- `--delete-branch`: 원격 브랜치 자동 삭제
+- 머지 실패 시 해당 PR 스킵하고 이유 출력 후 계속
+
+**c. 로컬 브랜치 삭제** (존재하는 경우에만)
+```bash
+git branch -d {headRefName} 2>/dev/null || true
+```
+
+**d. 타겟 브랜치로 이동 및 pull**
+```bash
+git checkout {baseRefName}
+git pull origin {baseRefName}
+```
+
+### 3. 결과 출력
+
+각 PR마다:
+```
+✅ 머지: #{번호} {제목}
+   브랜치 삭제: {headRefName}
+   현재 브랜치: {baseRefName} (최신)
+```
+
+`all` 모드에서 여러 PR 처리 시:
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+머지 완료 (3/3)
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+✅ #101 RootNavigator 기반 세팅
+✅ #102 헤더 3-dot 메뉴 구현
+✅ #103 Drawer 제거 및 정리
+
+현재 브랜치: develop (최신)
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+## 주의사항
+- force merge, --force 옵션 절대 사용 안 함
+- main/master 브랜치 직접 머지 금지 — PR을 통해서만 처리
+- 머지 전 PR 상태(state)가 OPEN인지 확인
+- 로컬 브랜치 삭제는 `-d`(안전 삭제)만 사용, `-D` 금지

--- a/src/screens/RecordScreen.tsx
+++ b/src/screens/RecordScreen.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { View, ScrollView, StyleSheet } from 'react-native';
-import { Appbar, Text, IconButton, TouchableRipple } from 'react-native-paper';
-import { useNavigation, DrawerActions } from '@react-navigation/native';
+import { Appbar, Text, IconButton, TouchableRipple, Menu } from 'react-native-paper';
+import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { Colors } from '../theme';
 import { useCategories } from '../hooks/useCategories';
@@ -17,15 +17,32 @@ const CURRENT_YEAR = new Date().getFullYear();
 export default function RecordScreen() {
   const navigation = useNavigation<Nav>();
   const [year, setYear] = useState(CURRENT_YEAR);
+  const [menuVisible, setMenuVisible] = useState(false);
   const { data: categories = [] } = useCategories();
   const { data: earliestYear = CURRENT_YEAR } = useEarliestCompletionYear();
 
   return (
     <View style={styles.container}>
       <Appbar.Header style={styles.header}>
-        <Appbar.Action icon="menu" onPress={() => navigation.dispatch(DrawerActions.openDrawer())} />
         <Appbar.Content title="CheckCheck" titleStyle={{ fontWeight: '700' }} />
-        <Appbar.Action icon="cog-outline" onPress={() => navigation.navigate('SettingsMain' as never)} />
+        <Menu
+          visible={menuVisible}
+          onDismiss={() => setMenuVisible(false)}
+          anchor={
+            <Appbar.Action icon="dots-vertical" onPress={() => setMenuVisible(true)} />
+          }
+        >
+          <Menu.Item
+            leadingIcon="tag-outline"
+            title="카테고리 관리"
+            onPress={() => { setMenuVisible(false); navigation.navigate('CategoryRoot' as never); }}
+          />
+          <Menu.Item
+            leadingIcon="repeat"
+            title="루틴 관리"
+            onPress={() => { setMenuVisible(false); navigation.navigate('RoutineRoot' as never); }}
+          />
+        </Menu>
       </Appbar.Header>
 
       <View style={styles.yearRow}>

--- a/src/screens/TodoScreen.tsx
+++ b/src/screens/TodoScreen.tsx
@@ -1,7 +1,7 @@
 import { StyleSheet, View, useWindowDimensions, InteractionManager } from 'react-native';
-import { Appbar, FAB } from 'react-native-paper';
+import { Appbar, FAB, Menu } from 'react-native-paper';
 import { TabView, TabBar } from 'react-native-tab-view';
-import { useNavigation, useIsFocused, CommonActions, DrawerActions } from '@react-navigation/native';
+import { useNavigation, useIsFocused, CommonActions } from '@react-navigation/native';
 import { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useState, useEffect } from 'react';
@@ -36,6 +36,7 @@ export default function TodoScreen() {
   const navigation = useNavigation<Nav>();
   const layout = useWindowDimensions();
   const [tabIndex, setTabIndex] = useState(0);
+  const [menuVisible, setMenuVisible] = useState(false);
   const isPremium = usePremiumStore((s) => s.isPremium);
   const isFocused = useIsFocused();
   const queryClient = useQueryClient();
@@ -71,9 +72,25 @@ export default function TodoScreen() {
   return (
     <View style={styles.container}>
       <Appbar.Header style={styles.header}>
-        <Appbar.Action icon="menu" onPress={() => navigation.dispatch(DrawerActions.openDrawer())} />
         <Appbar.Content title="CheckCheck" titleStyle={{ fontWeight: '700' }} />
-        <Appbar.Action icon="cog-outline" onPress={() => navigation.navigate('SettingsMain' as never)} />
+        <Menu
+          visible={menuVisible}
+          onDismiss={() => setMenuVisible(false)}
+          anchor={
+            <Appbar.Action icon="dots-vertical" onPress={() => setMenuVisible(true)} />
+          }
+        >
+          <Menu.Item
+            leadingIcon="tag-outline"
+            title="카테고리 관리"
+            onPress={() => { setMenuVisible(false); navigation.navigate('CategoryRoot' as never); }}
+          />
+          <Menu.Item
+            leadingIcon="repeat"
+            title="루틴 관리"
+            onPress={() => { setMenuVisible(false); navigation.navigate('RoutineRoot' as never); }}
+          />
+        </Menu>
       </Appbar.Header>
 
       <TabView


### PR DESCRIPTION
## 이슈
Closes #99

## 변경 사항
- `TodoScreen.tsx`: ☰(Drawer 열기), ⚙(설정) 제거 → ⋮(dots-vertical) 3-dot 메뉴로 교체
  - 팝오버: 카테고리 관리(`CategoryRoot`), 루틴 관리(`RoutineRoot`)
  - `DrawerActions` import 제거
- `RecordScreen.tsx`: 동일한 헤더 변경 적용

## 테스트
- [ ] 할 일 화면 헤더에 ⋮ 버튼만 표시됨
- [ ] 기록 화면 헤더에 ⋮ 버튼만 표시됨
- [ ] ⋮ 탭 → 팝오버에 카테고리 관리/루틴 관리 메뉴 표시
- [ ] 카테고리 관리 탭 → CategoryManagementScreen 정상 이동
- [ ] 루틴 관리 탭 → RoutineManagementScreen 정상 이동
- [ ] 뒤로가기로 원래 탭 복귀