### PR TITLE
#136 오늘 탭 완료 항목 즉시 정리 기능 추가

### DIFF
--- a/src/hooks/useTodos.ts
+++ b/src/hooks/useTodos.ts
@@ -1,5 +1,5 @@
 import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { and, asc, desc, eq, gte, isNull, lt, or } from 'drizzle-orm';
+import { and, asc, desc, eq, gte, isNull, lt, lte, or } from 'drizzle-orm';
 import dayjs from 'dayjs';
 import { db } from '../db';
 import { todos, todoCompletions } from '../db/schema';
@@ -393,5 +393,52 @@ export const useBulkDeleteTodos = () => {
       }
     },
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['todos'] }),
+  });
+};
+
+/** 오늘 탭에서 체크된 항목을 즉시 완료 처리 (isCompleted=1)
+ *  자정이 지나도 앱이 켜져 있어 runDueDateCheck가 재실행되지 않을 때 수동으로 정리 */
+export const useFlushTodayCompleted = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (): Promise<number> => {
+      const today = dayjs().format('YYYY-MM-DD');
+      const todayStart = dayjs().startOf('day').valueOf();
+      const todayEnd = dayjs().endOf('day').valueOf();
+      const now = Date.now();
+
+      const todayTodos = db.select().from(todos)
+        .where(and(
+          eq(todos.isCompleted, 0),
+          eq(todos.isDeleted, 0),
+          gte(todos.dueDate, todayStart),
+          lte(todos.dueDate, todayEnd),
+        ))
+        .all();
+
+      let count = 0;
+      for (const todo of todayTodos) {
+        const completion = db.select().from(todoCompletions)
+          .where(and(
+            eq(todoCompletions.todoId, todo.id),
+            eq(todoCompletions.completedDate, today),
+          ))
+          .get();
+        if (completion) {
+          db.update(todos).set({
+            isCompleted: 1,
+            completedAt: now,
+            updatedAt: now,
+          }).where(eq(todos.id, todo.id)).run();
+          count++;
+        }
+      }
+      return count;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['todos'] });
+      queryClient.invalidateQueries({ queryKey: ['todo-completions'] });
+      queryClient.invalidateQueries({ queryKey: ['completions'] });
+    },
   });
 };

--- a/src/screens/TodoScreen.tsx
+++ b/src/screens/TodoScreen.tsx
@@ -8,7 +8,7 @@ import { useState, useEffect } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { Colors } from '../theme';
 import { getAdFreeUntil } from '../db';
-import { runDueDateCheck } from '../hooks/useTodos';
+import { runDueDateCheck, useFlushTodayCompleted } from '../hooks/useTodos';
 import { TodoStackParamList } from '../navigation/TodoStack';
 import BannerAdView from '../components/BannerAdView';
 import TodoTabToday from '../components/TodoTabToday';
@@ -38,6 +38,7 @@ export default function TodoScreen() {
   const [tabIndex, setTabIndex] = useState(0);
   const [menuVisible, setMenuVisible] = useState(false);
   const isAdFree = getAdFreeUntil() > Date.now();
+  const { mutate: flushTodayCompleted } = useFlushTodayCompleted();
   const isFocused = useIsFocused();
   const queryClient = useQueryClient();
 
@@ -81,6 +82,13 @@ export default function TodoScreen() {
             <Appbar.Action icon="dots-vertical" onPress={() => setMenuVisible(true)} />
           }
         >
+          {tabIndex === 0 && (
+            <Menu.Item
+              leadingIcon="broom"
+              title="완료 항목 정리"
+              onPress={() => { setMenuVisible(false); flushTodayCompleted(); }}
+            />
+          )}
           <Menu.Item
             leadingIcon="label-multiple-outline"
             title="카테고리 관리"


### PR DESCRIPTION
## 이슈
Closes #136

## 변경 사항
- `useTodos.ts`: `useFlushTodayCompleted` 뮤테이션 추가 — 오늘 기한이며 체크된 항목을 즉시 `isCompleted=1`로 처리
- `TodoScreen.tsx`: 오늘 탭 활성 시 3-dot 메뉴에 "완료 항목 정리" (broom 아이콘) 항목 추가

## 테스트
- [ ] 오늘 탭에서 할 일 체크 후 ⋮ 메뉴 열기 → "완료 항목 정리" 항목 표시 확인
- [ ] "완료 항목 정리" 탭 → 체크된 항목이 오늘 탭에서 사라지는지 확인
- [ ] 완료 탭 / 기록 화면에 해당 항목 반영 확인
- [ ] 오늘 탭이 아닌 탭(할 일/미완료)에서 ⋮ 메뉴 열기 → "완료 항목 정리" 미표시 확인