### PR TITLE
#121 루틴 아이템 메타 정보 스타일을 할 일 아이템과 통일

### DIFF
--- a/src/components/RoutineItem.tsx
+++ b/src/components/RoutineItem.tsx
@@ -1,7 +1,7 @@
 import { View, StyleSheet, TouchableOpacity } from 'react-native';
 import { Text, Checkbox } from 'react-native-paper';
 import { Colors } from '../theme';
-import { LEVEL_LABELS } from '../constants/todo';
+import TodoItemMeta from './TodoItem/TodoItemMeta';
 
 type Category = {
   id: number;
@@ -14,18 +14,13 @@ type Props = {
   title: string;
   urgency?: number | null;
   importance?: number | null;
+  alarmTime?: number | null;
   category?: Category;
   isCompletedToday: boolean;
   onToggle: () => void;
 };
 
-const URGENCY_COLOR = Colors.urgency;
-const IMPORTANCE_COLOR = Colors.importance;
-
-export default function RoutineItem({ routineId: _, title, urgency, importance, category, isCompletedToday, onToggle }: Props) {
-  const urgencyLevel = urgency ?? 0;
-  const importanceLevel = importance ?? 0;
-
+export default function RoutineItem({ routineId: _, title, urgency, importance, alarmTime, category, isCompletedToday, onToggle }: Props) {
   return (
     <View style={styles.container}>
       <TouchableOpacity onPress={onToggle} activeOpacity={0.6} style={styles.checkboxArea}>
@@ -42,30 +37,16 @@ export default function RoutineItem({ routineId: _, title, urgency, importance, 
         >
           {title}
         </Text>
-        <View style={styles.meta}>
-          {category && (
-            <View style={[styles.categoryDot, { backgroundColor: category.color }]} />
-          )}
-          {category && (
-            <Text variant="labelSmall" style={[styles.metaText, { color: category.color }]}>
-              {category.name}
-            </Text>
-          )}
-          <Text variant="labelSmall" style={[styles.metaText, styles.routineTag]}>루틴</Text>
-          {urgencyLevel > 0 && (
-            <View style={[styles.badge, { backgroundColor: URGENCY_COLOR + '33' }]}>
-              <Text style={[styles.badgeText, { color: URGENCY_COLOR }]}>
-                긴급 {LEVEL_LABELS[urgencyLevel]}
-              </Text>
-            </View>
-          )}
-          {importanceLevel > 0 && (
-            <View style={[styles.badge, { backgroundColor: IMPORTANCE_COLOR + '33' }]}>
-              <Text style={[styles.badgeText, { color: IMPORTANCE_COLOR }]}>
-                중요 {LEVEL_LABELS[importanceLevel]}
-              </Text>
-            </View>
-          )}
+        <View style={styles.metaRow}>
+          <View style={styles.routineTag}>
+            <Text style={styles.routineTagText}>루틴</Text>
+          </View>
+          <TodoItemMeta
+            category={category}
+            dueTime={alarmTime}
+            urgency={urgency}
+            importance={importance}
+          />
         </View>
       </View>
     </View>
@@ -84,10 +65,12 @@ const styles = StyleSheet.create({
   content: { flex: 1, marginLeft: 4, paddingVertical: 4 },
   titleText: { flexShrink: 1 },
   completed: { textDecorationLine: 'line-through', color: Colors.textMuted },
-  meta: { flexDirection: 'row', alignItems: 'center', gap: 6, marginTop: 4, flexWrap: 'wrap' },
-  categoryDot: { width: 8, height: 8, borderRadius: 4 },
-  metaText: { color: Colors.textSecondary },
-  routineTag: { color: Colors.primary },
-  badge: { paddingHorizontal: 6, paddingVertical: 2, borderRadius: 4 },
-  badgeText: { fontSize: 10, fontWeight: '600' },
+  metaRow: { flexDirection: 'row', alignItems: 'center', flexWrap: 'wrap', marginTop: 4, gap: 6 },
+  routineTag: {
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    borderRadius: 4,
+    backgroundColor: Colors.primary + '22',
+  },
+  routineTagText: { fontSize: 10, fontWeight: '600', color: Colors.primary },
 });

--- a/src/components/TodoTabToday.tsx
+++ b/src/components/TodoTabToday.tsx
@@ -95,6 +95,7 @@ export default function TodoTabToday() {
                       title={routine.title}
                       urgency={routine.urgency}
                       importance={routine.importance}
+                      alarmTime={routine.alarmTime}
                       category={categoryMap.get(routine.categoryId)}
                       isCompletedToday={routine.isCompletedToday}
                       onToggle={() => toggleRoutine({ routineId: routine.id, date: today })}

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -87,6 +87,10 @@ export const initDb = async () => {
     );
   `);
 
+  const routineColumns = (sqlite.getAllSync('PRAGMA table_info(routines)') as { name: string }[]).map(c => c.name);
+  if (!routineColumns.includes('alarm_time'))
+    sqlite.execSync('ALTER TABLE routines ADD COLUMN alarm_time INTEGER;');
+
   sqlite.execSync(`
     CREATE TABLE IF NOT EXISTS routine_completions (
       id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -52,6 +52,7 @@ export const routines = sqliteTable('routines', {
   description: text('description'),
   repeatType: text('repeat_type').notNull(), // 'daily' | 'weekly' | 'monthly'
   repeatValue: text('repeat_value'),         // weekly: '1,3,5' (0=일), monthly: '15' (날짜)
+  alarmTime: int('alarm_time'), // minutes from midnight (0-1439), null = no alarm
   urgency: int('urgency').default(0),
   importance: int('importance').default(0),
   sortOrder: int('sort_order').notNull().default(0),

--- a/src/hooks/useRoutines.ts
+++ b/src/hooks/useRoutines.ts
@@ -23,6 +23,7 @@ export const useCreateRoutine = () => {
       description,
       repeatType,
       repeatValue,
+      alarmTime,
       urgency,
       importance,
     }: {
@@ -31,6 +32,7 @@ export const useCreateRoutine = () => {
       description?: string;
       repeatType: string;
       repeatValue?: string;
+      alarmTime?: number | null;
       urgency?: number;
       importance?: number;
     }) => {
@@ -43,6 +45,7 @@ export const useCreateRoutine = () => {
         description: description ?? null,
         repeatType,
         repeatValue: repeatValue ?? null,
+        alarmTime: alarmTime ?? null,
         urgency: urgency ?? 0,
         importance: importance ?? 0,
         sortOrder: maxOrder + 1,
@@ -67,6 +70,7 @@ export const useUpdateRoutine = () => {
       description,
       repeatType,
       repeatValue,
+      alarmTime,
       urgency,
       importance,
     }: {
@@ -76,6 +80,7 @@ export const useUpdateRoutine = () => {
       description?: string;
       repeatType: string;
       repeatValue?: string;
+      alarmTime?: number | null;
       urgency?: number;
       importance?: number;
     }) => {
@@ -85,6 +90,7 @@ export const useUpdateRoutine = () => {
         description: description ?? null,
         repeatType,
         repeatValue: repeatValue ?? null,
+        alarmTime: alarmTime ?? null,
         urgency: urgency ?? 0,
         importance: importance ?? 0,
         updatedAt: Date.now(),

--- a/src/screens/RoutineFormScreen.tsx
+++ b/src/screens/RoutineFormScreen.tsx
@@ -189,7 +189,7 @@ export default function RoutineFormScreen() {
 
         <Divider style={styles.divider} />
 
-        <Text variant="labelLarge" style={styles.label}>알람 시간 (선택)</Text>
+        <Text variant="labelLarge" style={styles.label}>시간</Text>
         <View style={styles.timeRow}>
           <TouchableOpacity
             style={[styles.dateButton, styles.timeButton]}

--- a/src/screens/RoutineFormScreen.tsx
+++ b/src/screens/RoutineFormScreen.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react';
 import { View, StyleSheet, ScrollView, TouchableOpacity } from 'react-native';
-import { Appbar, Text, TextInput, Button, Dialog, Portal, SegmentedButtons } from 'react-native-paper';
+import { Appbar, Text, TextInput, Button, IconButton, Dialog, Portal, SegmentedButtons, Divider } from 'react-native-paper';
 import { Colors } from '../theme';
+import DateTimePicker from '@react-native-community/datetimepicker';
 import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useCreateRoutine, useUpdateRoutine, useDeleteRoutine } from '../hooks/useRoutines';
@@ -39,6 +40,8 @@ export default function RoutineFormScreen() {
   const [repeatType, setRepeatType] = useState<'daily' | 'weekly' | 'monthly'>('daily');
   const [selectedDays, setSelectedDays] = useState<Set<string>>(new Set());
   const [selectedMonthDays, setSelectedMonthDays] = useState<Set<string>>(new Set());
+  const [alarmTime, setAlarmTime] = useState<Date | null>(null);
+  const [showTimePicker, setShowTimePicker] = useState(false);
   const [urgency, setUrgency] = useState('0');
   const [importance, setImportance] = useState('0');
   const [deleteDialogVisible, setDeleteDialogVisible] = useState(false);
@@ -54,6 +57,13 @@ export default function RoutineFormScreen() {
       }
       if (routine.repeatType === 'monthly' && routine.repeatValue) {
         setSelectedMonthDays(new Set(routine.repeatValue.split(',')));
+      }
+      if (routine.alarmTime != null) {
+        const t = new Date();
+        t.setHours(Math.floor(routine.alarmTime / 60), routine.alarmTime % 60, 0, 0);
+        setAlarmTime(t);
+      } else {
+        setAlarmTime(null);
       }
       setUrgency(String(routine.urgency ?? 0));
       setImportance(String(routine.importance ?? 0));
@@ -103,6 +113,7 @@ export default function RoutineFormScreen() {
       description: description.trim() || undefined,
       repeatType,
       repeatValue: getRepeatValue(),
+      alarmTime: alarmTime ? alarmTime.getHours() * 60 + alarmTime.getMinutes() : null,
       urgency: Number(urgency),
       importance: Number(importance),
     };
@@ -156,20 +167,73 @@ export default function RoutineFormScreen() {
         />
 
         <Text variant="labelLarge" style={styles.label}>카테고리 *</Text>
-        <View style={styles.chipRow}>
+        <ScrollView horizontal showsHorizontalScrollIndicator={false} style={styles.categoryScroll}>
           {categories.map((cat) => (
             <TouchableOpacity
               key={cat.id}
-              style={[styles.chip, categoryId === cat.id && { borderColor: cat.color, borderWidth: 2 }]}
               onPress={() => setCategoryId(cat.id)}
+              style={[
+                styles.categoryChip,
+                { backgroundColor: cat.color + '28' },
+                categoryId === cat.id
+                  ? { borderColor: cat.color }
+                  : { borderColor: 'transparent' },
+              ]}
             >
-              <View style={[styles.chipDot, { backgroundColor: cat.color }]} />
-              <Text variant="labelMedium" style={categoryId === cat.id ? { color: cat.color } : { color: Colors.textSecondary }}>
+              <Text style={[styles.categoryChipText, { color: cat.color }]}>
                 {cat.name}
               </Text>
             </TouchableOpacity>
           ))}
+        </ScrollView>
+
+        <Divider style={styles.divider} />
+
+        <Text variant="labelLarge" style={styles.label}>알람 시간 (선택)</Text>
+        <View style={styles.timeRow}>
+          <TouchableOpacity
+            style={[styles.dateButton, styles.timeButton]}
+            onPress={() => {
+              if (!alarmTime) {
+                const d = new Date();
+                d.setHours(9, 0, 0, 0);
+                setAlarmTime(d);
+              }
+              setShowTimePicker(true);
+            }}
+          >
+            <Text style={alarmTime ? styles.dateText : styles.datePlaceholder}>
+              {alarmTime
+                ? alarmTime.toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit' })
+                : '설정 안 함'}
+            </Text>
+          </TouchableOpacity>
+          {alarmTime && (
+            <IconButton icon="close-circle" size={20} onPress={() => setAlarmTime(null)} />
+          )}
         </View>
+
+        {showTimePicker && (
+          <DateTimePicker
+            value={alarmTime ?? new Date(new Date().setHours(9, 0, 0, 0))}
+            mode="time"
+            display="spinner"
+            locale="ko"
+            textColor="#F2F2F7"
+            onChange={(_, date) => {
+              if (date) setAlarmTime(date);
+            }}
+          />
+        )}
+        {showTimePicker && (
+          <View style={styles.confirmRow}>
+            <Button mode="contained" onPress={() => setShowTimePicker(false)}>
+              확인
+            </Button>
+          </View>
+        )}
+
+        <Divider style={styles.divider} />
 
         <Text variant="labelLarge" style={styles.label}>반복 주기 *</Text>
         <SegmentedButtons
@@ -257,7 +321,7 @@ export default function RoutineFormScreen() {
         {isEdit && (
           <Button
             mode="outlined"
-            textColor="#B03A2E"
+            textColor={Colors.dangerDark}
             icon="delete-outline"
             onPress={() => setDeleteDialogVisible(true)}
             style={styles.deleteButton}
@@ -278,7 +342,7 @@ export default function RoutineFormScreen() {
           </Dialog.Content>
           <Dialog.Actions>
             <Button onPress={() => setDeleteDialogVisible(false)}>취소</Button>
-            <Button textColor="#EA4335" onPress={handleDelete}>삭제</Button>
+            <Button textColor={Colors.danger} onPress={handleDelete}>삭제</Button>
           </Dialog.Actions>
         </Dialog>
       </Portal>
@@ -293,21 +357,35 @@ const styles = StyleSheet.create({
   descriptionInput: { minHeight: 80 },
   label: { marginBottom: 8, marginTop: 4 },
   subLabel: { marginBottom: 8, marginTop: 8, color: Colors.textSecondary },
+  divider: { marginVertical: 16 },
   segmented: { marginBottom: 16 },
-  chipRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 8, marginBottom: 16 },
-  dayGrid: { flexDirection: 'row', flexWrap: 'wrap', gap: 8, marginBottom: 16 },
-  chip: {
+  categoryScroll: { marginBottom: 4 },
+  categoryChip: {
+    borderWidth: 1.5,
+    borderRadius: 6,
+    paddingHorizontal: 10,
+    paddingVertical: 5,
+    marginRight: 8,
+  },
+  categoryChipText: { fontSize: 12, fontWeight: '600' },
+  timeRow: { flexDirection: 'row', alignItems: 'center', gap: 8, marginBottom: 12 },
+  timeButton: { flex: 1, marginBottom: 0 },
+  dateButton: {
     flexDirection: 'row',
     alignItems: 'center',
-    gap: 6,
-    paddingHorizontal: 12,
-    paddingVertical: 6,
-    borderRadius: 20,
-    backgroundColor: Colors.surfaceVariant,
-    borderWidth: 2,
-    borderColor: 'transparent',
+    borderWidth: 1,
+    borderColor: Colors.border,
+    borderRadius: 4,
+    paddingHorizontal: 14,
+    paddingVertical: 14,
+    marginBottom: 12,
+    backgroundColor: Colors.surface,
   },
-  chipDot: { width: 8, height: 8, borderRadius: 4 },
+  dateText: { fontSize: 15, color: Colors.text },
+  datePlaceholder: { color: Colors.textMuted },
+  confirmRow: { flexDirection: 'row', justifyContent: 'flex-end', gap: 8, marginBottom: 8 },
+  chipRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 8, marginBottom: 16 },
+  dayGrid: { flexDirection: 'row', flexWrap: 'wrap', gap: 8, marginBottom: 16 },
   dayChip: {
     width: 36,
     height: 36,

--- a/src/screens/RoutineManagementScreen.tsx
+++ b/src/screens/RoutineManagementScreen.tsx
@@ -8,7 +8,7 @@ import { useMemo } from 'react';
 import { useRoutines, useReorderRoutines } from '../hooks/useRoutines';
 import { useCategories } from '../hooks/useCategories';
 import { RoutineStackParamList } from '../navigation/RoutineStack';
-import { LEVEL_LABELS } from '../constants/todo';
+import TodoItemMeta from '../components/TodoItem/TodoItemMeta';
 
 type Nav = NativeStackNavigationProp<RoutineStackParamList, 'RoutineManagement'>;
 
@@ -19,18 +19,13 @@ type Routine = {
   description?: string | null;
   repeatType: string;
   repeatValue?: string | null;
+  alarmTime?: number | null;
   urgency: number | null;
   importance: number | null;
   sortOrder: number;
   isActive: number;
   createdAt: number;
   updatedAt: number;
-};
-
-const REPEAT_LABELS: Record<string, string> = {
-  daily: '매일',
-  weekly: '매주',
-  monthly: '매월',
 };
 
 const DAY_NAMES = ['일', '월', '화', '수', '목', '금', '토'];
@@ -47,11 +42,8 @@ function repeatDescription(routine: Routine): string {
       .join(', ');
     return `매월 ${days}`;
   }
-  return REPEAT_LABELS[routine.repeatType] ?? routine.repeatType;
+  return routine.repeatType;
 }
-
-const URGENCY_COLOR = Colors.urgency;
-const IMPORTANCE_COLOR = Colors.importance;
 
 export default function RoutineManagementScreen() {
   const navigation = useNavigation<Nav>();
@@ -66,8 +58,6 @@ export default function RoutineManagementScreen() {
 
   const renderItem = ({ item, drag, isActive }: RenderItemParams<Routine>) => {
     const category = categoryMap.get(item.categoryId);
-    const urgencyLevel = item.urgency ?? 0;
-    const importanceLevel = item.importance ?? 0;
 
     return (
       <ScaleDecorator>
@@ -79,30 +69,16 @@ export default function RoutineManagementScreen() {
         >
           <View style={styles.itemText}>
             <Text variant="bodyLarge">{item.title}</Text>
-            <View style={styles.meta}>
-              {category && (
-                <View style={[styles.categoryDot, { backgroundColor: category.color }]} />
-              )}
-              {category && (
-                <Text variant="labelSmall" style={[styles.metaText, { color: category.color }]}>
-                  {category.name}
-                </Text>
-              )}
-              <Text variant="labelSmall" style={styles.metaText}>{repeatDescription(item)}</Text>
-              {urgencyLevel > 0 && (
-                <View style={[styles.badge, { backgroundColor: URGENCY_COLOR + '33' }]}>
-                  <Text style={[styles.badgeText, { color: URGENCY_COLOR }]}>
-                    긴급 {LEVEL_LABELS[urgencyLevel]}
-                  </Text>
-                </View>
-              )}
-              {importanceLevel > 0 && (
-                <View style={[styles.badge, { backgroundColor: IMPORTANCE_COLOR + '33' }]}>
-                  <Text style={[styles.badgeText, { color: IMPORTANCE_COLOR }]}>
-                    중요 {LEVEL_LABELS[importanceLevel]}
-                  </Text>
-                </View>
-              )}
+            <View style={styles.metaRow}>
+              <View style={styles.repeatTag}>
+                <Text style={styles.repeatTagText}>{repeatDescription(item)}</Text>
+              </View>
+              <TodoItemMeta
+                category={category}
+                dueTime={item.alarmTime}
+                urgency={item.urgency}
+                importance={item.importance}
+              />
             </View>
           </View>
           <Text style={styles.dragHandle}>☰</Text>
@@ -152,11 +128,14 @@ const styles = StyleSheet.create({
   },
   itemDragging: { backgroundColor: Colors.surfaceVariant, elevation: 4 },
   itemText: { flex: 1 },
-  meta: { flexDirection: 'row', alignItems: 'center', gap: 6, marginTop: 4, flexWrap: 'wrap' },
-  categoryDot: { width: 8, height: 8, borderRadius: 4 },
-  metaText: { color: Colors.textSecondary },
-  badge: { paddingHorizontal: 6, paddingVertical: 2, borderRadius: 4 },
-  badgeText: { fontSize: 10, fontWeight: '600' },
+  metaRow: { flexDirection: 'row', alignItems: 'center', flexWrap: 'wrap', marginTop: 4, gap: 6 },
+  repeatTag: {
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    borderRadius: 4,
+    backgroundColor: Colors.surfaceVariant,
+  },
+  repeatTagText: { fontSize: 10, fontWeight: '600', color: Colors.textSecondary },
   dragHandle: { color: Colors.textMuted, fontSize: 18 },
   fab: { position: 'absolute', right: 16, bottom: 48 },
   empty: { textAlign: 'center', marginTop: 60, color: Colors.textMuted },

--- a/src/screens/TodoFormScreen.tsx
+++ b/src/screens/TodoFormScreen.tsx
@@ -210,14 +210,13 @@ export default function TodoFormScreen() {
               onPress={() => setCategoryId(cat.id)}
               style={[
                 styles.categoryChip,
-                { borderColor: cat.color },
-                categoryId === cat.id && { backgroundColor: cat.color },
+                { backgroundColor: cat.color + '28' },
+                categoryId === cat.id
+                  ? { borderColor: cat.color }
+                  : { borderColor: 'transparent' },
               ]}
             >
-              <Text style={[
-                styles.categoryChipText,
-                categoryId === cat.id && { color: '#fff' },
-              ]}>
+              <Text style={[styles.categoryChipText, { color: cat.color }]}>
                 {cat.name}
               </Text>
             </TouchableOpacity>
@@ -303,11 +302,11 @@ const styles = StyleSheet.create({
   categoryScroll: { marginBottom: 4 },
   categoryChip: {
     borderWidth: 1.5,
-    borderRadius: 20,
-    paddingHorizontal: 14,
-    paddingVertical: 6,
+    borderRadius: 6,
+    paddingHorizontal: 10,
+    paddingVertical: 5,
     marginRight: 8,
   },
-  categoryChipText: { fontSize: 13 },
+  categoryChipText: { fontSize: 12, fontWeight: '600' },
   segment: { marginBottom: 16 },
 });

--- a/src/screens/TodoFormScreen.tsx
+++ b/src/screens/TodoFormScreen.tsx
@@ -156,7 +156,7 @@ export default function TodoFormScreen() {
           </View>
         )}
 
-        <Text variant="labelLarge" style={styles.label}>시간 (선택)</Text>
+        <Text variant="labelLarge" style={styles.label}>시간</Text>
         <View style={styles.timeRow}>
           <TouchableOpacity
             style={[styles.dateButton, styles.timeButton]}


### PR DESCRIPTION
## 이슈
Closes #121

## 변경 사항
- `RoutineItem.tsx` — 인라인 메타 제거, `TodoItemMeta` 재사용. `alarmTime` prop 추가, 루틴 pill 태그 유지
- `RoutineManagementScreen.tsx` — 인라인 메타 제거, `TodoItemMeta` 재사용. 반복 주기를 회색 pill 태그로 표시
- `RoutineFormScreen.tsx` — 카테고리 칩을 `color+'28'` 반투명 배경 + 선택 시 테두리 스타일로 통일. 알람 시간 설정 UI 추가 (할 일 폼과 동일한 UX). `alarmTime` DB 컬럼 추가
- `TodoFormScreen.tsx` — 카테고리 칩 동일 스타일 적용 (반투명 배경, 점 제거, 선택 시 테두리)
- `TodoTabToday.tsx` — `RoutineItem`에 `alarmTime` 전달
- `src/db/schema.ts` / `src/db/index.ts` — `routines.alarm_time` 컬럼 추가 및 마이그레이션
- `src/hooks/useRoutines.ts` — create/update에 `alarmTime` payload 추가

## 테스트
- [ ] 오늘 탭 루틴 아이템 메타 스타일이 할 일 아이템과 동일한지 확인
- [ ] 루틴 관리 화면 아이템 메타 스타일 확인 (반복 주기 pill + TodoItemMeta)
- [ ] 루틴 등록 폼 카테고리 칩 스타일 확인 (반투명 배경, 선택 시 테두리)
- [ ] 루틴 등록 폼 알람 시간 설정/제거 동작 확인
- [ ] 할 일 등록 폼 카테고리 칩 스타일 확인