### PR TITLE
#129 기록 화면 카테고리 터치 안 되는 버그 수정 (Android)

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,8 +1,8 @@
 {
   "expo": {
-    "name": "checkcheck",
+    "name": "CheckCheck",
     "slug": "checkcheck",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",
@@ -26,7 +26,8 @@
         "backgroundColor": "#ffffff"
       },
       "edgeToEdgeEnabled": true,
-      "predictiveBackGestureEnabled": false
+      "predictiveBackGestureEnabled": false,
+      "package": "com.limlimlimstudio.checkcheck"
     },
     "web": {
       "favicon": "./assets/favicon.png"

--- a/src/screens/RecordScreen.tsx
+++ b/src/screens/RecordScreen.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { View, ScrollView, StyleSheet } from 'react-native';
-import { Appbar, Text, IconButton, TouchableRipple, Menu } from 'react-native-paper';
+import { Appbar, Text, IconButton, TouchableRipple, Menu, Icon } from 'react-native-paper';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { Colors } from '../theme';
@@ -82,12 +82,9 @@ export default function RecordScreen() {
                     {category.description}
                   </Text>
                 ) : null}
-                <IconButton
-                  icon="chevron-right"
-                  size={16}
-                  iconColor={Colors.textMuted}
-                  style={styles.chevron}
-                />
+                <View style={styles.chevron}>
+                  <Icon source="chevron-right" size={16} color={Colors.textMuted} />
+                </View>
               </View>
             </TouchableRipple>
             <ContributionGrid categoryId={category.id} color={category.color} year={year} />
@@ -125,7 +122,7 @@ const styles = StyleSheet.create({
     paddingHorizontal: 12,
     paddingVertical: 4,
   },
-  chevron: { marginLeft: 'auto', margin: 0 },
+  chevron: { marginLeft: 'auto' },
   dot: { width: 10, height: 10, borderRadius: 5 },
   categoryName: { color: Colors.text },
   categoryDesc: { color: Colors.textMuted, flexShrink: 1 },


### PR DESCRIPTION
## 이슈
Closes #129

## 변경 사항
- `RecordScreen`의 카테고리 헤더 내 `IconButton`(chevron)을 비대화형 `Icon`으로 교체
- Android에서 `TouchableRipple` 내부 중첩 `IconButton`이 터치를 가로채던 문제 해결

## 원인
React Native Paper의 `TouchableRipple` 안에 `IconButton`이 중첩될 경우, Android에서는 내부 버튼이 터치 이벤트를 가로채 `onPress`가 동작하지 않음. iOS는 터치 응답 시스템 차이로 정상 동작.

## 테스트
- [ ] Android 에뮬레이터에서 기록 탭 → 카테고리 탭 → CategoryCompletedScreen으로 이동 확인
- [ ] iOS에서 기존 동작 이상 없음 확인