### PR TITLE
#138 하루 기준 시간 사용자 설정 기능 추가

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -8,10 +8,12 @@ import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { PaperProvider } from 'react-native-paper';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import MobileAds from 'react-native-google-mobile-ads';
-import { initDb } from './src/db';
+import { initDb, getDayStartHour } from './src/db';
 import { requestNotificationPermission } from './src/utils/notifications';
 import RootNavigator from './src/navigation/RootNavigator';
 import { AppTheme, NavTheme } from './src/theme';
+import { useDayStartStore } from './src/stores/dayStartStore';
+import { useDayStartTimer } from './src/hooks/useDayStartTimer';
 
 // JS 로드 직후 스플래시를 자동으로 숨기지 않도록 유지
 SplashScreen.preventAutoHideAsync();
@@ -27,6 +29,13 @@ AppState.addEventListener('change', onAppStateChange);
 // 스플래시 최소 유지 시간 (ms)
 const SPLASH_MIN_DURATION = 1500;
 
+// 하루 시작 타이머 — QueryClientProvider 내부에서 마운트
+function AppTimers() {
+  const dayStartHour = useDayStartStore(s => s.dayStartHour);
+  useDayStartTimer(dayStartHour);
+  return null;
+}
+
 export default function App() {
   const [ready, setReady] = useState(false);
 
@@ -35,6 +44,10 @@ export default function App() {
 
     MobileAds().initialize()
       .then(() => initDb())
+      .then(() => {
+        // DB 초기화 완료 후 스토어에 설정값 동기화
+        useDayStartStore.getState().setDayStartHour(getDayStartHour());
+      })
       .then(() => requestNotificationPermission())
       .then(async () => {
         // 최소 유지 시간 보장 후 앱 렌더링 → 스플래시 숨김
@@ -57,6 +70,7 @@ export default function App() {
   return (
     <GestureHandlerRootView style={{ flex: 1, backgroundColor: '#111111' }}>
       <QueryClientProvider client={queryClient}>
+        <AppTimers />
         <SafeAreaProvider>
           <PaperProvider theme={AppTheme}>
             <NavigationContainer theme={NavTheme}>

--- a/App.tsx
+++ b/App.tsx
@@ -8,7 +8,7 @@ import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { PaperProvider } from 'react-native-paper';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import MobileAds from 'react-native-google-mobile-ads';
-import { initDb, getDayStartHour } from './src/db';
+import { initDb, getDayStartMinutes } from './src/db';
 import { requestNotificationPermission } from './src/utils/notifications';
 import RootNavigator from './src/navigation/RootNavigator';
 import { AppTheme, NavTheme } from './src/theme';
@@ -31,8 +31,8 @@ const SPLASH_MIN_DURATION = 1500;
 
 // 하루 시작 타이머 — QueryClientProvider 내부에서 마운트
 function AppTimers() {
-  const dayStartHour = useDayStartStore(s => s.dayStartHour);
-  useDayStartTimer(dayStartHour);
+  const dayStartMinutes = useDayStartStore(s => s.dayStartMinutes);
+  useDayStartTimer(dayStartMinutes);
   return null;
 }
 
@@ -46,7 +46,7 @@ export default function App() {
       .then(() => initDb())
       .then(() => {
         // DB 초기화 완료 후 스토어에 설정값 동기화
-        useDayStartStore.getState().setDayStartHour(getDayStartHour());
+        useDayStartStore.getState().setDayStartMinutes(getDayStartMinutes());
       })
       .then(() => requestNotificationPermission())
       .then(async () => {

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -128,16 +128,17 @@ export const initDb = async () => {
   }
 };
 
-export function getDayStartHour(): number {
+/** 하루 시작 시각 — 자정 기준 분(0~1439). 기본값 0(자정). */
+export function getDayStartMinutes(): number {
   const row = db.select().from(schema.appSettings)
     .where(eq(schema.appSettings.key, 'day_start_hour')).get();
   return row ? parseInt(row.value, 10) : 0;
 }
 
-export function setDayStartHour(hour: number): void {
+export function setDayStartMinutes(minutes: number): void {
   db.insert(schema.appSettings)
-    .values({ key: 'day_start_hour', value: String(hour) })
-    .onConflictDoUpdate({ target: schema.appSettings.key, set: { value: String(hour) } })
+    .values({ key: 'day_start_hour', value: String(minutes) })
+    .onConflictDoUpdate({ target: schema.appSettings.key, set: { value: String(minutes) } })
     .run();
 }
 

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -128,6 +128,19 @@ export const initDb = async () => {
   }
 };
 
+export function getDayStartHour(): number {
+  const row = db.select().from(schema.appSettings)
+    .where(eq(schema.appSettings.key, 'day_start_hour')).get();
+  return row ? parseInt(row.value, 10) : 0;
+}
+
+export function setDayStartHour(hour: number): void {
+  db.insert(schema.appSettings)
+    .values({ key: 'day_start_hour', value: String(hour) })
+    .onConflictDoUpdate({ target: schema.appSettings.key, set: { value: String(hour) } })
+    .run();
+}
+
 export function getAdFreeUntil(): number {
   const row = db.select().from(schema.appSettings)
     .where(eq(schema.appSettings.key, 'ad_free_until')).get();

--- a/src/hooks/useDayStartTimer.ts
+++ b/src/hooks/useDayStartTimer.ts
@@ -1,0 +1,45 @@
+import { useEffect, useRef } from 'react';
+import dayjs from 'dayjs';
+import { useQueryClient } from '@tanstack/react-query';
+import { runDueDateCheck } from './useTodos';
+
+export function useDayStartTimer(dayStartHour: number) {
+  const queryClient = useQueryClient();
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // scheduleRef로 재귀 호출 시 최신 dayStartHour를 참조
+  const scheduleRef = useRef<() => void>(() => {});
+
+  useEffect(() => {
+    scheduleRef.current = () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+
+      const now = dayjs();
+      let next = now.startOf('day').add(dayStartHour, 'hour');
+      if (!now.isBefore(next)) next = next.add(1, 'day');
+      const delay = next.valueOf() - now.valueOf();
+
+      if (__DEV__) {
+        console.log(
+          `[DayStartTimer] 다음 실행: ${next.format('HH:mm')} ` +
+          `(${Math.ceil(delay / 1000 / 60)}분 후)`,
+        );
+      }
+
+      timerRef.current = setTimeout(async () => {
+        if (__DEV__) console.log('[DayStartTimer] 할 일 정리 실행');
+        const changed = await runDueDateCheck();
+        if (changed) {
+          queryClient.invalidateQueries({ queryKey: ['todos'] });
+          queryClient.invalidateQueries({ queryKey: ['completions'], exact: false });
+        }
+        scheduleRef.current(); // 다음 날 타이머 재예약
+      }, delay);
+    };
+
+    scheduleRef.current();
+
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [dayStartHour, queryClient]);
+}

--- a/src/hooks/useDayStartTimer.ts
+++ b/src/hooks/useDayStartTimer.ts
@@ -3,10 +3,9 @@ import dayjs from 'dayjs';
 import { useQueryClient } from '@tanstack/react-query';
 import { runDueDateCheck } from './useTodos';
 
-export function useDayStartTimer(dayStartHour: number) {
+export function useDayStartTimer(dayStartMinutes: number) {
   const queryClient = useQueryClient();
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  // scheduleRef로 재귀 호출 시 최신 dayStartHour를 참조
   const scheduleRef = useRef<() => void>(() => {});
 
   useEffect(() => {
@@ -14,7 +13,7 @@ export function useDayStartTimer(dayStartHour: number) {
       if (timerRef.current) clearTimeout(timerRef.current);
 
       const now = dayjs();
-      let next = now.startOf('day').add(dayStartHour, 'hour');
+      let next = now.startOf('day').add(dayStartMinutes, 'minute');
       if (!now.isBefore(next)) next = next.add(1, 'day');
       const delay = next.valueOf() - now.valueOf();
 
@@ -32,7 +31,7 @@ export function useDayStartTimer(dayStartHour: number) {
           queryClient.invalidateQueries({ queryKey: ['todos'] });
           queryClient.invalidateQueries({ queryKey: ['completions'], exact: false });
         }
-        scheduleRef.current(); // 다음 날 타이머 재예약
+        scheduleRef.current();
       }, delay);
     };
 
@@ -41,5 +40,5 @@ export function useDayStartTimer(dayStartHour: number) {
     return () => {
       if (timerRef.current) clearTimeout(timerRef.current);
     };
-  }, [dayStartHour, queryClient]);
+  }, [dayStartMinutes, queryClient]);
 }

--- a/src/hooks/useTodos.ts
+++ b/src/hooks/useTodos.ts
@@ -1,7 +1,7 @@
 import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { and, asc, desc, eq, gte, isNull, lt, or } from 'drizzle-orm';
 import dayjs from 'dayjs';
-import { db, getDayStartHour } from '../db';
+import { db, getDayStartMinutes } from '../db';
 import { todos, todoCompletions } from '../db/schema';
 import { scheduleTodoNotifications, cancelTodoNotifications, offsetsToString } from '../utils/notifications';
 
@@ -149,12 +149,12 @@ let _lastDueDateCheckDate = '';
 export const resetDueDateCheckGuard = () => { _lastDueDateCheckDate = ''; };
 
 export const runDueDateCheck = async (): Promise<boolean> => {
-  const dayStartHour = getDayStartHour();
+  const dayStartMinutes = getDayStartMinutes();
   const now = dayjs();
-  const todayAtStartHour = now.startOf('day').add(dayStartHour, 'hour');
-  const effectiveDayStart = now.isBefore(todayAtStartHour)
-    ? todayAtStartHour.subtract(1, 'day')
-    : todayAtStartHour;
+  const todayAtStart = now.startOf('day').add(dayStartMinutes, 'minute');
+  const effectiveDayStart = now.isBefore(todayAtStart)
+    ? todayAtStart.subtract(1, 'day')
+    : todayAtStart;
 
   const today = effectiveDayStart.format('YYYY-MM-DD');
   if (_lastDueDateCheckDate === today) return false;

--- a/src/hooks/useTodos.ts
+++ b/src/hooks/useTodos.ts
@@ -146,6 +146,8 @@ export const useTodayToggle = () => {
  *  앱 포그라운드 진입 및 탭 포커스 시 실행, 하루 1회만 실제 처리 */
 let _lastDueDateCheckDate = '';
 
+export const resetDueDateCheckGuard = () => { _lastDueDateCheckDate = ''; };
+
 export const runDueDateCheck = async (): Promise<boolean> => {
   const dayStartHour = getDayStartHour();
   const now = dayjs();

--- a/src/hooks/useTodos.ts
+++ b/src/hooks/useTodos.ts
@@ -1,7 +1,7 @@
 import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { and, asc, desc, eq, gte, isNull, lt, or } from 'drizzle-orm';
 import dayjs from 'dayjs';
-import { db } from '../db';
+import { db, getDayStartHour } from '../db';
 import { todos, todoCompletions } from '../db/schema';
 import { scheduleTodoNotifications, cancelTodoNotifications, offsetsToString } from '../utils/notifications';
 
@@ -147,11 +147,18 @@ export const useTodayToggle = () => {
 let _lastDueDateCheckDate = '';
 
 export const runDueDateCheck = async (): Promise<boolean> => {
-  const today = dayjs().format('YYYY-MM-DD');
+  const dayStartHour = getDayStartHour();
+  const now = dayjs();
+  const todayAtStartHour = now.startOf('day').add(dayStartHour, 'hour');
+  const effectiveDayStart = now.isBefore(todayAtStartHour)
+    ? todayAtStartHour.subtract(1, 'day')
+    : todayAtStartHour;
+
+  const today = effectiveDayStart.format('YYYY-MM-DD');
   if (_lastDueDateCheckDate === today) return false;
   _lastDueDateCheckDate = today;
 
-  const todayStart = dayjs().startOf('day').valueOf();
+  const todayStart = effectiveDayStart.valueOf();
   let changed = false;
 
   // 1. 기한이 지난 항목 중 완료 기록 있는 경우

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -1,4 +1,4 @@
-import { View, StyleSheet, TouchableOpacity, Alert, ActivityIndicator } from 'react-native';
+import { View, ScrollView, Modal, StyleSheet, TouchableOpacity, Alert, ActivityIndicator } from 'react-native';
 import { useMemo, useState } from 'react';
 import DateTimePicker, { DateTimePickerEvent } from '@react-native-community/datetimepicker';
 import { Appbar, Text, Divider } from 'react-native-paper';
@@ -10,7 +10,7 @@ import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { SettingsStackParamList } from '../navigation/SettingsStack';
 import Constants from 'expo-constants';
 import { useAdFree, REQUIRED_AD_COUNT } from '../hooks/useAdFree';
-import { setDayStartHour, db } from '../db';
+import { setDayStartMinutes, db } from '../db';
 import { todos, todoCompletions } from '../db/schema';
 import { useDayStartStore } from '../stores/dayStartStore';
 import { resetDueDateCheckGuard, runDueDateCheck } from '../hooks/useTodos';
@@ -18,9 +18,7 @@ import { resetDueDateCheckGuard, runDueDateCheck } from '../hooks/useTodos';
 type NavigationProp = NativeStackNavigationProp<SettingsStackParamList, 'SettingsHome'>;
 
 const APP_INFO = [
-  { label: '앱 이름', value: Constants.expoConfig?.name ?? 'checkcheck' },
   { label: '버전', value: Constants.expoConfig?.version ?? '1.0.0' },
-  { label: '개발사', value: 'limlimlim studio' },
 ];
 
 function formatDate(ts: number): string {
@@ -28,11 +26,14 @@ function formatDate(ts: number): string {
   return `${d.getMonth() + 1}월 ${d.getDate()}일`;
 }
 
-function formatHour(hour: number): string {
-  if (hour === 0) return '오전 12:00';
-  if (hour < 12) return `오전 ${hour}:00`;
-  if (hour === 12) return '오후 12:00';
-  return `오후 ${hour - 12}:00`;
+function formatMinutes(minutes: number): string {
+  const h = Math.floor(minutes / 60);
+  const m = minutes % 60;
+  const mm = String(m).padStart(2, '0');
+  if (h === 0) return `오전 12:${mm}`;
+  if (h < 12) return `오전 ${h}:${mm}`;
+  if (h === 12) return `오후 12:${mm}`;
+  return `오후 ${h - 12}:${mm}`;
 }
 
 export default function SettingsScreen() {
@@ -40,30 +41,45 @@ export default function SettingsScreen() {
   const { isAdFree, adFreeUntil, watchedCount, watchAd, isLoading, resetAdFree } = useAdFree();
   const queryClient = useQueryClient();
 
-  // 하루 시작 시간 — Zustand 스토어에서 읽음 (변경 시 타이머 자동 재시작)
-  const { dayStartHour, setDayStartHour: setDayStartHourInStore } = useDayStartStore();
+  const { dayStartMinutes, setDayStartMinutes: setDayStartMinutesInStore } = useDayStartStore();
   const [showTimePicker, setShowTimePicker] = useState(false);
+  const [tempDate, setTempDate] = useState<Date>(() => {
+    const d = new Date();
+    d.setHours(Math.floor(dayStartMinutes / 60), dayStartMinutes % 60, 0, 0);
+    return d;
+  });
 
   const dayStartDate = useMemo(() => {
     const d = new Date();
-    d.setHours(dayStartHour, 0, 0, 0);
+    d.setHours(Math.floor(dayStartMinutes / 60), dayStartMinutes % 60, 0, 0);
     return d;
-  }, [dayStartHour]);
+  }, [dayStartMinutes]);
 
   const nextTimerStr = useMemo(() => {
     const now = dayjs();
-    let next = now.startOf('day').add(dayStartHour, 'hour');
+    let next = now.startOf('day').add(dayStartMinutes, 'minute');
     if (!now.isBefore(next)) next = next.add(1, 'day');
     return next.format('M월 D일 HH:mm');
-  }, [dayStartHour]);
+  }, [dayStartMinutes]);
 
-  const handleTimeChange = (_: DateTimePickerEvent, date?: Date) => {
+  const handleOpenPicker = () => {
+    setTempDate(dayStartDate);
+    setShowTimePicker(true);
+  };
+
+  const handlePickerChange = (_: DateTimePickerEvent, date?: Date) => {
+    if (date) setTempDate(date);
+  };
+
+  const handleConfirm = () => {
+    const minutes = tempDate.getHours() * 60 + tempDate.getMinutes();
+    setDayStartMinutes(minutes);
+    setDayStartMinutesInStore(minutes);
     setShowTimePicker(false);
-    if (date) {
-      const hour = date.getHours();
-      setDayStartHour(hour);         // DB 저장
-      setDayStartHourInStore(hour);  // 스토어 업데이트 → 타이머 재시작
-    }
+  };
+
+  const handleCancel = () => {
+    setShowTimePicker(false);
   };
 
   // ── 개발용 ──────────────────────────────────────────
@@ -113,6 +129,7 @@ export default function SettingsScreen() {
         <Appbar.Content title="설정" />
       </Appbar.Header>
 
+      <ScrollView contentContainerStyle={styles.scrollContent}>
       <Text variant="labelSmall" style={styles.sectionLabel}>광고 없이 보기</Text>
       <View style={styles.section}>
         {isAdFree ? (
@@ -190,24 +207,15 @@ export default function SettingsScreen() {
 
       <Text variant="labelSmall" style={styles.sectionLabel}>하루 기준 시간</Text>
       <View style={styles.section}>
-        <TouchableOpacity style={styles.item} onPress={() => setShowTimePicker(true)}>
+        <TouchableOpacity style={styles.item} onPress={handleOpenPicker}>
           <View>
             <Text variant="bodyLarge">하루 시작 시간</Text>
             <Text variant="bodySmall" style={styles.description}>
               이 시간이 지나면 오늘 완료한 할 일이 정리돼요
             </Text>
           </View>
-          <Text style={styles.timeValue}>{formatHour(dayStartHour)}</Text>
+          <Text style={styles.timeValue}>{formatMinutes(dayStartMinutes)}</Text>
         </TouchableOpacity>
-        {showTimePicker && (
-          <DateTimePicker
-            value={dayStartDate}
-            mode="time"
-            display="spinner"
-            themeVariant="dark"
-            onChange={handleTimeChange}
-          />
-        )}
       </View>
 
       <Text variant="labelSmall" style={styles.sectionLabel}>앱</Text>
@@ -222,12 +230,38 @@ export default function SettingsScreen() {
           </View>
         ))}
       </View>
+      </ScrollView>
+
+      {/* 시간 선택 Modal */}
+      <Modal visible={showTimePicker} transparent animationType="slide">
+        <View style={styles.modalOverlay}>
+          <View style={styles.modalSheet}>
+            <View style={styles.modalHeader}>
+              <TouchableOpacity onPress={handleCancel} hitSlop={12}>
+                <Text style={styles.modalCancel}>취소</Text>
+              </TouchableOpacity>
+              <TouchableOpacity onPress={handleConfirm} hitSlop={12}>
+                <Text style={styles.modalConfirm}>완료</Text>
+              </TouchableOpacity>
+            </View>
+            <DateTimePicker
+              value={tempDate}
+              mode="time"
+              display="spinner"
+              themeVariant="dark"
+              onChange={handlePickerChange}
+              style={styles.picker}
+            />
+          </View>
+        </View>
+      </Modal>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: Colors.background },
+  scrollContent: { paddingBottom: 40 },
   section: {
     backgroundColor: Colors.surface,
     marginTop: 4,
@@ -292,5 +326,38 @@ const styles = StyleSheet.create({
     color: '#FFFFFF',
     fontWeight: '600',
     fontSize: 14,
+  },
+  // Modal
+  modalOverlay: {
+    flex: 1,
+    justifyContent: 'flex-end',
+    backgroundColor: 'rgba(0,0,0,0.5)',
+  },
+  modalSheet: {
+    backgroundColor: Colors.surface,
+    borderTopLeftRadius: 16,
+    borderTopRightRadius: 16,
+    paddingBottom: 32,
+  },
+  modalHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingHorizontal: 20,
+    paddingVertical: 14,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: Colors.border,
+  },
+  modalCancel: {
+    fontSize: 16,
+    color: Colors.textSecondary,
+  },
+  modalConfirm: {
+    fontSize: 16,
+    color: Colors.primary,
+    fontWeight: '600',
+  },
+  picker: {
+    width: '100%',
   },
 });

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -1,4 +1,6 @@
 import { View, StyleSheet, TouchableOpacity, Alert, ActivityIndicator } from 'react-native';
+import { useState } from 'react';
+import DateTimePicker, { DateTimePickerEvent } from '@react-native-community/datetimepicker';
 import { Appbar, Text, Divider } from 'react-native-paper';
 import { Colors } from '../theme';
 import { useNavigation } from '@react-navigation/native';
@@ -6,6 +8,7 @@ import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { SettingsStackParamList } from '../navigation/SettingsStack';
 import Constants from 'expo-constants';
 import { useAdFree, REQUIRED_AD_COUNT } from '../hooks/useAdFree';
+import { getDayStartHour, setDayStartHour } from '../db';
 
 type NavigationProp = NativeStackNavigationProp<SettingsStackParamList, 'SettingsHome'>;
 
@@ -23,6 +26,20 @@ function formatDate(ts: number): string {
 export default function SettingsScreen() {
   const navigation = useNavigation<NavigationProp>();
   const { isAdFree, adFreeUntil, watchedCount, watchAd, isLoading, resetAdFree } = useAdFree();
+  const [dayStartHour, setDayStartHourState] = useState(() => getDayStartHour());
+  const [showTimePicker, setShowTimePicker] = useState(false);
+
+  const dayStartDate = new Date();
+  dayStartDate.setHours(dayStartHour, 0, 0, 0);
+
+  const handleTimeChange = (_: DateTimePickerEvent, date?: Date) => {
+    setShowTimePicker(false);
+    if (date) {
+      const hour = date.getHours();
+      setDayStartHour(hour);
+      setDayStartHourState(hour);
+    }
+  };
 
   return (
     <View style={styles.container}>
@@ -90,6 +107,27 @@ export default function SettingsScreen() {
         </>
       )}
 
+      <Text variant="labelSmall" style={styles.sectionLabel}>하루 기준 시간</Text>
+      <View style={styles.section}>
+        <TouchableOpacity style={styles.item} onPress={() => setShowTimePicker(true)}>
+          <View>
+            <Text variant="bodyLarge">하루 시작 시간</Text>
+            <Text variant="bodySmall" style={styles.description}>
+              이 시간 이후부터 새로운 날로 인식해요
+            </Text>
+          </View>
+          <Text style={styles.timeValue}>오전 {String(dayStartHour).padStart(2, '0')}:00</Text>
+        </TouchableOpacity>
+        {showTimePicker && (
+          <DateTimePicker
+            value={dayStartDate}
+            mode="time"
+            display="spinner"
+            onChange={handleTimeChange}
+          />
+        )}
+      </View>
+
       <Text variant="labelSmall" style={styles.sectionLabel}>앱</Text>
       <View style={styles.section}>
         {APP_INFO.map((info, index) => (
@@ -133,6 +171,7 @@ const styles = StyleSheet.create({
     padding: 16,
   },
   infoValue: { color: Colors.textSecondary },
+  timeValue: { color: Colors.primary, fontWeight: '600', fontSize: 15 },
   rewardedSection: {
     flexDirection: 'row',
     alignItems: 'center',

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -1,14 +1,19 @@
 import { View, StyleSheet, TouchableOpacity, Alert, ActivityIndicator } from 'react-native';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import DateTimePicker, { DateTimePickerEvent } from '@react-native-community/datetimepicker';
 import { Appbar, Text, Divider } from 'react-native-paper';
+import { useQueryClient } from '@tanstack/react-query';
+import dayjs from 'dayjs';
 import { Colors } from '../theme';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { SettingsStackParamList } from '../navigation/SettingsStack';
 import Constants from 'expo-constants';
 import { useAdFree, REQUIRED_AD_COUNT } from '../hooks/useAdFree';
-import { getDayStartHour, setDayStartHour } from '../db';
+import { setDayStartHour, db } from '../db';
+import { todos, todoCompletions } from '../db/schema';
+import { useDayStartStore } from '../stores/dayStartStore';
+import { resetDueDateCheckGuard, runDueDateCheck } from '../hooks/useTodos';
 
 type NavigationProp = NativeStackNavigationProp<SettingsStackParamList, 'SettingsHome'>;
 
@@ -23,23 +28,83 @@ function formatDate(ts: number): string {
   return `${d.getMonth() + 1}월 ${d.getDate()}일`;
 }
 
+function formatHour(hour: number): string {
+  if (hour === 0) return '오전 12:00';
+  if (hour < 12) return `오전 ${hour}:00`;
+  if (hour === 12) return '오후 12:00';
+  return `오후 ${hour - 12}:00`;
+}
+
 export default function SettingsScreen() {
   const navigation = useNavigation<NavigationProp>();
   const { isAdFree, adFreeUntil, watchedCount, watchAd, isLoading, resetAdFree } = useAdFree();
-  const [dayStartHour, setDayStartHourState] = useState(() => getDayStartHour());
+  const queryClient = useQueryClient();
+
+  // 하루 시작 시간 — Zustand 스토어에서 읽음 (변경 시 타이머 자동 재시작)
+  const { dayStartHour, setDayStartHour: setDayStartHourInStore } = useDayStartStore();
   const [showTimePicker, setShowTimePicker] = useState(false);
 
-  const dayStartDate = new Date();
-  dayStartDate.setHours(dayStartHour, 0, 0, 0);
+  const dayStartDate = useMemo(() => {
+    const d = new Date();
+    d.setHours(dayStartHour, 0, 0, 0);
+    return d;
+  }, [dayStartHour]);
+
+  const nextTimerStr = useMemo(() => {
+    const now = dayjs();
+    let next = now.startOf('day').add(dayStartHour, 'hour');
+    if (!now.isBefore(next)) next = next.add(1, 'day');
+    return next.format('M월 D일 HH:mm');
+  }, [dayStartHour]);
 
   const handleTimeChange = (_: DateTimePickerEvent, date?: Date) => {
     setShowTimePicker(false);
     if (date) {
       const hour = date.getHours();
-      setDayStartHour(hour);
-      setDayStartHourState(hour);
+      setDayStartHour(hour);         // DB 저장
+      setDayStartHourInStore(hour);  // 스토어 업데이트 → 타이머 재시작
     }
   };
+
+  // ── 개발용 ──────────────────────────────────────────
+  const handleCreateTestTodo = async () => {
+    const yesterday = dayjs().subtract(1, 'day');
+    const yesterdayTs = yesterday.startOf('day').valueOf();
+    const yesterdayStr = yesterday.format('YYYY-MM-DD');
+    const now = Date.now();
+
+    const cats = db.select().from(require('../db/schema').categories).all() as { id: number }[];
+    const catId = cats[0]?.id ?? 1;
+
+    const result = db.insert(todos).values({
+      categoryId: catId,
+      title: '[타이머테스트] 어제 완료한 할 일',
+      dueDate: yesterdayTs,
+      sortOrder: -9999,
+      urgency: 0,
+      importance: 0,
+      createdAt: now,
+      updatedAt: now,
+    }).returning({ id: todos.id }).get();
+
+    if (result) {
+      db.insert(todoCompletions).values({ todoId: result.id, completedDate: yesterdayStr }).run();
+      queryClient.invalidateQueries({ queryKey: ['todos'] });
+      Alert.alert(
+        '테스트 할 일 생성',
+        `"[타이머테스트] 어제 완료한 할 일" 생성\n어제(${yesterdayStr}) 완료 기록 추가\n\n이제 "타이머 강제 실행"을 눌러 정리 여부를 확인하세요`,
+      );
+    }
+  };
+
+  const handleForceRunTimer = async () => {
+    resetDueDateCheckGuard();
+    const changed = await runDueDateCheck();
+    queryClient.invalidateQueries({ queryKey: ['todos'] });
+    queryClient.invalidateQueries({ queryKey: ['completions'], exact: false });
+    Alert.alert('타이머 강제 실행', changed ? '할 일이 정리됐어요 ✓' : '정리할 항목이 없어요');
+  };
+  // ────────────────────────────────────────────────────
 
   return (
     <View style={styles.container}>
@@ -103,6 +168,22 @@ export default function SettingsScreen() {
             >
               <Text variant="bodyLarge" style={{ color: Colors.danger }}>광고 면제 초기화</Text>
             </TouchableOpacity>
+            <Divider />
+            <TouchableOpacity style={styles.item} onPress={handleCreateTestTodo}>
+              <View>
+                <Text variant="bodyLarge" style={{ color: Colors.danger }}>테스트 할 일 생성</Text>
+                <Text variant="bodySmall" style={styles.description}>어제 날짜 + 완료 기록 포함</Text>
+              </View>
+            </TouchableOpacity>
+            <Divider />
+            <TouchableOpacity style={styles.item} onPress={handleForceRunTimer}>
+              <View>
+                <Text variant="bodyLarge" style={{ color: Colors.danger }}>타이머 강제 실행</Text>
+                <Text variant="bodySmall" style={styles.description}>
+                  다음 예약: {nextTimerStr}
+                </Text>
+              </View>
+            </TouchableOpacity>
           </View>
         </>
       )}
@@ -113,16 +194,17 @@ export default function SettingsScreen() {
           <View>
             <Text variant="bodyLarge">하루 시작 시간</Text>
             <Text variant="bodySmall" style={styles.description}>
-              이 시간 이후부터 새로운 날로 인식해요
+              이 시간이 지나면 오늘 완료한 할 일이 정리돼요
             </Text>
           </View>
-          <Text style={styles.timeValue}>오전 {String(dayStartHour).padStart(2, '0')}:00</Text>
+          <Text style={styles.timeValue}>{formatHour(dayStartHour)}</Text>
         </TouchableOpacity>
         {showTimePicker && (
           <DateTimePicker
             value={dayStartDate}
             mode="time"
             display="spinner"
+            themeVariant="dark"
             onChange={handleTimeChange}
           />
         )}

--- a/src/stores/dayStartStore.ts
+++ b/src/stores/dayStartStore.ts
@@ -1,11 +1,11 @@
 import { create } from 'zustand';
 
 interface DayStartState {
-  dayStartHour: number;
-  setDayStartHour: (hour: number) => void;
+  dayStartMinutes: number;
+  setDayStartMinutes: (minutes: number) => void;
 }
 
 export const useDayStartStore = create<DayStartState>((set) => ({
-  dayStartHour: 0,
-  setDayStartHour: (hour) => set({ dayStartHour: hour }),
+  dayStartMinutes: 0,
+  setDayStartMinutes: (minutes) => set({ dayStartMinutes: minutes }),
 }));

--- a/src/stores/dayStartStore.ts
+++ b/src/stores/dayStartStore.ts
@@ -1,0 +1,11 @@
+import { create } from 'zustand';
+
+interface DayStartState {
+  dayStartHour: number;
+  setDayStartHour: (hour: number) => void;
+}
+
+export const useDayStartStore = create<DayStartState>((set) => ({
+  dayStartHour: 0,
+  setDayStartHour: (hour) => set({ dayStartHour: hour }),
+}));


### PR DESCRIPTION
## 이슈
Closes #138

## 변경 사항
- `src/db/index.ts`: `getDayStartHour()` / `setDayStartHour()` 헬퍼 추가 — `app_settings`에 `day_start_hour` 키로 저장 (기본값: 0)
- `src/hooks/useTodos.ts`: `runDueDateCheck`에서 설정된 시간을 기준으로 유효 하루 시작 시각 계산
- `src/screens/SettingsScreen.tsx`: 하루 기준 시간 설정 UI — DateTimePicker(spinner) 방식으로 구현, 현재 설정 시간을 우측에 표시

## 테스트
- [ ] 설정 화면에서 "하루 시작 시간" 항목 탭 시 타임 피커 표시 확인
- [ ] 시간 변경 후 표시값 업데이트 확인
- [ ] 앱 재시작 후 설정 유지 확인
- [ ] 설정 시간 이후에 runDueDateCheck 실행 시 새 날로 인식하는지 확인