### PR TITLE
#105 [Phase 1] 훅 4종 구현

### DIFF
--- a/.claude/phase-map.json
+++ b/.claude/phase-map.json
@@ -1,27 +1,20 @@
 {
   "planFile": "shimmying-snuggling-cat.md",
-  "mainIssueNumber": 97,
+  "mainIssueNumber": 104,
   "phases": [
     {
       "number": 1,
-      "title": "RootNavigator 기반 세팅 및 설정 탭 추가",
-      "issueNumber": 98,
-      "branch": "feature/issue-97/root-navigator-setup",
-      "status": "done"
+      "title": "훅 4종 구현",
+      "issueNumber": 105,
+      "branch": "refactor/issue-104/extract-hooks",
+      "status": "in_progress"
     },
     {
       "number": 2,
-      "title": "헤더 3-dot 메뉴 구현",
-      "issueNumber": 99,
-      "branch": "feature/issue-97/header-three-dot-menu",
-      "status": "done"
-    },
-    {
-      "number": 3,
-      "title": "Drawer 제거 및 관련 파일 정리",
-      "issueNumber": 100,
-      "branch": "feature/issue-97/remove-drawer",
-      "status": "in_progress"
+      "title": "TodoItem 리팩토링 + 탭 컴포넌트 훅 적용",
+      "issueNumber": 106,
+      "branch": "refactor/issue-104/refactor-todo-item",
+      "status": "pending"
     }
   ]
 }

--- a/src/hooks/useCategoryMap.ts
+++ b/src/hooks/useCategoryMap.ts
@@ -1,0 +1,6 @@
+import { useMemo } from 'react';
+import { Category } from '../types';
+
+export function useCategoryMap(categories: Category[]): Map<number, Category> {
+  return useMemo(() => new Map(categories.map((c) => [c.id, c])), [categories]);
+}

--- a/src/hooks/useCheckable.ts
+++ b/src/hooks/useCheckable.ts
@@ -1,0 +1,28 @@
+type CheckableTodayConfig = {
+  mode: 'today';
+  todoId: number;
+  completedIds: Set<number>;
+  toggleFn: (id: number) => void;
+};
+
+type CheckableToggleConfig = {
+  mode: 'toggle';
+  todoId: number;
+  isCompleted: number;
+  toggleFn: (args: { id: number; isCompleted: number }) => void;
+};
+
+type CheckableConfig = CheckableTodayConfig | CheckableToggleConfig;
+
+export function useCheckable(config: CheckableConfig): { checked: boolean; onCheck: () => void } {
+  if (config.mode === 'today') {
+    return {
+      checked: config.completedIds.has(config.todoId),
+      onCheck: () => config.toggleFn(config.todoId),
+    };
+  }
+  return {
+    checked: config.isCompleted === 1,
+    onCheck: () => config.toggleFn({ id: config.todoId, isCompleted: config.isCompleted }),
+  };
+}

--- a/src/hooks/useDraggable.ts
+++ b/src/hooks/useDraggable.ts
@@ -1,0 +1,20 @@
+import { useCallback } from 'react';
+
+type Options = {
+  reorderFn: (ids: number[]) => void;
+  disabled?: boolean;
+};
+
+export function useDraggable<T extends { id: number }>({ reorderFn, disabled = false }: Options) {
+  const onDragEnd = useCallback(
+    ({ data }: { data: T[] }) => reorderFn(data.map((t) => t.id)),
+    [reorderFn],
+  );
+
+  return {
+    onDragEnd,
+    activationDistance: disabled ? 9999 : 20,
+    autoscrollThreshold: 80,
+    autoscrollSpeed: 200,
+  };
+}

--- a/src/hooks/useSelectable.ts
+++ b/src/hooks/useSelectable.ts
@@ -1,0 +1,27 @@
+import { useState, useCallback } from 'react';
+
+export function useSelectable<T extends { id: number }>(items: T[]) {
+  const [isSelecting, setIsSelecting] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
+
+  const startSelecting = useCallback(() => setIsSelecting(true), []);
+
+  const clearSelection = useCallback(() => {
+    setIsSelecting(false);
+    setSelectedIds(new Set());
+  }, []);
+
+  const toggleSelection = useCallback((id: number) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      next.has(id) ? next.delete(id) : next.add(id);
+      return next;
+    });
+  }, []);
+
+  const selectAll = useCallback(() => {
+    setSelectedIds(new Set(items.map((t) => t.id)));
+  }, [items]);
+
+  return { isSelecting, selectedIds, startSelecting, clearSelection, toggleSelection, selectAll };
+}


### PR DESCRIPTION
## 이슈
Closes #105

## 변경 사항
- `src/hooks/useCategoryMap.ts` 신규: 세 탭의 중복 categoryMap memoization 추출
- `src/hooks/useCheckable.ts` 신규: `mode: 'today' | 'toggle'` 주입 → `checked`, `onCheck` 반환
- `src/hooks/useSelectable.ts` 신규: 다중 선택 상태 (`isSelecting`, `selectedIds`, `toggleSelection`, `selectAll`, `clearSelection`)
- `src/hooks/useDraggable.ts` 신규: `onDragEnd`, `activationDistance`(disabled 시 9999 자동 전환), `autoscrollThreshold`, `autoscrollSpeed`

## 테스트
- [ ] TypeScript 컴파일 오류 없음
- [ ] 기존 탭 동작 영향 없음 (훅 신규 추가만, 기존 코드 미변경)