### PR TITLE
#117 [Phase 2] 알림

### DIFF
--- a/.claude/phase-map.json
+++ b/.claude/phase-map.json
@@ -7,14 +7,14 @@
       "title": "할 일 시간 설정",
       "issueNumber": 116,
       "branch": "feature/issue-115/due-time",
-      "status": "in_progress"
+      "status": "done"
     },
     {
       "number": 2,
       "title": "알림",
       "issueNumber": 117,
       "branch": "feature/issue-115/notifications",
-      "status": "pending"
+      "status": "in_progress"
     },
     {
       "number": 3,

--- a/App.tsx
+++ b/App.tsx
@@ -11,6 +11,7 @@ import MobileAds from 'react-native-google-mobile-ads';
 import { initDb } from './src/db';
 import { loadPremiumStatus } from './src/hooks/usePremiumStatus';
 import { configurePurchases } from './src/screens/PremiumScreen';
+import { requestNotificationPermission } from './src/utils/notifications';
 import RootNavigator from './src/navigation/RootNavigator';
 import { AppTheme, NavTheme } from './src/theme';
 
@@ -38,6 +39,7 @@ export default function App() {
     MobileAds().initialize()
       .then(() => initDb())
       .then(() => loadPremiumStatus())
+      .then(() => requestNotificationPermission())
       .then(async () => {
         // 최소 유지 시간 보장 후 앱 렌더링 → 스플래시 숨김
         const elapsed = Date.now() - start;

--- a/app.json
+++ b/app.json
@@ -33,6 +33,13 @@
     },
     "plugins": [
       "expo-sqlite",
+      [
+        "expo-notifications",
+        {
+          "icon": "./assets/icon.png",
+          "color": "#1E2030"
+        }
+      ],
       "@react-native-community/datetimepicker",
       [
         "react-native-google-mobile-ads",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "dependencies": {
         "@react-native-community/datetimepicker": "8.4.4",
         "@react-navigation/bottom-tabs": "^7.15.9",
-        "@react-navigation/drawer": "^7.9.8",
         "@react-navigation/native": "^7.2.2",
         "@react-navigation/native-stack": "^7.14.10",
         "@tanstack/react-query": "^5.96.2",
@@ -19,6 +18,7 @@
         "expo": "~54.0.33",
         "expo-build-properties": "~1.0.10",
         "expo-dev-client": "~6.0.20",
+        "expo-notifications": "~0.32.16",
         "expo-splash-screen": "~31.0.13",
         "expo-sqlite": "~16.0.10",
         "expo-status-bar": "~3.0.9",
@@ -3298,6 +3298,12 @@
       "integrity": "sha512-u2q9thI9vLurYZdGtyJsDYOqoeLc4EgQsYGSc+UVibYII61B/ENJPZS6eFlML1F0hSoTR/goptpo5nGRDkKd2w==",
       "license": "Apache-2.0"
     },
+    "node_modules/@ide/backoff": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@ide/backoff/-/backoff-1.0.0.tgz",
+      "integrity": "sha512-F0YfUDjvT+Mtt/R4xdl2X0EYCHMMiJqNLdxHD++jDT5ydEFIyqbCHh51Qx2E211dgZprPKhV7sHmnXKpLuvc5g==",
+      "license": "MIT"
+    },
     "node_modules/@isaacs/fs-minipass": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
@@ -4066,27 +4072,6 @@
         "react": ">= 18.2.0"
       }
     },
-    "node_modules/@react-navigation/drawer": {
-      "version": "7.9.8",
-      "resolved": "https://registry.npmjs.org/@react-navigation/drawer/-/drawer-7.9.8.tgz",
-      "integrity": "sha512-mSR5tgMaq5rtPQdpXL0ijzll8MSCGzpaflATitdyRZWEF29qS1XfQ2YHc0m4B/V4HyVQtaF7euEF5f7NMrc87w==",
-      "license": "MIT",
-      "dependencies": {
-        "@react-navigation/elements": "^2.9.14",
-        "color": "^4.2.3",
-        "react-native-drawer-layout": "^4.2.2",
-        "use-latest-callback": "^0.2.4"
-      },
-      "peerDependencies": {
-        "@react-navigation/native": "^7.2.2",
-        "react": ">= 18.2.0",
-        "react-native": "*",
-        "react-native-gesture-handler": ">= 2.0.0",
-        "react-native-reanimated": ">= 2.0.0",
-        "react-native-safe-area-context": ">= 4.0.0",
-        "react-native-screens": ">= 4.0.0"
-      }
-    },
     "node_modules/@react-navigation/elements": {
       "version": "2.9.14",
       "resolved": "https://registry.npmjs.org/@react-navigation/elements/-/elements-2.9.14.tgz",
@@ -4565,11 +4550,39 @@
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "license": "MIT"
     },
+    "node_modules/assert": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz",
+      "integrity": "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "is-nan": "^1.3.2",
+        "object-is": "^1.1.5",
+        "object.assign": "^4.1.4",
+        "util": "^0.12.5"
+      }
+    },
     "node_modules/async-limiter": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
       "license": "MIT"
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/await-lock": {
       "version": "2.2.2",
@@ -4847,6 +4860,12 @@
         "@babel/core": "^7.0.0"
       }
     },
+    "node_modules/badgin": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/badgin/-/badgin-1.2.3.tgz",
+      "integrity": "sha512-NQGA7LcfCpSzIbGRbkgjgdWkjy7HI+Th5VLxTJfW5EeaAf3fnS+xWQaQOCYiny+q6QSvxqoSO04vCx+4u++EJw==",
+      "license": "MIT"
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -5044,6 +5063,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/camelcase": {
@@ -5454,6 +5520,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/define-lazy-prop": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
@@ -5461,6 +5544,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/depd": {
@@ -5668,6 +5768,20 @@
         }
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -5711,6 +5825,36 @@
       "license": "MIT",
       "dependencies": {
         "stackframe": "^1.3.4"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/esbuild": {
@@ -5863,6 +6007,15 @@
         "react-native-webview": {
           "optional": true
         }
+      }
+    },
+    "node_modules/expo-application": {
+      "version": "7.0.8",
+      "resolved": "https://registry.npmjs.org/expo-application/-/expo-application-7.0.8.tgz",
+      "integrity": "sha512-qFGyxk7VJbrNOQWBbE09XUuGuvkOgFS9QfToaK2FdagM2aQ+x3CvGV2DuVgl/l4ZxPgIf3b/MNh9xHpwSwn74Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-asset": {
@@ -6088,6 +6241,26 @@
         "invariant": "^2.2.4"
       },
       "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-notifications": {
+      "version": "0.32.16",
+      "resolved": "https://registry.npmjs.org/expo-notifications/-/expo-notifications-0.32.16.tgz",
+      "integrity": "sha512-QQD/UA6v7LgvwIJ+tS7tSvqJZkdp0nCSj9MxsDk/jU1GttYdK49/5L2LvE/4U0H7sNBz1NZAyhDZozg8xgBLXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/image-utils": "^0.8.8",
+        "@ide/backoff": "^1.0.0",
+        "abort-controller": "^3.0.0",
+        "assert": "^2.0.0",
+        "badgin": "^1.1.5",
+        "expo-application": "~7.0.8",
+        "expo-constants": "~18.0.13"
+      },
+      "peerDependencies": {
+        "expo": "*",
         "react": "*",
         "react-native": "*"
       }
@@ -6488,6 +6661,21 @@
       "integrity": "sha512-6FPvD/IVyT4ZlNe7Wcn5Fb/4ChigpucKYSvD6a+0iMoLn2inpo711eyIcKjmDtE5XNcgAkSH9uN/nfAeZzHEfg==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/freeport-async": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/freeport-async/-/freeport-async-2.0.0.tgz",
@@ -6535,6 +6723,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -6553,6 +6750,30 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/get-package-type": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
@@ -6560,6 +6781,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-tsconfig": {
@@ -6637,6 +6871,18 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -6650,6 +6896,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/hasown": {
@@ -6854,11 +7139,39 @@
         "loose-envify": "^1.0.0"
       }
     },
+    "node_modules/is-arguments": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
       "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
       "license": "MIT"
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/is-core-module": {
       "version": "2.16.1",
@@ -6899,6 +7212,41 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-generator-function": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-nan": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
+      "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -6906,6 +7254,39 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-wsl": {
@@ -7752,6 +8133,15 @@
       "integrity": "sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==",
       "license": "Apache-2.0"
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/memoize-one": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
@@ -8383,6 +8773,51 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/object-is": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -8657,6 +9092,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=4.0.0"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/postcss": {
@@ -8963,22 +9407,6 @@
         "react-native": ">=0.64.0",
         "react-native-gesture-handler": ">=2.0.0",
         "react-native-reanimated": ">=2.8.0"
-      }
-    },
-    "node_modules/react-native-drawer-layout": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/react-native-drawer-layout/-/react-native-drawer-layout-4.2.2.tgz",
-      "integrity": "sha512-UG/PTTeyyr43KahbgoGyXri8LMO5USHY3/RUpeKBKwCc7xLVGnDLOVNSRrJw0dDc7YmPbmAyJ4oxp8nKboKKuw==",
-      "license": "MIT",
-      "dependencies": {
-        "color": "^4.2.3",
-        "use-latest-callback": "^0.2.4"
-      },
-      "peerDependencies": {
-        "react": ">= 18.2.0",
-        "react-native": "*",
-        "react-native-gesture-handler": ">= 2.0.0",
-        "react-native-reanimated": ">= 2.0.0"
       }
     },
     "node_modules/react-native-gesture-handler": {
@@ -9555,6 +9983,23 @@
       ],
       "license": "MIT"
     },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/sax": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
@@ -9682,6 +10127,23 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/setimmediate": {
@@ -10974,6 +11436,19 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/util": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "which-typed-array": "^1.1.2"
+      }
+    },
     "node_modules/utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -11098,6 +11573,27 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/wonka": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@react-native-community/datetimepicker": "8.4.4",
     "@react-navigation/bottom-tabs": "^7.15.9",
-"@react-navigation/native": "^7.2.2",
+    "@react-navigation/native": "^7.2.2",
     "@react-navigation/native-stack": "^7.14.10",
     "@tanstack/react-query": "^5.96.2",
     "dayjs": "^1.11.20",
@@ -24,6 +24,7 @@
     "expo": "~54.0.33",
     "expo-build-properties": "~1.0.10",
     "expo-dev-client": "~6.0.20",
+    "expo-notifications": "~0.32.16",
     "expo-splash-screen": "~31.0.13",
     "expo-sqlite": "~16.0.10",
     "expo-status-bar": "~3.0.9",

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -54,6 +54,8 @@ export const initDb = async () => {
     sqlite.execSync('ALTER TABLE todos ADD COLUMN deleted_at INTEGER;');
   if (!todoColumns.includes('due_time'))
     sqlite.execSync('ALTER TABLE todos ADD COLUMN due_time INTEGER;');
+  if (!todoColumns.includes('notification_offsets'))
+    sqlite.execSync('ALTER TABLE todos ADD COLUMN notification_offsets TEXT;');
 
   sqlite.execSync(`
     CREATE TABLE IF NOT EXISTS app_settings (
@@ -90,6 +92,8 @@ export const initDb = async () => {
   const routineColumns = (sqlite.getAllSync('PRAGMA table_info(routines)') as { name: string }[]).map(c => c.name);
   if (!routineColumns.includes('alarm_time'))
     sqlite.execSync('ALTER TABLE routines ADD COLUMN alarm_time INTEGER;');
+  if (!routineColumns.includes('notification_offsets'))
+    sqlite.execSync('ALTER TABLE routines ADD COLUMN notification_offsets TEXT;');
 
   sqlite.execSync(`
     CREATE TABLE IF NOT EXISTS routine_completions (

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -19,6 +19,7 @@ export const todos = sqliteTable('todos', {
   description: text('description'),
   dueDate: int('due_date'),
   dueTime: int('due_time'), // minutes from midnight (0-1439), null = no time set
+  notificationOffsets: text('notification_offsets'), // comma-separated offset minutes e.g. "0,10,30"
   urgency: int('urgency').default(0),
   importance: int('importance').default(0),
   sortOrder: int('sort_order').notNull().default(0),
@@ -53,6 +54,7 @@ export const routines = sqliteTable('routines', {
   repeatType: text('repeat_type').notNull(), // 'daily' | 'weekly' | 'monthly'
   repeatValue: text('repeat_value'),         // weekly: '1,3,5' (0=일), monthly: '15' (날짜)
   alarmTime: int('alarm_time'), // minutes from midnight (0-1439), null = no alarm
+  notificationOffsets: text('notification_offsets'), // comma-separated offset minutes e.g. "0,10,30"
   urgency: int('urgency').default(0),
   importance: int('importance').default(0),
   sortOrder: int('sort_order').notNull().default(0),

--- a/src/hooks/useRoutines.ts
+++ b/src/hooks/useRoutines.ts
@@ -3,6 +3,7 @@ import { and, asc, eq } from 'drizzle-orm';
 import dayjs from 'dayjs';
 import { db } from '../db';
 import { routines, routineCompletions } from '../db/schema';
+import { scheduleRoutineNotifications, cancelRoutineNotifications, offsetsToString } from '../utils/notifications';
 
 export const useRoutines = () =>
   useQuery({
@@ -24,6 +25,7 @@ export const useCreateRoutine = () => {
       repeatType,
       repeatValue,
       alarmTime,
+      notificationOffsets,
       urgency,
       importance,
     }: {
@@ -33,25 +35,31 @@ export const useCreateRoutine = () => {
       repeatType: string;
       repeatValue?: string;
       alarmTime?: number | null;
+      notificationOffsets?: number[];
       urgency?: number;
       importance?: number;
     }) => {
       const all = db.select().from(routines).all();
       const maxOrder = all.reduce((max, r) => Math.max(max, r.sortOrder), 0);
       const now = Date.now();
-      await db.insert(routines).values({
+      const offsets = notificationOffsets ?? [];
+      const result = await db.insert(routines).values({
         categoryId,
         title,
         description: description ?? null,
         repeatType,
         repeatValue: repeatValue ?? null,
         alarmTime: alarmTime ?? null,
+        notificationOffsets: offsets.length > 0 ? offsetsToString(offsets) : null,
         urgency: urgency ?? 0,
         importance: importance ?? 0,
         sortOrder: maxOrder + 1,
         createdAt: now,
         updatedAt: now,
-      }).run();
+      }).returning({ id: routines.id }).get();
+      if (result && alarmTime != null && offsets.length > 0) {
+        scheduleRoutineNotifications({ id: result.id, title, alarmTime, notificationOffsets: offsets }).catch(() => {});
+      }
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['routines'] });
@@ -71,6 +79,7 @@ export const useUpdateRoutine = () => {
       repeatType,
       repeatValue,
       alarmTime,
+      notificationOffsets,
       urgency,
       importance,
     }: {
@@ -81,9 +90,11 @@ export const useUpdateRoutine = () => {
       repeatType: string;
       repeatValue?: string;
       alarmTime?: number | null;
+      notificationOffsets?: number[];
       urgency?: number;
       importance?: number;
     }) => {
+      const offsets = notificationOffsets ?? [];
       await db.update(routines).set({
         categoryId,
         title,
@@ -91,10 +102,15 @@ export const useUpdateRoutine = () => {
         repeatType,
         repeatValue: repeatValue ?? null,
         alarmTime: alarmTime ?? null,
+        notificationOffsets: offsets.length > 0 ? offsetsToString(offsets) : null,
         urgency: urgency ?? 0,
         importance: importance ?? 0,
         updatedAt: Date.now(),
       }).where(eq(routines.id, id)).run();
+      await cancelRoutineNotifications(id);
+      if (alarmTime != null && offsets.length > 0) {
+        scheduleRoutineNotifications({ id, title, alarmTime, notificationOffsets: offsets }).catch(() => {});
+      }
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['routines'] });
@@ -111,6 +127,7 @@ export const useDeleteRoutine = () => {
         isActive: 0,
         updatedAt: Date.now(),
       }).where(eq(routines.id, id)).run();
+      cancelRoutineNotifications(id).catch(() => {});
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['routines'] });

--- a/src/hooks/useTodos.ts
+++ b/src/hooks/useTodos.ts
@@ -3,6 +3,7 @@ import { and, asc, desc, eq, gte, isNull, lt, or } from 'drizzle-orm';
 import dayjs from 'dayjs';
 import { db } from '../db';
 import { todos, todoCompletions } from '../db/schema';
+import { scheduleTodoNotifications, cancelTodoNotifications, offsetsToString } from '../utils/notifications';
 
 export const useTodos = (isCompleted: 0 | 1) =>
   useQuery({
@@ -207,6 +208,7 @@ export const useCreateTodo = () => {
       description,
       dueDate,
       dueTime,
+      notificationOffsets,
       urgency,
       importance,
     }: {
@@ -215,6 +217,7 @@ export const useCreateTodo = () => {
       description?: string;
       dueDate?: number;
       dueTime?: number | null;
+      notificationOffsets?: number[];
       urgency?: number;
       importance?: number;
     }) => {
@@ -223,18 +226,23 @@ export const useCreateTodo = () => {
         .all();
       const minOrder = all.reduce((min, t) => Math.min(min, t.sortOrder), 0);
       const now = Date.now();
-      await db.insert(todos).values({
+      const offsets = notificationOffsets ?? [];
+      const result = await db.insert(todos).values({
         categoryId,
         title,
         description: description ?? null,
         dueDate: dueDate ?? null,
         dueTime: dueTime ?? null,
+        notificationOffsets: offsets.length > 0 ? offsetsToString(offsets) : null,
         urgency: urgency ?? 0,
         importance: importance ?? 0,
         sortOrder: minOrder - 1,
         createdAt: now,
         updatedAt: now,
-      }).run();
+      }).returning({ id: todos.id }).get();
+      if (result && dueDate != null && dueTime != null && offsets.length > 0) {
+        scheduleTodoNotifications({ id: result.id, title, dueDate, dueTime, notificationOffsets: offsets }).catch(() => {});
+      }
     },
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['todos'] }),
   });
@@ -250,6 +258,7 @@ export const useUpdateTodo = () => {
       description,
       dueDate,
       dueTime,
+      notificationOffsets,
       urgency,
       importance,
     }: {
@@ -259,19 +268,26 @@ export const useUpdateTodo = () => {
       description?: string;
       dueDate?: number;
       dueTime?: number | null;
+      notificationOffsets?: number[];
       urgency?: number;
       importance?: number;
     }) => {
+      const offsets = notificationOffsets ?? [];
       await db.update(todos).set({
         categoryId,
         title,
         description: description ?? null,
         dueDate: dueDate ?? null,
         dueTime: dueTime ?? null,
+        notificationOffsets: offsets.length > 0 ? offsetsToString(offsets) : null,
         urgency: urgency ?? 0,
         importance: importance ?? 0,
         updatedAt: Date.now(),
       }).where(eq(todos.id, id)).run();
+      await cancelTodoNotifications(id);
+      if (dueDate != null && dueTime != null && offsets.length > 0) {
+        scheduleTodoNotifications({ id, title, dueDate, dueTime, notificationOffsets: offsets }).catch(() => {});
+      }
     },
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['todos'] }),
   });
@@ -288,6 +304,9 @@ export const useToggleTodo = () => {
         completedAt: newCompleted === 1 ? now : null,
         updatedAt: now,
       }).where(eq(todos.id, id)).run();
+      if (newCompleted === 1) {
+        cancelTodoNotifications(id).catch(() => {});
+      }
 
       const today = new Date().toISOString().split('T')[0];
       if (newCompleted === 1) {
@@ -315,6 +334,7 @@ export const useDeleteTodo = () => {
         deletedAt: Date.now(),
         updatedAt: Date.now(),
       }).where(eq(todos.id, id)).run();
+      cancelTodoNotifications(id).catch(() => {});
     },
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['todos'] }),
   });

--- a/src/screens/RoutineFormScreen.tsx
+++ b/src/screens/RoutineFormScreen.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { View, StyleSheet, ScrollView, TouchableOpacity } from 'react-native';
-import { Appbar, Text, TextInput, Button, IconButton, Dialog, Portal, SegmentedButtons, Divider } from 'react-native-paper';
+import { Appbar, Text, TextInput, Button, IconButton, Dialog, Portal, SegmentedButtons, Divider, Checkbox } from 'react-native-paper';
 import { Colors } from '../theme';
 import DateTimePicker from '@react-native-community/datetimepicker';
 import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
@@ -9,6 +9,7 @@ import { useCreateRoutine, useUpdateRoutine, useDeleteRoutine } from '../hooks/u
 import { useCategories } from '../hooks/useCategories';
 import { RoutineStackParamList } from '../navigation/RoutineStack';
 import { LEVEL_OPTIONS } from '../constants/todo';
+import { OFFSET_OPTIONS, offsetsFromString, offsetLabel } from '../utils/notifications';
 
 type Nav = NativeStackNavigationProp<RoutineStackParamList, 'RoutineForm'>;
 type Route = RouteProp<RoutineStackParamList, 'RoutineForm'>;
@@ -42,6 +43,9 @@ export default function RoutineFormScreen() {
   const [selectedMonthDays, setSelectedMonthDays] = useState<Set<string>>(new Set());
   const [alarmTime, setAlarmTime] = useState<Date | null>(null);
   const [showTimePicker, setShowTimePicker] = useState(false);
+  const [notificationOffsets, setNotificationOffsets] = useState<number[]>([]);
+  const [showNotifDialog, setShowNotifDialog] = useState(false);
+  const [pendingOffsets, setPendingOffsets] = useState<number[]>([]);
   const [urgency, setUrgency] = useState('0');
   const [importance, setImportance] = useState('0');
   const [deleteDialogVisible, setDeleteDialogVisible] = useState(false);
@@ -65,6 +69,7 @@ export default function RoutineFormScreen() {
       } else {
         setAlarmTime(null);
       }
+      setNotificationOffsets(offsetsFromString((routine as any)?.notificationOffsets));
       setUrgency(String(routine.urgency ?? 0));
       setImportance(String(routine.importance ?? 0));
     } else {
@@ -114,6 +119,7 @@ export default function RoutineFormScreen() {
       repeatType,
       repeatValue: getRepeatValue(),
       alarmTime: alarmTime ? alarmTime.getHours() * 60 + alarmTime.getMinutes() : null,
+      notificationOffsets: alarmTime ? notificationOffsets : [],
       urgency: Number(urgency),
       importance: Number(importance),
     };
@@ -233,6 +239,32 @@ export default function RoutineFormScreen() {
           </View>
         )}
 
+        {alarmTime && (
+          <View style={styles.notifRow}>
+            <Button
+              mode="outlined"
+              icon="bell-outline"
+              compact
+              onPress={() => {
+                setPendingOffsets([...notificationOffsets]);
+                setShowNotifDialog(true);
+              }}
+              style={styles.notifBtn}
+            >
+              알림 설정
+            </Button>
+            {notificationOffsets.length > 0 && (
+              <View style={styles.notifTagRow}>
+                {notificationOffsets.map((o) => (
+                  <View key={o} style={styles.notifTag}>
+                    <Text style={styles.notifTagText}>{offsetLabel(o)}</Text>
+                  </View>
+                ))}
+              </View>
+            )}
+          </View>
+        )}
+
         <Divider style={styles.divider} />
 
         <Text variant="labelLarge" style={styles.label}>반복 주기 *</Text>
@@ -346,6 +378,41 @@ export default function RoutineFormScreen() {
           </Dialog.Actions>
         </Dialog>
       </Portal>
+
+      {showNotifDialog && (
+        <Portal>
+          <Dialog visible onDismiss={() => setShowNotifDialog(false)}>
+            <Dialog.Title>알림 설정</Dialog.Title>
+            <Dialog.Content>
+              {OFFSET_OPTIONS.map((opt) => (
+                <TouchableOpacity
+                  key={opt.value}
+                  style={styles.checkRow}
+                  onPress={() => {
+                    setPendingOffsets((prev) =>
+                      prev.includes(opt.value)
+                        ? prev.filter((v) => v !== opt.value)
+                        : [...prev, opt.value],
+                    );
+                  }}
+                >
+                  <Checkbox.Android
+                    status={pendingOffsets.includes(opt.value) ? 'checked' : 'unchecked'}
+                    color={Colors.primary}
+                  />
+                  <Text variant="bodyMedium">{opt.label}</Text>
+                </TouchableOpacity>
+              ))}
+            </Dialog.Content>
+            <Dialog.Actions>
+              <Button onPress={() => setShowNotifDialog(false)}>취소</Button>
+              <Button onPress={() => { setNotificationOffsets(pendingOffsets); setShowNotifDialog(false); }}>
+                확인
+              </Button>
+            </Dialog.Actions>
+          </Dialog>
+        </Portal>
+      )}
     </View>
   );
 }
@@ -409,4 +476,15 @@ const styles = StyleSheet.create({
   actionButtonLabel: { fontSize: 14 },
   deleteButton: { marginTop: 8 },
   bold: { fontWeight: 'bold' },
+  notifRow: { marginBottom: 12 },
+  notifBtn: { alignSelf: 'flex-start' },
+  notifTagRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 6, marginTop: 8 },
+  notifTag: {
+    backgroundColor: Colors.primary + '22',
+    borderRadius: 4,
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+  },
+  notifTagText: { fontSize: 12, color: Colors.primary },
+  checkRow: { flexDirection: 'row', alignItems: 'center', paddingVertical: 6 },
 });

--- a/src/screens/TodoFormScreen.tsx
+++ b/src/screens/TodoFormScreen.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { View, StyleSheet, ScrollView, TouchableOpacity } from 'react-native';
-import { Appbar, Text, TextInput, Button, IconButton, SegmentedButtons, Divider, Dialog, Portal } from 'react-native-paper';
+import { Appbar, Text, TextInput, Button, IconButton, SegmentedButtons, Divider, Dialog, Portal, Checkbox } from 'react-native-paper';
 import { Colors } from '../theme';
 import DateTimePicker from '@react-native-community/datetimepicker';
 import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
@@ -9,6 +9,7 @@ import { useCategories } from '../hooks/useCategories';
 import { useCreateTodo, useUpdateTodo, useDeleteTodo } from '../hooks/useTodos';
 import { TodoStackParamList } from '../navigation/TodoStack';
 import { LEVEL_OPTIONS } from '../constants/todo';
+import { OFFSET_OPTIONS, offsetsFromString, offsetLabel } from '../utils/notifications';
 
 type Nav = NativeStackNavigationProp<TodoStackParamList, 'TodoForm'>;
 type Route = RouteProp<TodoStackParamList, 'TodoForm'>;
@@ -33,9 +34,12 @@ export default function TodoFormScreen() {
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
   const [dueDate, setDueDate] = useState<Date>(getTodayMidnight);
-  const [dueTime, setDueTime] = useState<Date | null>(null); // null = 시간 없음
+  const [dueTime, setDueTime] = useState<Date | null>(null);
   const [showDatePicker, setShowDatePicker] = useState(false);
   const [showTimePicker, setShowTimePicker] = useState(false);
+  const [notificationOffsets, setNotificationOffsets] = useState<number[]>([]);
+  const [showNotifDialog, setShowNotifDialog] = useState(false);
+  const [pendingOffsets, setPendingOffsets] = useState<number[]>([]);
   const [deleteDialogVisible, setDeleteDialogVisible] = useState(false);
 
   const [urgency, setUrgency] = useState('0');
@@ -54,6 +58,7 @@ export default function TodoFormScreen() {
     } else {
       setDueTime(null);
     }
+    setNotificationOffsets(offsetsFromString((todo as any)?.notificationOffsets));
     setUrgency(String(todo?.urgency ?? 0));
     setImportance(String(todo?.importance ?? 0));
     setCategoryId(todo?.categoryId ?? (categories[0]?.id ?? null));
@@ -66,6 +71,7 @@ export default function TodoFormScreen() {
       description: description.trim() || undefined,
       dueDate: new Date(dueDate.getFullYear(), dueDate.getMonth(), dueDate.getDate()).getTime(),
       dueTime: dueTime ? dueTime.getHours() * 60 + dueTime.getMinutes() : null,
+      notificationOffsets: dueTime ? notificationOffsets : [],
       urgency: Number(urgency),
       importance: Number(importance),
       categoryId,
@@ -200,6 +206,32 @@ export default function TodoFormScreen() {
           </View>
         )}
 
+        {dueTime && (
+          <View style={styles.notifRow}>
+            <Button
+              mode="outlined"
+              icon="bell-outline"
+              compact
+              onPress={() => {
+                setPendingOffsets([...notificationOffsets]);
+                setShowNotifDialog(true);
+              }}
+              style={styles.notifBtn}
+            >
+              알림 설정
+            </Button>
+            {notificationOffsets.length > 0 && (
+              <View style={styles.notifTagRow}>
+                {notificationOffsets.map((o) => (
+                  <View key={o} style={styles.notifTag}>
+                    <Text style={styles.notifTagText}>{offsetLabel(o)}</Text>
+                  </View>
+                ))}
+              </View>
+            )}
+          </View>
+        )}
+
         <Divider style={styles.divider} />
 
         <Text variant="labelLarge" style={styles.label}>카테고리</Text>
@@ -267,6 +299,41 @@ export default function TodoFormScreen() {
           </Dialog.Actions>
         </Dialog>
       </Portal>
+
+      {showNotifDialog && (
+        <Portal>
+          <Dialog visible onDismiss={() => setShowNotifDialog(false)}>
+            <Dialog.Title>알림 설정</Dialog.Title>
+            <Dialog.Content>
+              {OFFSET_OPTIONS.map((opt) => (
+                <TouchableOpacity
+                  key={opt.value}
+                  style={styles.checkRow}
+                  onPress={() => {
+                    setPendingOffsets((prev) =>
+                      prev.includes(opt.value)
+                        ? prev.filter((v) => v !== opt.value)
+                        : [...prev, opt.value],
+                    );
+                  }}
+                >
+                  <Checkbox.Android
+                    status={pendingOffsets.includes(opt.value) ? 'checked' : 'unchecked'}
+                    color={Colors.primary}
+                  />
+                  <Text variant="bodyMedium">{opt.label}</Text>
+                </TouchableOpacity>
+              ))}
+            </Dialog.Content>
+            <Dialog.Actions>
+              <Button onPress={() => setShowNotifDialog(false)}>취소</Button>
+              <Button onPress={() => { setNotificationOffsets(pendingOffsets); setShowNotifDialog(false); }}>
+                확인
+              </Button>
+            </Dialog.Actions>
+          </Dialog>
+        </Portal>
+      )}
     </View>
   );
 }
@@ -309,4 +376,15 @@ const styles = StyleSheet.create({
   },
   categoryChipText: { fontSize: 12, fontWeight: '600' },
   segment: { marginBottom: 16 },
+  notifRow: { marginBottom: 12 },
+  notifBtn: { alignSelf: 'flex-start' },
+  notifTagRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 6, marginTop: 8 },
+  notifTag: {
+    backgroundColor: Colors.primary + '22',
+    borderRadius: 4,
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+  },
+  notifTagText: { fontSize: 12, color: Colors.primary },
+  checkRow: { flexDirection: 'row', alignItems: 'center', paddingVertical: 6 },
 });

--- a/src/utils/notifications.ts
+++ b/src/utils/notifications.ts
@@ -1,0 +1,109 @@
+import * as Notifications from 'expo-notifications';
+
+// 앱 포그라운드에서도 알림 표시
+Notifications.setNotificationHandler({
+  handleNotification: async () => ({
+    shouldShowAlert: true,
+    shouldPlaySound: true,
+    shouldSetBadge: false,
+    shouldShowBanner: true,
+    shouldShowList: true,
+  }),
+});
+
+export const OFFSET_OPTIONS = [
+  { value: 0,   label: '정시' },
+  { value: 10,  label: '10분 전' },
+  { value: 30,  label: '30분 전' },
+  { value: 60,  label: '1시간 전' },
+  { value: 120, label: '2시간 전' },
+];
+
+export function offsetsToString(offsets: number[]): string {
+  return offsets.sort((a, b) => a - b).join(',');
+}
+
+export function offsetsFromString(str: string | null | undefined): number[] {
+  if (!str) return [];
+  return str.split(',').map(Number).filter((n) => !isNaN(n));
+}
+
+export function offsetLabel(offset: number): string {
+  return OFFSET_OPTIONS.find((o) => o.value === offset)?.label ?? `${offset}분 전`;
+}
+
+export async function requestNotificationPermission(): Promise<boolean> {
+  const { status } = await Notifications.requestPermissionsAsync();
+  return status === 'granted';
+}
+
+/** 할 일 알림 전체 예약. 기존 예약은 모두 취소 후 재예약 */
+export async function scheduleTodoNotifications(todo: {
+  id: number;
+  title: string;
+  dueDate: number;
+  dueTime: number;
+  notificationOffsets: number[];
+}): Promise<void> {
+  await cancelTodoNotifications(todo.id);
+  const dueMoment = todo.dueDate + todo.dueTime * 60 * 1000;
+
+  for (const offset of todo.notificationOffsets) {
+    const triggerAt = new Date(dueMoment - offset * 60 * 1000);
+    if (triggerAt <= new Date()) continue;
+
+    await Notifications.scheduleNotificationAsync({
+      identifier: `todo-${todo.id}-${offset}`,
+      content: {
+        title: offset === 0 ? '지금' : offsetLabel(offset),
+        body: todo.title,
+      },
+      trigger: {
+        type: Notifications.SchedulableTriggerInputTypes.DATE,
+        date: triggerAt,
+      },
+    });
+  }
+}
+
+/** 루틴 알림 전체 예약. 기존 예약은 모두 취소 후 재예약 */
+export async function scheduleRoutineNotifications(routine: {
+  id: number;
+  title: string;
+  alarmTime: number;
+  notificationOffsets: number[];
+}): Promise<void> {
+  await cancelRoutineNotifications(routine.id);
+  const now = new Date();
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const alarmMoment = today.getTime() + routine.alarmTime * 60 * 1000;
+
+  for (const offset of routine.notificationOffsets) {
+    const triggerAt = new Date(alarmMoment - offset * 60 * 1000);
+    if (triggerAt <= now) continue;
+
+    await Notifications.scheduleNotificationAsync({
+      identifier: `routine-${routine.id}-${offset}`,
+      content: {
+        title: offset === 0 ? '지금' : offsetLabel(offset),
+        body: routine.title,
+      },
+      trigger: {
+        type: Notifications.SchedulableTriggerInputTypes.DATE,
+        date: triggerAt,
+      },
+    });
+  }
+}
+
+export async function cancelTodoNotifications(todoId: number): Promise<void> {
+  for (const { value } of OFFSET_OPTIONS) {
+    await Notifications.cancelScheduledNotificationAsync(`todo-${todoId}-${value}`).catch(() => {});
+  }
+}
+
+export async function cancelRoutineNotifications(routineId: number): Promise<void> {
+  for (const { value } of OFFSET_OPTIONS) {
+    await Notifications.cancelScheduledNotificationAsync(`routine-${routineId}-${value}`).catch(() => {});
+  }
+}


### PR DESCRIPTION
## 이슈
Closes #117

## 변경 사항
- `app.json` — expo-notifications 플러그인 추가
- `src/utils/notifications.ts` — 신규: 알림 권한 요청, 할 일/루틴 알림 예약·취소 유틸
- `src/db/schema.ts` / `src/db/index.ts` — todos에 `notification_offsets` 컬럼, routines에 `alarm_time` / `notification_offsets` 컬럼 추가 및 마이그레이션
- `src/hooks/useTodos.ts` — create/update/delete/toggle에 알림 스케줄링 연동
- `src/hooks/useRoutines.ts` — create/update/delete에 알림 스케줄링 연동
- `src/screens/TodoFormScreen.tsx` — 시간 설정 시 알림 설정 버튼 노출, 체크박스 다이얼로그로 복수 오프셋 선택
- `src/screens/RoutineFormScreen.tsx` — 동일한 알림 설정 UI 추가
- `src/screens/SettingsScreen.tsx` — 전역 알림 오프셋 설정 제거 (항목별 관리로 변경)
- `App.tsx` — 앱 시작 시 알림 권한 요청

## 주요 설계
- 알림은 전역 설정 대신 **항목별**로 관리 (정시 / 10분 전 / 30분 전 / 1시간 전 / 2시간 전 복수 선택)
- DB에 `notification_offsets` TEXT 컬럼으로 콤마 구분 저장 (예: "0,10,30")
- 알림 ID: `todo-{id}-{offset}`, `routine-{id}-{offset}` 패턴으로 개별 취소 가능
- 알림 메시지: `{시간}` / `{할 일 제목}` 형태로 간결하게 표시

## 테스트
- [ ] 시간 설정 후 알림 설정 버튼 노출 확인
- [ ] 체크박스 다이얼로그에서 복수 오프셋 선택 및 태그 표시 확인
- [ ] 저장 후 기기 알림 예약 확인 (미래 시각으로 테스트)
- [ ] 할 일 삭제/완료 시 알림 취소 확인
- [ ] 루틴 동일 동작 확인