### PR TITLE
#113 미완료 탭 선택 모드 FAB 버튼 사이즈 통일

### DIFF
--- a/src/components/TodoTabOverdue.tsx
+++ b/src/components/TodoTabOverdue.tsx
@@ -116,14 +116,12 @@ export default function TodoTabOverdue() {
       {isSelecting ? (
         <View style={styles.actionColumn}>
           <FAB
-            size="small"
             icon="calendar-arrow-right"
             style={[styles.fabAction, selectedIds.size === 0 && styles.fabDisabled]}
             onPress={handleMoveToToday}
             disabled={selectedIds.size === 0}
           />
           <FAB
-            size="small"
             icon="trash-can-outline"
             style={[styles.fabAction, styles.fabDanger, selectedIds.size === 0 && styles.fabDisabled]}
             color={Colors.danger}
@@ -131,7 +129,6 @@ export default function TodoTabOverdue() {
             disabled={selectedIds.size === 0}
           />
           <FAB
-            size="small"
             icon="close-circle-outline"
             style={styles.fabAction}
             onPress={clearSelection}


### PR DESCRIPTION
## 이슈
Closes #113

## 변경 사항
- 액션 FAB 3개(오늘 이동, 삭제, 취소)에서 `size="small"` 제거 → 선택 트리거 FAB과 동일한 medium으로 통일

## 테스트
- [ ] 미완료 탭 선택 모드 진입 시 FAB 4개 크기 동일한지 확인