### PR TITLE
#126 할 일·루틴 통합 검색 기능 추가

### DIFF
--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -1,0 +1,37 @@
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { and, eq } from 'drizzle-orm';
+import { db } from '../db';
+import { todos, routines } from '../db/schema';
+
+export function useSearch(query: string) {
+  const { data: allTodos = [] } = useQuery({
+    queryKey: ['todos', 'all'],
+    queryFn: () =>
+      db.select().from(todos)
+        .where(and(eq(todos.isDeleted, 0), eq(todos.isCompleted, 0)))
+        .all(),
+  });
+
+  const { data: allRoutines = [] } = useQuery({
+    queryKey: ['routines'],
+    queryFn: () =>
+      db.select().from(routines)
+        .where(eq(routines.isActive, 1))
+        .all(),
+  });
+
+  const q = query.trim().toLowerCase();
+
+  const filteredTodos = useMemo(() => {
+    if (!q) return [];
+    return allTodos.filter((t) => t.title.toLowerCase().includes(q));
+  }, [allTodos, q]);
+
+  const filteredRoutines = useMemo(() => {
+    if (!q) return [];
+    return allRoutines.filter((r) => r.title.toLowerCase().includes(q));
+  }, [allRoutines, q]);
+
+  return { todos: filteredTodos, routines: filteredRoutines };
+}

--- a/src/navigation/TodoStack.tsx
+++ b/src/navigation/TodoStack.tsx
@@ -1,6 +1,7 @@
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import TodoScreen from '../screens/TodoScreen';
 import TodoFormScreen from '../screens/TodoFormScreen';
+import SearchScreen from '../screens/SearchScreen';
 
 export type TodoStackParamList = {
   TodoList: undefined;
@@ -16,6 +17,7 @@ export type TodoStackParamList = {
       isCompleted: number;
     };
   } | undefined;
+  Search: undefined;
 };
 
 const Stack = createNativeStackNavigator<TodoStackParamList>();
@@ -25,6 +27,7 @@ export default function TodoStack() {
     <Stack.Navigator screenOptions={{ headerShown: false, animation: 'slide_from_right' }}>
       <Stack.Screen name="TodoList" component={TodoScreen} />
       <Stack.Screen name="TodoForm" component={TodoFormScreen} />
+      <Stack.Screen name="Search" component={SearchScreen} />
     </Stack.Navigator>
   );
 }

--- a/src/screens/SearchScreen.tsx
+++ b/src/screens/SearchScreen.tsx
@@ -1,0 +1,213 @@
+import { useState, useCallback } from 'react';
+import { View, SectionList, StyleSheet, TouchableOpacity } from 'react-native';
+import { Appbar, Text, Searchbar, Divider } from 'react-native-paper';
+import { useNavigation } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Colors } from '../theme';
+import { useSearch } from '../hooks/useSearch';
+import { useCategories } from '../hooks/useCategories';
+import { useCategoryMap } from '../hooks/useCategoryMap';
+import { TodoStackParamList } from '../navigation/TodoStack';
+import { formatDueDateLabel } from '../utils/date';
+
+type Nav = NativeStackNavigationProp<TodoStackParamList, 'Search'>;
+
+type SectionItem =
+  | { kind: 'todo'; id: number; title: string; categoryId: number; dueDate: number | null; isCompleted: number; item: any }
+  | { kind: 'routine'; id: number; title: string; categoryId: number; repeatType: string; item: any };
+
+export default function SearchScreen() {
+  const navigation = useNavigation<Nav>();
+  const { top } = useSafeAreaInsets();
+  const [query, setQuery] = useState('');
+  const { data: categories = [] } = useCategories();
+  const categoryMap = useCategoryMap(categories);
+  const { todos, routines } = useSearch(query);
+
+  const sections = [
+    ...(todos.length > 0
+      ? [{
+          title: '할 일',
+          data: todos.map((t): SectionItem => ({
+            kind: 'todo', id: t.id, title: t.title,
+            categoryId: t.categoryId, dueDate: t.dueDate,
+            isCompleted: t.isCompleted, item: t,
+          })),
+        }]
+      : []),
+    ...(routines.length > 0
+      ? [{
+          title: '루틴',
+          data: routines.map((r): SectionItem => ({
+            kind: 'routine', id: r.id, title: r.title,
+            categoryId: r.categoryId, repeatType: r.repeatType, item: r,
+          })),
+        }]
+      : []),
+  ];
+
+  const handleTodoPress = useCallback((item: any) => {
+    navigation.navigate('TodoForm', { todo: item });
+  }, [navigation]);
+
+  const handleRoutinePress = useCallback((item: any) => {
+    (navigation as any).navigate('RoutineRoot', {
+      screen: 'RoutineForm',
+      params: { routine: item },
+    });
+  }, [navigation]);
+
+  const renderItem = ({ item }: { item: SectionItem }) => {
+    const category = categoryMap.get(item.categoryId);
+    const onPress = item.kind === 'todo'
+      ? () => handleTodoPress(item.item)
+      : () => handleRoutinePress(item.item);
+
+    return (
+      <TouchableOpacity style={styles.item} onPress={onPress} activeOpacity={0.7}>
+        <View style={[styles.dot, { backgroundColor: category?.color ?? Colors.textMuted }]} />
+        <View style={styles.itemContent}>
+          <Text
+            style={[styles.itemTitle, item.kind === 'todo' && item.isCompleted === 1 && styles.itemCompleted]}
+            numberOfLines={1}
+          >
+            {item.title}
+          </Text>
+          <Text style={styles.itemMeta} numberOfLines={1}>
+            {category?.name ?? '미분류'}
+            {item.kind === 'todo' && item.dueDate
+              ? `  ·  ${formatDueDateLabel(item.dueDate)}`
+              : item.kind === 'routine'
+              ? `  ·  ${repeatLabel(item.repeatType)}`
+              : ''}
+          </Text>
+        </View>
+      </TouchableOpacity>
+    );
+  };
+
+  const renderSectionHeader = ({ section }: { section: { title: string } }) => (
+    <View style={styles.sectionHeader}>
+      <Text style={styles.sectionTitle}>{section.title}</Text>
+    </View>
+  );
+
+  const isEmpty = query.trim().length > 0 && todos.length === 0 && routines.length === 0;
+
+  return (
+    <View style={[styles.container, { paddingTop: top }]}>
+      <Appbar.Header style={styles.header}>
+        <Appbar.BackAction onPress={() => navigation.goBack()} />
+        <Searchbar
+          placeholder="할 일, 루틴 검색"
+          value={query}
+          onChangeText={setQuery}
+          style={styles.searchbar}
+          inputStyle={styles.searchInput}
+          autoFocus
+        />
+      </Appbar.Header>
+
+      {isEmpty ? (
+        <View style={styles.empty}>
+          <Text style={styles.emptyText}>검색 결과가 없어요</Text>
+        </View>
+      ) : query.trim().length === 0 ? (
+        <View style={styles.empty}>
+          <Text style={styles.emptyText}>제목으로 검색하세요</Text>
+        </View>
+      ) : (
+        <SectionList
+          sections={sections}
+          keyExtractor={(item) => `${item.kind}-${item.id}`}
+          renderItem={renderItem}
+          renderSectionHeader={renderSectionHeader}
+          ItemSeparatorComponent={() => <Divider />}
+          stickySectionHeadersEnabled={false}
+          keyboardShouldPersistTaps="handled"
+          style={styles.list}
+        />
+      )}
+    </View>
+  );
+}
+
+function repeatLabel(repeatType: string): string {
+  if (repeatType === 'daily') return '매일';
+  if (repeatType === 'weekly') return '매주';
+  if (repeatType === 'monthly') return '매월';
+  return repeatType;
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: Colors.background },
+  header: {
+    height: 64,
+    paddingHorizontal: 4,
+    backgroundColor: Colors.background,
+    elevation: 0,
+  },
+  searchbar: {
+    flex: 1,
+    backgroundColor: Colors.surfaceVariant,
+    borderRadius: 10,
+    marginRight: 8,
+    height: 44,
+  },
+  searchInput: {
+    fontSize: 15,
+    color: Colors.text,
+    minHeight: 0,
+  },
+  list: { flex: 1 },
+  sectionHeader: {
+    paddingHorizontal: 16,
+    paddingTop: 20,
+    paddingBottom: 6,
+    backgroundColor: Colors.background,
+  },
+  sectionTitle: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: Colors.textMuted,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  item: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    backgroundColor: Colors.background,
+    gap: 12,
+  },
+  dot: {
+    width: 10,
+    height: 10,
+    borderRadius: 5,
+  },
+  itemContent: { flex: 1 },
+  itemTitle: {
+    fontSize: 15,
+    color: Colors.text,
+    marginBottom: 2,
+  },
+  itemCompleted: {
+    textDecorationLine: 'line-through',
+    color: Colors.textMuted,
+  },
+  itemMeta: {
+    fontSize: 12,
+    color: Colors.textSecondary,
+  },
+  empty: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  emptyText: {
+    color: Colors.textMuted,
+    fontSize: 14,
+  },
+});

--- a/src/screens/TodoScreen.tsx
+++ b/src/screens/TodoScreen.tsx
@@ -73,6 +73,7 @@ export default function TodoScreen() {
     <View style={styles.container}>
       <Appbar.Header style={styles.header}>
         <Appbar.Content title="CheckCheck" titleStyle={{ fontWeight: '700' }} />
+        <Appbar.Action icon="magnify" onPress={() => navigation.navigate('Search')} style={{ marginRight: -8 }} />
         <Menu
           visible={menuVisible}
           onDismiss={() => setMenuVisible(false)}


### PR DESCRIPTION
## 이슈
Closes #126

## 변경 사항
- `src/hooks/useSearch.ts` — 신규: 제목 기준 in-memory 필터 훅 (미완료 할 일 + 루틴 통합)
- `src/screens/SearchScreen.tsx` — 신규: 검색 입력창 + 할 일/루틴 섹션 결과 목록
- `src/navigation/TodoStack.tsx` — Search 스크린 추가
- `src/screens/TodoScreen.tsx` — 헤더에 돋보기 아이콘 추가

## 테스트
- [ ] 할 일 탭 헤더 돋보기 아이콘 탭 → 검색 화면 진입
- [ ] 키워드 입력 시 할 일 / 루틴 섹션으로 구분 표시
- [ ] 항목 탭 시 편집 화면으로 이동
- [ ] 완료된 할 일은 검색 결과에서 제외 확인
- [ ] 검색 결과 없을 때 안내 문구 표시