### PR TITLE
#134 iOS/Android 로컬 릴리즈 빌드 스크립트 추가

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "checkcheck",
     "slug": "checkcheck",
-    "version": "1.0.0",
+    "version": "1.1.1",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
     "ios:prebuild": "expo prebuild --platform ios --clean",
     "web": "expo start --web",
     "db:generate": "drizzle-kit generate",
-    "db:studio": "drizzle-kit studio"
+    "db:studio": "drizzle-kit studio",
+    "build:ios": "bash scripts/build-ios.sh",
+    "build:android": "bash scripts/build-android.sh",
+    "build:all": "bash scripts/build-all.sh"
   },
   "dependencies": {
     "@react-native-community/datetimepicker": "8.4.4",

--- a/scripts/build-all.sh
+++ b/scripts/build-all.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+echo "🚀 iOS + Android 릴리즈 빌드 시작..."
+echo ""
+
+# iOS 빌드
+bash "$SCRIPT_DIR/build-ios.sh"
+echo ""
+
+# Android 빌드
+bash "$SCRIPT_DIR/build-android.sh"
+echo ""
+
+echo "🎉 전체 빌드 완료!"
+echo "📦 iOS:     $(ls *.ipa 2>/dev/null | head -1)"
+echo "📦 Android: $(ls *.apk *.aab 2>/dev/null | head -1)"

--- a/scripts/build-android.sh
+++ b/scripts/build-android.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -e
+
+echo "🤖 Android 릴리즈 빌드 시작..."
+
+# 이전 apk/aab 파일 정리
+PREV_COUNT=$(ls *.apk *.aab 2>/dev/null | wc -l | tr -d ' ')
+if [ "$PREV_COUNT" -gt 0 ]; then
+  echo "🗑  이전 빌드 파일 삭제 중..."
+  rm -f *.apk *.aab
+fi
+
+# 빌드 시작 시간
+START=$(date +%s)
+
+eas build --platform android --profile production --local
+
+# 빌드 결과물 확인
+BUILD_FILE=$(ls *.apk *.aab 2>/dev/null | head -1)
+END=$(date +%s)
+ELAPSED=$((END - START))
+
+if [ -n "$BUILD_FILE" ]; then
+  echo ""
+  echo "✅ Android 빌드 완료 (${ELAPSED}초)"
+  echo "📦 결과물: $BUILD_FILE"
+else
+  echo ""
+  echo "❌ 빌드 결과물을 찾을 수 없습니다."
+  exit 1
+fi

--- a/scripts/build-ios.sh
+++ b/scripts/build-ios.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -e
+
+echo "🍎 iOS 릴리즈 빌드 시작..."
+
+# 이전 ipa 파일 정리
+IPA_COUNT=$(ls *.ipa 2>/dev/null | wc -l | tr -d ' ')
+if [ "$IPA_COUNT" -gt 0 ]; then
+  echo "🗑  이전 ipa 파일 삭제 중..."
+  rm -f *.ipa
+fi
+
+# 빌드 시작 시간
+START=$(date +%s)
+
+eas build --platform ios --profile production --local
+
+# 빌드 결과물 확인
+IPA_FILE=$(ls *.ipa 2>/dev/null | head -1)
+END=$(date +%s)
+ELAPSED=$((END - START))
+
+if [ -n "$IPA_FILE" ]; then
+  echo ""
+  echo "✅ iOS 빌드 완료 (${ELAPSED}초)"
+  echo "📦 결과물: $IPA_FILE"
+else
+  echo ""
+  echo "❌ ipa 파일을 찾을 수 없습니다."
+  exit 1
+fi


### PR DESCRIPTION
## 이슈
Closes #134

## 변경 사항
- `scripts/build-ios.sh`: iOS 로컬 프로덕션 빌드 + 이전 ipa 자동 정리
- `scripts/build-android.sh`: Android 로컬 프로덕션 빌드 + 이전 apk/aab 자동 정리
- `scripts/build-all.sh`: iOS → Android 순차 빌드 통합 스크립트
- `package.json`: `build:ios`, `build:android`, `build:all` npm script 등록
- `app.json`: 버전 1.0.0 → 1.1.1 업데이트

## 테스트
- [ ] `npm run build:ios` 실행 시 ipa 생성 확인
- [ ] `npm run build:android` 실행 시 apk/aab 생성 확인
- [ ] `npm run build:all` 실행 시 순차 빌드 완료 확인
- [ ] 이전 빌드 파일 자동 삭제 확인