### PR TITLE
#109 할 일 아이템 시인성 개선 — 카테고리 태그화, 긴급도/중요도 아이콘 표현, 카테고리 자동생성 색상 조정

### DIFF
--- a/src/components/TodoItem/TodoItemMeta.tsx
+++ b/src/components/TodoItem/TodoItemMeta.tsx
@@ -1,10 +1,14 @@
 import { View, StyleSheet } from 'react-native';
 import { Text } from 'react-native-paper';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { Colors } from '../../theme';
-import { LEVEL_LABELS } from '../../constants/todo';
 
 const URGENCY_COLOR = Colors.urgency;
 const IMPORTANCE_COLOR = Colors.importance;
+
+// 레벨별 아이콘 수 (1→1개, 2→2개, 3→3개)
+const URGENCY_ICON = 'lightning-bolt';
+const IMPORTANCE_ICON = 'star';
 
 type Category = {
   id: number;
@@ -25,25 +29,33 @@ export default function TodoItemMeta({ category, urgency, importance }: Props) {
   return (
     <View style={styles.meta}>
       {category && (
-        <View style={[styles.categoryDot, { backgroundColor: category.color }]} />
-      )}
-      {category && (
-        <Text variant="labelSmall" style={[styles.metaText, { color: category.color }]}>
-          {category.name}
-        </Text>
+        <View style={[styles.tag, { backgroundColor: category.color + '28' }]}>
+          <View style={[styles.tagDot, { backgroundColor: category.color }]} />
+          <Text style={[styles.tagText, { color: category.color }]}>{category.name}</Text>
+        </View>
       )}
       {urgencyLevel > 0 && (
-        <View style={[styles.badge, { backgroundColor: URGENCY_COLOR + '33' }]}>
-          <Text style={[styles.badgeText, { color: URGENCY_COLOR }]}>
-            긴급 {LEVEL_LABELS[urgencyLevel]}
-          </Text>
+        <View style={[styles.tag, { backgroundColor: URGENCY_COLOR + '22' }]}>
+          {Array.from({ length: urgencyLevel }).map((_, i) => (
+            <MaterialCommunityIcons
+              key={i}
+              name={URGENCY_ICON}
+              size={10}
+              color={URGENCY_COLOR}
+            />
+          ))}
         </View>
       )}
       {importanceLevel > 0 && (
-        <View style={[styles.badge, { backgroundColor: IMPORTANCE_COLOR + '33' }]}>
-          <Text style={[styles.badgeText, { color: IMPORTANCE_COLOR }]}>
-            중요 {LEVEL_LABELS[importanceLevel]}
-          </Text>
+        <View style={[styles.tag, { backgroundColor: IMPORTANCE_COLOR + '22' }]}>
+          {Array.from({ length: importanceLevel }).map((_, i) => (
+            <MaterialCommunityIcons
+              key={i}
+              name={IMPORTANCE_ICON}
+              size={10}
+              color={IMPORTANCE_COLOR}
+            />
+          ))}
         </View>
       )}
     </View>
@@ -52,8 +64,14 @@ export default function TodoItemMeta({ category, urgency, importance }: Props) {
 
 const styles = StyleSheet.create({
   meta: { flexDirection: 'row', alignItems: 'center', gap: 6, marginTop: 4, flexWrap: 'wrap' },
-  categoryDot: { width: 8, height: 8, borderRadius: 4 },
-  metaText: { color: Colors.textSecondary },
-  badge: { paddingHorizontal: 6, paddingVertical: 2, borderRadius: 4 },
-  badgeText: { fontSize: 10, fontWeight: '600' },
+  tag: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 3,
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    borderRadius: 4,
+  },
+  tagDot: { width: 6, height: 6, borderRadius: 3 },
+  tagText: { fontSize: 10, fontWeight: '600' },
 });

--- a/src/constants/colors.ts
+++ b/src/constants/colors.ts
@@ -1,8 +1,8 @@
-// GitHub 태그 스타일 — 채도 낮은 파스텔 계열 랜덤 생성
+// 다크 화면 최적화 — 채도를 낮추고 밝기를 높여 눈에 편한 색상 생성
 export const generateRandomColor = (): string => {
   const hue = Math.floor(Math.random() * 360);
-  const saturation = 55 + Math.floor(Math.random() * 20); // 55~75%
-  const lightness = 45 + Math.floor(Math.random() * 15);  // 45~60%
+  const saturation = 30 + Math.floor(Math.random() * 20); // 30~50% (낮은 채도)
+  const lightness = 60 + Math.floor(Math.random() * 15);  // 60~75% (높은 밝기)
   return hslToHex(hue, saturation, lightness);
 };
 


### PR DESCRIPTION
## 이슈
Closes #109

## 변경 사항
- `TodoItemMeta`: 카테고리를 dot+텍스트에서 반투명 pill 태그 형식으로 변경
- `TodoItemMeta`: 긴급도(`⚡`)·중요도(`★`) 아이콘을 레벨 수만큼 표시 (텍스트 배지 제거)
- `constants/colors.ts`: 카테고리 자동생성 채도 55~75% → 30~50%, 밝기 45~60% → 60~75% (다크 화면 최적화)

## 테스트
- [ ] 할 일 아이템에서 카테고리가 pill 태그로 표시되는지 확인
- [ ] 긴급도/중요도가 아이콘 개수로 표현되는지 확인 (1→1개, 2→2개, 3→3개)
- [ ] 카테고리 새로 생성 시 연한 색상으로 생성되는지 확인