### PR TITLE
#116 [Phase 1] 할 일 시간 설정

### DIFF
--- a/.claude/phase-map.json
+++ b/.claude/phase-map.json
@@ -1,20 +1,34 @@
 {
   "planFile": "shimmying-snuggling-cat.md",
-  "mainIssueNumber": 104,
+  "mainIssueNumber": 115,
   "phases": [
     {
       "number": 1,
-      "title": "훅 4종 구현",
-      "issueNumber": 105,
-      "branch": "refactor/issue-104/extract-hooks",
-      "status": "done"
+      "title": "할 일 시간 설정",
+      "issueNumber": 116,
+      "branch": "feature/issue-115/due-time",
+      "status": "in_progress"
     },
     {
       "number": 2,
-      "title": "TodoItem 리팩토링 + 탭 컴포넌트 훅 적용",
-      "issueNumber": 106,
-      "branch": "refactor/issue-104/refactor-todo-item",
-      "status": "in_progress"
+      "title": "알림",
+      "issueNumber": 117,
+      "branch": "feature/issue-115/notifications",
+      "status": "pending"
+    },
+    {
+      "number": 3,
+      "title": "정렬",
+      "issueNumber": 118,
+      "branch": "feature/issue-115/sort",
+      "status": "pending"
+    },
+    {
+      "number": 4,
+      "title": "사용자 가이드",
+      "issueNumber": 119,
+      "branch": "feature/issue-115/onboarding",
+      "status": "pending"
     }
   ]
 }

--- a/src/components/TodoItem/TodoItemMeta.tsx
+++ b/src/components/TodoItem/TodoItemMeta.tsx
@@ -16,13 +16,22 @@ type Category = {
   color: string;
 };
 
+function formatDueTime(minutes: number): string {
+  const h = Math.floor(minutes / 60);
+  const m = minutes % 60;
+  const date = new Date();
+  date.setHours(h, m, 0, 0);
+  return date.toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit' });
+}
+
 type Props = {
   category?: Category;
+  dueTime?: number | null;
   urgency?: number | null;
   importance?: number | null;
 };
 
-export default function TodoItemMeta({ category, urgency, importance }: Props) {
+export default function TodoItemMeta({ category, dueTime, urgency, importance }: Props) {
   const urgencyLevel = urgency ?? 0;
   const importanceLevel = importance ?? 0;
 
@@ -32,6 +41,12 @@ export default function TodoItemMeta({ category, urgency, importance }: Props) {
         <View style={[styles.tag, { backgroundColor: category.color + '28' }]}>
           <View style={[styles.tagDot, { backgroundColor: category.color }]} />
           <Text style={[styles.tagText, { color: category.color }]}>{category.name}</Text>
+        </View>
+      )}
+      {dueTime != null && (
+        <View style={[styles.tag, { backgroundColor: Colors.textMuted + '22' }]}>
+          <MaterialCommunityIcons name="clock-outline" size={10} color={Colors.textSecondary} />
+          <Text style={[styles.tagText, { color: Colors.textSecondary }]}>{formatDueTime(dueTime)}</Text>
         </View>
       )}
       {urgencyLevel > 0 && (

--- a/src/components/TodoItem/index.tsx
+++ b/src/components/TodoItem/index.tsx
@@ -9,6 +9,7 @@ type Todo = {
   title: string;
   description?: string | null;
   dueDate?: number | null;
+  dueTime?: number | null;
   urgency?: number | null;
   importance?: number | null;
   isCompleted: number;
@@ -88,6 +89,7 @@ export default function TodoItem({
         )}
         <TodoItemMeta
           category={category}
+          dueTime={todo.dueTime}
           urgency={todo.urgency}
           importance={todo.importance}
         />

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -52,6 +52,8 @@ export const initDb = async () => {
     sqlite.execSync('ALTER TABLE todos ADD COLUMN is_deleted INTEGER NOT NULL DEFAULT 0;');
   if (!todoColumns.includes('deleted_at'))
     sqlite.execSync('ALTER TABLE todos ADD COLUMN deleted_at INTEGER;');
+  if (!todoColumns.includes('due_time'))
+    sqlite.execSync('ALTER TABLE todos ADD COLUMN due_time INTEGER;');
 
   sqlite.execSync(`
     CREATE TABLE IF NOT EXISTS app_settings (

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -18,6 +18,7 @@ export const todos = sqliteTable('todos', {
   title: text('title').notNull(),
   description: text('description'),
   dueDate: int('due_date'),
+  dueTime: int('due_time'), // minutes from midnight (0-1439), null = no time set
   urgency: int('urgency').default(0),
   importance: int('importance').default(0),
   sortOrder: int('sort_order').notNull().default(0),

--- a/src/hooks/useTodos.ts
+++ b/src/hooks/useTodos.ts
@@ -206,6 +206,7 @@ export const useCreateTodo = () => {
       title,
       description,
       dueDate,
+      dueTime,
       urgency,
       importance,
     }: {
@@ -213,6 +214,7 @@ export const useCreateTodo = () => {
       title: string;
       description?: string;
       dueDate?: number;
+      dueTime?: number | null;
       urgency?: number;
       importance?: number;
     }) => {
@@ -226,6 +228,7 @@ export const useCreateTodo = () => {
         title,
         description: description ?? null,
         dueDate: dueDate ?? null,
+        dueTime: dueTime ?? null,
         urgency: urgency ?? 0,
         importance: importance ?? 0,
         sortOrder: minOrder - 1,
@@ -246,6 +249,7 @@ export const useUpdateTodo = () => {
       title,
       description,
       dueDate,
+      dueTime,
       urgency,
       importance,
     }: {
@@ -254,6 +258,7 @@ export const useUpdateTodo = () => {
       title: string;
       description?: string;
       dueDate?: number;
+      dueTime?: number | null;
       urgency?: number;
       importance?: number;
     }) => {
@@ -262,6 +267,7 @@ export const useUpdateTodo = () => {
         title,
         description: description ?? null,
         dueDate: dueDate ?? null,
+        dueTime: dueTime ?? null,
         urgency: urgency ?? 0,
         importance: importance ?? 0,
         updatedAt: Date.now(),

--- a/src/screens/TodoFormScreen.tsx
+++ b/src/screens/TodoFormScreen.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { View, StyleSheet, ScrollView, TouchableOpacity } from 'react-native';
-import { Appbar, Text, TextInput, Button, SegmentedButtons, Divider, Dialog, Portal } from 'react-native-paper';
+import { Appbar, Text, TextInput, Button, IconButton, SegmentedButtons, Divider, Dialog, Portal } from 'react-native-paper';
 import { Colors } from '../theme';
 import DateTimePicker from '@react-native-community/datetimepicker';
 import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
@@ -33,7 +33,9 @@ export default function TodoFormScreen() {
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
   const [dueDate, setDueDate] = useState<Date>(getTodayMidnight);
+  const [dueTime, setDueTime] = useState<Date | null>(null); // null = 시간 없음
   const [showDatePicker, setShowDatePicker] = useState(false);
+  const [showTimePicker, setShowTimePicker] = useState(false);
   const [deleteDialogVisible, setDeleteDialogVisible] = useState(false);
 
   const [urgency, setUrgency] = useState('0');
@@ -45,6 +47,13 @@ export default function TodoFormScreen() {
     setTitle(todo?.title ?? '');
     setDescription(todo?.description ?? '');
     setDueDate(todo?.dueDate ? new Date(todo.dueDate) : getTodayMidnight());
+    if (todo?.dueTime != null) {
+      const t = new Date();
+      t.setHours(Math.floor(todo.dueTime / 60), todo.dueTime % 60, 0, 0);
+      setDueTime(t);
+    } else {
+      setDueTime(null);
+    }
     setUrgency(String(todo?.urgency ?? 0));
     setImportance(String(todo?.importance ?? 0));
     setCategoryId(todo?.categoryId ?? (categories[0]?.id ?? null));
@@ -56,6 +65,7 @@ export default function TodoFormScreen() {
       title: title.trim(),
       description: description.trim() || undefined,
       dueDate: new Date(dueDate.getFullYear(), dueDate.getMonth(), dueDate.getDate()).getTime(),
+      dueTime: dueTime ? dueTime.getHours() * 60 + dueTime.getMinutes() : null,
       urgency: Number(urgency),
       importance: Number(importance),
       categoryId,
@@ -141,6 +151,50 @@ export default function TodoFormScreen() {
         {showDatePicker && (
           <View style={styles.dateConfirmRow}>
             <Button mode="contained" onPress={() => setShowDatePicker(false)}>
+              확인
+            </Button>
+          </View>
+        )}
+
+        <Text variant="labelLarge" style={styles.label}>시간 (선택)</Text>
+        <View style={styles.timeRow}>
+          <TouchableOpacity
+            style={[styles.dateButton, styles.timeButton]}
+            onPress={() => {
+              if (!dueTime) {
+                const d = new Date();
+                d.setHours(9, 0, 0, 0);
+                setDueTime(d);
+              }
+              setShowTimePicker(true);
+            }}
+          >
+            <Text style={dueTime ? styles.dateText : styles.datePlaceholder}>
+              {dueTime
+                ? dueTime.toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit' })
+                : '설정 안 함'}
+            </Text>
+          </TouchableOpacity>
+          {dueTime && (
+            <IconButton icon="close-circle" size={20} onPress={() => setDueTime(null)} />
+          )}
+        </View>
+
+        {showTimePicker && (
+          <DateTimePicker
+            value={dueTime ?? new Date(new Date().setHours(9, 0, 0, 0))}
+            mode="time"
+            display="spinner"
+            locale="ko"
+            textColor="#F2F2F7"
+            onChange={(_, date) => {
+              if (date) setDueTime(date);
+            }}
+          />
+        )}
+        {showTimePicker && (
+          <View style={styles.dateConfirmRow}>
+            <Button mode="contained" onPress={() => setShowTimePicker(false)}>
               확인
             </Button>
           </View>
@@ -243,6 +297,8 @@ const styles = StyleSheet.create({
   datePlaceholder: { color: Colors.textMuted },
   dateClear: { fontSize: 14, color: Colors.textSecondary },
   dateConfirmRow: { flexDirection: 'row', justifyContent: 'flex-end', gap: 8, marginBottom: 8 },
+  timeRow: { flexDirection: 'row', alignItems: 'center', gap: 8, marginBottom: 12 },
+  timeButton: { flex: 1, marginBottom: 0 },
   divider: { marginVertical: 16 },
   categoryScroll: { marginBottom: 4 },
   categoryChip: {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -11,6 +11,7 @@ export interface Todo {
   title: string;
   description: string | null;
   dueDate: number | null;
+  dueTime: number | null; // minutes from midnight (0-1439), null = no time set
   urgency: number | null;
   importance: number | null;
   isCompleted: number; // 0 | 1 (SQLite boolean)


### PR DESCRIPTION
## 이슈
Closes #116
Part of #115

## 변경 사항
- `src/db/schema.ts` — `due_time` INT 컬럼 추가 (자정 기준 분, 0~1439, nullable)
- `src/db/index.ts` — 기존 DB에 `ALTER TABLE todos ADD COLUMN due_time INTEGER` 마이그레이션
- `src/types/index.ts` — `Todo` 타입에 `dueTime: number | null` 추가
- `src/screens/TodoFormScreen.tsx` — 시간 설정 UI (선택 가능, × 버튼으로 제거, 피커 열 때 기본값 오전 9:00 즉시 세팅)
- `src/hooks/useTodos.ts` — `useCreateTodo` / `useUpdateTodo` payload에 `dueTime` 추가
- `src/components/TodoItem/index.tsx` — `dueTime` prop 전달
- `src/components/TodoItem/TodoItemMeta.tsx` — 시간 설정 시 시계 아이콘 + 시간 태그 표시

## 테스트
- [ ] 새 할 일 등록 시 "시간 (선택)" 섹션 표시 확인
- [ ] 시간 탭 → 피커 열림 → 스피너 조작 없이 확인 탭 시 등록되는지 확인
- [ ] × 버튼으로 시간 제거 확인
- [ ] 저장 후 목록에서 시계 아이콘 + 시간 표시 확인
- [ ] 기존 할 일 수정 시 저장된 시간 복원 확인