### PR TITLE
#118 [Phase 3] 정렬

### DIFF
--- a/.claude/phase-map.json
+++ b/.claude/phase-map.json
@@ -14,14 +14,14 @@
       "title": "알림",
       "issueNumber": 117,
       "branch": "feature/issue-115/notifications",
-      "status": "in_progress"
+      "status": "done"
     },
     {
       "number": 3,
       "title": "정렬",
       "issueNumber": 118,
       "branch": "feature/issue-115/sort",
-      "status": "pending"
+      "status": "in_progress"
     },
     {
       "number": 4,

--- a/src/components/TodoTabList.tsx
+++ b/src/components/TodoTabList.tsx
@@ -1,6 +1,6 @@
-import { useMemo } from 'react';
-import { FlatList, StyleSheet } from 'react-native';
-import { Text, Divider } from 'react-native-paper';
+import { useMemo, useState } from 'react';
+import { View, FlatList, StyleSheet, TouchableOpacity } from 'react-native';
+import { Text, Divider, Menu } from 'react-native-paper';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { Colors } from '../theme';
@@ -13,14 +13,26 @@ import DateSeparator from './DateSeparator';
 import { TodoStackParamList } from '../navigation/TodoStack';
 import { Todo } from '../types';
 import { toDateKey, formatDueDateLabel } from '../utils/date';
+import { SortKey, sortTodos } from '../utils/sort';
 
 type Nav = NativeStackNavigationProp<TodoStackParamList, 'TodoList'>;
+
+const LIST_SORT_OPTIONS: { key: SortKey; label: string }[] = [
+  { key: 'deadline', label: '기한순' },
+  { key: 'urgency', label: '긴급도순' },
+  { key: 'importance', label: '중요도순' },
+];
 
 type ListItem =
   | { type: 'header'; key: string; label: string }
   | { type: 'todo'; key: string; todo: Todo };
 
-function buildGroupedList(todos: Todo[]): ListItem[] {
+function buildGroupedList(todos: Todo[], sortKey: SortKey): ListItem[] {
+  if (sortKey === 'urgency' || sortKey === 'importance') {
+    const sorted = sortTodos(todos, sortKey);
+    return sorted.map((todo) => ({ type: 'todo', key: `todo-${todo.id}`, todo }));
+  }
+
   const sorted = [...todos].sort((a, b) => {
     if (a.dueDate === null && b.dueDate === null) return a.sortOrder - b.sortOrder;
     if (a.dueDate === null) return 1;
@@ -48,10 +60,13 @@ export default function TodoTabList() {
   const { data: categories = [] } = useCategories();
   const { mutate: todayToggle } = useTodayToggle();
 
+  const [sortKey, setSortKey] = useState<SortKey>('deadline');
+  const [sortMenuVisible, setSortMenuVisible] = useState(false);
+
   const categoryMap = useCategoryMap(categories);
   const getCheckable = useCheckable({ mode: 'today', completedIds, toggleFn: todayToggle });
 
-  const listItems = useMemo(() => buildGroupedList(todos as Todo[]), [todos]);
+  const listItems = useMemo(() => buildGroupedList(todos as Todo[], sortKey), [todos, sortKey]);
 
   const renderItem = ({ item }: { item: ListItem }) => {
     if (item.type === 'header') {
@@ -70,21 +85,59 @@ export default function TodoTabList() {
     );
   };
 
+  const currentLabel = LIST_SORT_OPTIONS.find((o) => o.key === sortKey)?.label ?? '기한순';
+
   return (
-    <FlatList
-      data={listItems}
-      keyExtractor={(item) => item.key}
-      ItemSeparatorComponent={({ leadingItem }) =>
-        leadingItem?.type === 'header' ? null : <Divider />
-      }
-      ListEmptyComponent={<Text style={styles.empty}>할 일이 없어요</Text>}
-      renderItem={renderItem}
-      style={styles.list}
-    />
+    <View style={styles.container}>
+      <View style={styles.sortRow}>
+        <Menu
+          visible={sortMenuVisible}
+          onDismiss={() => setSortMenuVisible(false)}
+          anchor={
+            <TouchableOpacity style={styles.sortAnchor} onPress={() => setSortMenuVisible(true)}>
+              <Text variant="labelSmall" style={styles.sortText}>{currentLabel} ▾</Text>
+            </TouchableOpacity>
+          }
+        >
+          {LIST_SORT_OPTIONS.map((opt) => (
+            <Menu.Item
+              key={opt.key}
+              title={opt.label}
+              onPress={() => { setSortKey(opt.key); setSortMenuVisible(false); }}
+              trailingIcon={sortKey === opt.key ? 'check' : undefined}
+            />
+          ))}
+        </Menu>
+      </View>
+      <FlatList
+        data={listItems}
+        keyExtractor={(item) => item.key}
+        ItemSeparatorComponent={({ leadingItem }) =>
+          leadingItem?.type === 'header' ? null : <Divider />
+        }
+        ListEmptyComponent={<Text style={styles.empty}>할 일이 없어요</Text>}
+        renderItem={renderItem}
+        style={styles.list}
+      />
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
-  list: { flex: 1, backgroundColor: Colors.background },
+  container: { flex: 1, backgroundColor: Colors.background },
+  sortRow: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: Colors.border,
+  },
+  sortAnchor: {
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+  },
+  sortText: { color: Colors.textSecondary },
+  list: { flex: 1 },
   empty: { textAlign: 'center', marginTop: 60, color: Colors.textMuted },
 });

--- a/src/components/TodoTabOverdue.tsx
+++ b/src/components/TodoTabOverdue.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo } from 'react';
-import { View, StyleSheet, FlatList } from 'react-native';
-import { Text, Divider, Button, FAB, Dialog, Portal, Snackbar } from 'react-native-paper';
+import { View, StyleSheet, FlatList, TouchableOpacity } from 'react-native';
+import { Text, Divider, Button, FAB, Dialog, Portal, Snackbar, Menu } from 'react-native-paper';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { Colors } from '../theme';
@@ -13,19 +13,32 @@ import DateSeparator from './DateSeparator';
 import { TodoStackParamList } from '../navigation/TodoStack';
 import { Todo } from '../types';
 import { toDateKey, formatDueDateLabel } from '../utils/date';
+import { SortKey, sortTodos } from '../utils/sort';
 
 type Nav = NativeStackNavigationProp<TodoStackParamList, 'TodoList'>;
+
+const OVERDUE_SORT_OPTIONS: { key: SortKey; label: string }[] = [
+  { key: 'deadline', label: '기한순' },
+  { key: 'urgency', label: '긴급도순' },
+  { key: 'importance', label: '중요도순' },
+];
 
 type ListItem =
   | { type: 'header'; key: string; label: string }
   | { type: 'todo'; key: string; todo: Todo };
 
-function buildGroupedList(todos: Todo[]): ListItem[] {
+function buildGroupedList(todos: Todo[], sortKey: SortKey): ListItem[] {
+  if (sortKey === 'urgency' || sortKey === 'importance') {
+    const sorted = sortTodos(todos, sortKey);
+    return sorted.map((todo) => ({ type: 'todo', key: `todo-${todo.id}`, todo }));
+  }
+
+  // 기한순: 오래된 미완료 먼저
   const sorted = [...todos].sort((a, b) => {
     if (a.dueDate === null && b.dueDate === null) return a.sortOrder - b.sortOrder;
     if (a.dueDate === null) return 1;
     if (b.dueDate === null) return -1;
-    return b.dueDate - a.dueDate || a.sortOrder - b.sortOrder;
+    return a.dueDate - b.dueDate || a.sortOrder - b.sortOrder;
   });
 
   const result: ListItem[] = [];
@@ -52,12 +65,14 @@ export default function TodoTabOverdue() {
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [snackbarVisible, setSnackbarVisible] = useState(false);
   const [snackbarMessage, setSnackbarMessage] = useState('');
+  const [sortKey, setSortKey] = useState<SortKey>('deadline');
+  const [sortMenuVisible, setSortMenuVisible] = useState(false);
 
   const categoryMap = useCategoryMap(categories);
   const { isSelecting, selectedIds, startSelecting, clearSelection, toggleSelection } =
     useSelectable(todos as Todo[]);
 
-  const listItems = useMemo(() => buildGroupedList(todos as Todo[]), [todos]);
+  const listItems = useMemo(() => buildGroupedList(todos as Todo[], sortKey), [todos, sortKey]);
 
   const handleMoveToToday = () => {
     if (selectedIds.size === 0) return;
@@ -100,8 +115,32 @@ export default function TodoTabOverdue() {
     );
   };
 
+  const currentLabel = OVERDUE_SORT_OPTIONS.find((o) => o.key === sortKey)?.label ?? '기한순';
+
   return (
     <View style={styles.container}>
+      {!isSelecting && (
+        <View style={styles.sortRow}>
+          <Menu
+            visible={sortMenuVisible}
+            onDismiss={() => setSortMenuVisible(false)}
+            anchor={
+              <TouchableOpacity style={styles.sortAnchor} onPress={() => setSortMenuVisible(true)}>
+                <Text variant="labelSmall" style={styles.sortText}>{currentLabel} ▾</Text>
+              </TouchableOpacity>
+            }
+          >
+            {OVERDUE_SORT_OPTIONS.map((opt) => (
+              <Menu.Item
+                key={opt.key}
+                title={opt.label}
+                onPress={() => { setSortKey(opt.key); setSortMenuVisible(false); }}
+                trailingIcon={sortKey === opt.key ? 'check' : undefined}
+              />
+            ))}
+          </Menu>
+        </View>
+      )}
       <FlatList
         data={listItems}
         keyExtractor={(item) => item.key}
@@ -169,6 +208,20 @@ export default function TodoTabOverdue() {
 
 const styles = StyleSheet.create({
   container: { flex: 1 },
+  sortRow: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: Colors.border,
+    backgroundColor: Colors.background,
+  },
+  sortAnchor: {
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+  },
+  sortText: { color: Colors.textSecondary },
   list: { flex: 1, backgroundColor: Colors.background },
   empty: { textAlign: 'center', marginTop: 60, color: Colors.textMuted },
   snackbar: { marginBottom: 80 },

--- a/src/components/TodoTabToday.tsx
+++ b/src/components/TodoTabToday.tsx
@@ -1,8 +1,8 @@
-import { View, StyleSheet, FlatList } from 'react-native';
-import { Text, Divider } from 'react-native-paper';
+import { View, StyleSheet, FlatList, TouchableOpacity } from 'react-native';
+import { Text, Divider, Menu } from 'react-native-paper';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import dayjs from 'dayjs';
 import { Colors } from '../theme';
 import { useTodosToday, useTodayCompletionIds, useTodayToggle } from '../hooks/useTodos';
@@ -15,8 +15,21 @@ import RoutineItem from './RoutineItem';
 import TodayProgressBar from './TodayProgressBar';
 import { TodoStackParamList } from '../navigation/TodoStack';
 import { Todo } from '../types';
+import { SortKey, SORT_OPTIONS, sortTodos } from '../utils/sort';
 
 type Nav = NativeStackNavigationProp<TodoStackParamList, 'TodoList'>;
+
+// 오늘 탭: 기한순 대신 시간순으로 대체
+const TODAY_SORT_OPTIONS = SORT_OPTIONS.map((o) =>
+  o.key === 'deadline' ? { ...o, label: '시간순' } : o,
+);
+
+function sortTodayTodos(todos: Todo[], sortKey: SortKey): Todo[] {
+  if (sortKey === 'deadline') {
+    return [...todos].sort((a, b) => (a.dueTime ?? 1440) - (b.dueTime ?? 1440));
+  }
+  return sortTodos(todos, sortKey);
+}
 
 export default function TodoTabToday() {
   const navigation = useNavigation<Nav>();
@@ -27,10 +40,15 @@ export default function TodoTabToday() {
   const { mutate: todayToggle } = useTodayToggle();
   const { mutate: toggleRoutine } = useToggleRoutineCompletion();
 
+  const [sortKey, setSortKey] = useState<SortKey>('default');
+  const [sortMenuVisible, setSortMenuVisible] = useState(false);
+
   const today = dayjs().format('YYYY-MM-DD');
 
   const categoryMap = useCategoryMap(categories);
   const getCheckable = useCheckable({ mode: 'today', completedIds, toggleFn: todayToggle });
+
+  const sortedTodos = useMemo(() => sortTodayTodos(todos as Todo[], sortKey), [todos, sortKey]);
 
   const progressData = useMemo(() => {
     const countMap = new Map<number, number>();
@@ -69,6 +87,7 @@ export default function TodoTabToday() {
   };
 
   const isEmpty = routines.length === 0 && todos.length === 0;
+  const currentLabel = TODAY_SORT_OPTIONS.find((o) => o.key === sortKey)?.label ?? '기본순';
 
   return (
     <View style={styles.container}>
@@ -78,7 +97,7 @@ export default function TodoTabToday() {
         total={progressData.total}
       />
       <FlatList
-        data={todos as Todo[]}
+        data={sortedTodos}
         keyExtractor={(item) => `todo-${item.id}`}
         ItemSeparatorComponent={() => <Divider />}
         renderItem={renderTodoItem}
@@ -104,12 +123,32 @@ export default function TodoTabToday() {
                   </View>
                 ))}
                 {todos.length > 0 && (
-                  <>
-                    <Divider style={styles.sectionDivider} />
-                    <Text variant="labelSmall" style={styles.sectionLabel}>할 일</Text>
-                  </>
+                  <Divider style={styles.sectionDivider} />
                 )}
               </>
+            )}
+            {todos.length > 0 && (
+              <View style={styles.todoHeader}>
+                <Text variant="labelSmall" style={styles.sectionLabel}>할 일</Text>
+                <Menu
+                  visible={sortMenuVisible}
+                  onDismiss={() => setSortMenuVisible(false)}
+                  anchor={
+                    <TouchableOpacity style={styles.sortAnchor} onPress={() => setSortMenuVisible(true)}>
+                      <Text variant="labelSmall" style={styles.sortText}>{currentLabel} ▾</Text>
+                    </TouchableOpacity>
+                  }
+                >
+                  {TODAY_SORT_OPTIONS.map((opt) => (
+                    <Menu.Item
+                      key={opt.key}
+                      title={opt.label}
+                      onPress={() => { setSortKey(opt.key); setSortMenuVisible(false); }}
+                      trailingIcon={sortKey === opt.key ? 'check' : undefined}
+                    />
+                  ))}
+                </Menu>
+              </View>
             )}
             {isEmpty && (
               <Text style={styles.empty}>오늘 할 일이 없어요</Text>
@@ -131,5 +170,16 @@ const styles = StyleSheet.create({
     marginBottom: 4,
   },
   sectionDivider: { marginTop: 8, backgroundColor: Colors.surfaceVariant },
+  todoHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingRight: 8,
+  },
+  sortAnchor: {
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+  },
+  sortText: { color: Colors.textSecondary },
   empty: { textAlign: 'center', marginTop: 60, color: Colors.textMuted },
 });

--- a/src/utils/sort.ts
+++ b/src/utils/sort.ts
@@ -1,0 +1,27 @@
+import { Todo } from '../types';
+
+export type SortKey = 'default' | 'deadline' | 'urgency' | 'importance';
+
+export const SORT_OPTIONS: { key: SortKey; label: string }[] = [
+  { key: 'default', label: '기본순' },
+  { key: 'deadline', label: '기한순' },
+  { key: 'urgency', label: '긴급도순' },
+  { key: 'importance', label: '중요도순' },
+];
+
+export function sortTodos(todos: Todo[], key: SortKey): Todo[] {
+  if (key === 'default') {
+    return [...todos].sort((a, b) => a.sortOrder - b.sortOrder);
+  }
+  if (key === 'deadline') {
+    return [...todos].sort((a, b) => {
+      if (a.dueDate == null) return 1;
+      if (b.dueDate == null) return -1;
+      return a.dueDate - b.dueDate;
+    });
+  }
+  if (key === 'urgency') {
+    return [...todos].sort((a, b) => (b.urgency ?? 0) - (a.urgency ?? 0));
+  }
+  return [...todos].sort((a, b) => (b.importance ?? 0) - (a.importance ?? 0));
+}


### PR DESCRIPTION
## 이슈
Closes #118

## 변경 사항
- `src/utils/sort.ts` — 신규: `sortTodos(todos, sortKey)` 유틸 (기한/긴급도/중요도)
- `src/components/TodoTabList.tsx` — 기한순/긴급도순/중요도순 정렬 메뉴 추가 (기한순 기본값, 기한순은 날짜 그룹 유지, 나머지는 플랫 리스트)
- `src/components/TodoTabOverdue.tsx` — 동일한 3가지 정렬 옵션 추가 (선택 모드 시 정렬 버튼 숨김)
- `src/components/TodoTabToday.tsx` — 기본순/시간순/긴급도순/중요도순 정렬 추가 (할 일 섹션 헤더에 위치)

## 설계 결정
- 할 일/미완료 탭: 이미 날짜 그룹이 기본이므로 기한순/긴급도순/중요도순 3가지만 제공
- 오늘 탭: 날짜 그룹 없이 기본순(sortOrder)/시간순(dueTime)/긴급도순/중요도순 4가지 제공
- 정렬은 in-memory — DB 쿼리 변경 없음

## 테스트
- [ ] 할 일 탭 상단 "기한순 ▾" 버튼 탭 → 메뉴 표시
- [ ] 긴급도순/중요도순 선택 시 날짜 헤더 없이 플랫 리스트로 전환
- [ ] 미완료 탭 동일 동작, 선택 모드 진입 시 정렬 버튼 숨김
- [ ] 오늘 탭 할 일 섹션 헤더 우측 정렬 버튼 동작
- [ ] 루틴은 정렬 영향 없이 항상 상단 고정