### PR TITLE
#140 자동 정리 실행 시 루틴 완료 상태 미갱신 버그 수정

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -8,7 +8,7 @@ import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { PaperProvider } from 'react-native-paper';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import MobileAds from 'react-native-google-mobile-ads';
-import { initDb, getDayStartMinutes } from './src/db';
+import { initDb, getDayStartMinutes, computeEffectiveToday } from './src/db';
 import { requestNotificationPermission } from './src/utils/notifications';
 import RootNavigator from './src/navigation/RootNavigator';
 import { AppTheme, NavTheme } from './src/theme';
@@ -47,6 +47,7 @@ export default function App() {
       .then(() => {
         // DB 초기화 완료 후 스토어에 설정값 동기화
         useDayStartStore.getState().setDayStartMinutes(getDayStartMinutes());
+        useDayStartStore.getState().setEffectiveToday(computeEffectiveToday());
       })
       .then(() => requestNotificationPermission())
       .then(async () => {

--- a/src/components/TodoTabToday.tsx
+++ b/src/components/TodoTabToday.tsx
@@ -3,9 +3,9 @@ import { Text, Divider, Menu } from 'react-native-paper';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useMemo, useState } from 'react';
-import dayjs from 'dayjs';
 import { Colors } from '../theme';
 import { useTodosToday, useTodayCompletionIds, useTodayToggle } from '../hooks/useTodos';
+import { useDayStartStore } from '../stores/dayStartStore';
 import { useRoutinesToday, useToggleRoutineCompletion } from '../hooks/useRoutines';
 import { useCategories } from '../hooks/useCategories';
 import { useCategoryMap } from '../hooks/useCategoryMap';
@@ -43,7 +43,7 @@ export default function TodoTabToday() {
   const [sortKey, setSortKey] = useState<SortKey>('default');
   const [sortMenuVisible, setSortMenuVisible] = useState(false);
 
-  const today = dayjs().format('YYYY-MM-DD');
+  const today = useDayStartStore(s => s.effectiveToday);
 
   const categoryMap = useCategoryMap(categories);
   const getCheckable = useCheckable({ mode: 'today', completedIds, toggleFn: todayToggle });

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,6 +1,7 @@
 import { openDatabaseSync } from 'expo-sqlite';
 import { drizzle } from 'drizzle-orm/expo-sqlite';
 import { eq } from 'drizzle-orm';
+import dayjs from 'dayjs';
 import * as schema from './schema';
 
 type Db = ReturnType<typeof drizzle<typeof schema>>;
@@ -133,6 +134,17 @@ export function getDayStartMinutes(): number {
   const row = db.select().from(schema.appSettings)
     .where(eq(schema.appSettings.key, 'day_start_hour')).get();
   return row ? parseInt(row.value, 10) : 0;
+}
+
+/** 현재 시각 기준 "유효 오늘" (YYYY-MM-DD).
+ *  하루 시작 시간 전이면 어제 날짜를 반환. */
+export function computeEffectiveToday(): string {
+  const minutes = getDayStartMinutes();
+  const now = dayjs();
+  const todayAtStart = now.startOf('day').add(minutes, 'minute');
+  return now.isBefore(todayAtStart)
+    ? now.subtract(1, 'day').format('YYYY-MM-DD')
+    : now.format('YYYY-MM-DD');
 }
 
 export function setDayStartMinutes(minutes: number): void {

--- a/src/hooks/useDayStartTimer.ts
+++ b/src/hooks/useDayStartTimer.ts
@@ -2,6 +2,8 @@ import { useEffect, useRef } from 'react';
 import dayjs from 'dayjs';
 import { useQueryClient } from '@tanstack/react-query';
 import { runDueDateCheck } from './useTodos';
+import { computeEffectiveToday } from '../db';
+import { useDayStartStore } from '../stores/dayStartStore';
 
 export function useDayStartTimer(dayStartMinutes: number) {
   const queryClient = useQueryClient();
@@ -26,11 +28,15 @@ export function useDayStartTimer(dayStartMinutes: number) {
 
       timerRef.current = setTimeout(async () => {
         if (__DEV__) console.log('[DayStartTimer] 할 일 정리 실행');
-        const changed = await runDueDateCheck();
-        if (changed) {
-          queryClient.invalidateQueries({ queryKey: ['todos'] });
-          queryClient.invalidateQueries({ queryKey: ['completions'], exact: false });
+        // effectiveToday 먼저 갱신 → 이후 쿼리 re-fetch 시 새 날짜 기준으로 동작
+        const newEffective = computeEffectiveToday();
+        const current = useDayStartStore.getState().effectiveToday;
+        if (newEffective > current) {
+          useDayStartStore.getState().setEffectiveToday(newEffective);
         }
+        await runDueDateCheck();
+        queryClient.invalidateQueries({ queryKey: ['todos'] });
+        queryClient.invalidateQueries({ queryKey: ['completions'], exact: false });
         scheduleRef.current();
       }, delay);
     };

--- a/src/hooks/useRoutines.ts
+++ b/src/hooks/useRoutines.ts
@@ -3,6 +3,7 @@ import { and, asc, eq } from 'drizzle-orm';
 import dayjs from 'dayjs';
 import { db } from '../db';
 import { routines, routineCompletions } from '../db/schema';
+import { useDayStartStore } from '../stores/dayStartStore';
 import { scheduleRoutineNotifications, cancelRoutineNotifications, offsetsToString } from '../utils/notifications';
 
 export const useRoutines = () =>
@@ -182,12 +183,12 @@ export const useToggleRoutineCompletion = () => {
 
 /** 오늘 해당하는 루틴 목록 + 완료 여부 */
 export const useRoutinesToday = () => {
-  const today = dayjs().format('YYYY-MM-DD');
-  const dayOfWeek = String(dayjs().day());   // 0=일 ~ 6=토
-  const dayOfMonth = String(dayjs().date()); // 1~31
+  const effectiveToday = useDayStartStore(s => s.effectiveToday);
+  const dayOfWeek = String(dayjs().day());
+  const dayOfMonth = String(dayjs().date());
 
   return useQuery({
-    queryKey: ['routinesToday', today],
+    queryKey: ['routinesToday', effectiveToday],
     queryFn: () => {
       const allRoutines = db.select().from(routines)
         .where(eq(routines.isActive, 1))
@@ -209,7 +210,7 @@ export const useRoutinesToday = () => {
 
       const completedIds = new Set(
         db.select().from(routineCompletions)
-          .where(eq(routineCompletions.completedDate, today))
+          .where(eq(routineCompletions.completedDate, effectiveToday))
           .all()
           .map((rc) => rc.routineId),
       );

--- a/src/hooks/useTodos.ts
+++ b/src/hooks/useTodos.ts
@@ -3,6 +3,7 @@ import { and, asc, desc, eq, gte, isNull, lt, lte, or } from 'drizzle-orm';
 import dayjs from 'dayjs';
 import { db, getDayStartMinutes } from '../db';
 import { todos, todoCompletions } from '../db/schema';
+import { useDayStartStore } from '../stores/dayStartStore';
 import { scheduleTodoNotifications, cancelTodoNotifications, offsetsToString } from '../utils/notifications';
 
 export const useTodos = (isCompleted: 0 | 1) =>
@@ -103,12 +104,12 @@ export const useTodosCompletedByCategory = (categoryId: number) =>
 
 /** 오늘 탭 전용: 오늘 완료 체크된 todoId Set */
 export const useTodayCompletionIds = () => {
-  const today = dayjs().format('YYYY-MM-DD');
+  const effectiveToday = useDayStartStore(s => s.effectiveToday);
   return useQuery({
-    queryKey: ['todayCompletionIds', today],
+    queryKey: ['todayCompletionIds', effectiveToday],
     queryFn: () => {
       const records = db.select().from(todoCompletions)
-        .where(eq(todoCompletions.completedDate, today))
+        .where(eq(todoCompletions.completedDate, effectiveToday))
         .all();
       return new Set(records.map((r) => r.todoId));
     },
@@ -120,7 +121,7 @@ export const useTodayToggle = () => {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async (id: number) => {
-      const today = dayjs().format('YYYY-MM-DD');
+      const today = useDayStartStore.getState().effectiveToday;
       const existing = db.select().from(todoCompletions)
         .where(and(eq(todoCompletions.todoId, id), eq(todoCompletions.completedDate, today)))
         .get();
@@ -411,9 +412,9 @@ export const useFlushTodayCompleted = () => {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async (): Promise<number> => {
-      const today = dayjs().format('YYYY-MM-DD');
-      const todayStart = dayjs().startOf('day').valueOf();
-      const todayEnd = dayjs().endOf('day').valueOf();
+      const today = useDayStartStore.getState().effectiveToday;
+      const todayStart = dayjs(today).startOf('day').valueOf();
+      const todayEnd = dayjs(today).endOf('day').valueOf();
       const now = Date.now();
 
       const todayTodos = db.select().from(todos)

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -41,7 +41,7 @@ export default function SettingsScreen() {
   const { isAdFree, adFreeUntil, watchedCount, watchAd, isLoading, resetAdFree } = useAdFree();
   const queryClient = useQueryClient();
 
-  const { dayStartMinutes, setDayStartMinutes: setDayStartMinutesInStore } = useDayStartStore();
+  const { dayStartMinutes, setDayStartMinutes: setDayStartMinutesInStore, setEffectiveToday } = useDayStartStore();
   const [showTimePicker, setShowTimePicker] = useState(false);
   const [tempDate, setTempDate] = useState<Date>(() => {
     const d = new Date();
@@ -115,6 +115,9 @@ export default function SettingsScreen() {
 
   const handleForceRunTimer = async () => {
     resetDueDateCheckGuard();
+    // 다음날 시작 시각을 시뮬레이션 — effectiveToday를 하루 앞으로 이동
+    const currentEffective = useDayStartStore.getState().effectiveToday;
+    setEffectiveToday(dayjs(currentEffective).add(1, 'day').format('YYYY-MM-DD'));
     const changed = await runDueDateCheck();
     queryClient.invalidateQueries({ queryKey: ['todos'] });
     queryClient.invalidateQueries({ queryKey: ['completions'], exact: false });

--- a/src/screens/TodoScreen.tsx
+++ b/src/screens/TodoScreen.tsx
@@ -7,7 +7,8 @@ import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useState, useEffect } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { Colors } from '../theme';
-import { getAdFreeUntil } from '../db';
+import { getAdFreeUntil, computeEffectiveToday } from '../db';
+import { useDayStartStore } from '../stores/dayStartStore';
 import { runDueDateCheck, useFlushTodayCompleted } from '../hooks/useTodos';
 import { TodoStackParamList } from '../navigation/TodoStack';
 import BannerAdView from '../components/BannerAdView';
@@ -57,8 +58,14 @@ export default function TodoScreen() {
   useEffect(() => {
     if (!isFocused) return;
     const task = InteractionManager.runAfterInteractions(() => {
-      runDueDateCheck().then((changed) => {
-        if (changed) queryClient.invalidateQueries({ queryKey: ['todos'] });
+      // effectiveToday를 앞으로만 갱신 (뒤로 돌아가지 않음)
+      const newEffective = computeEffectiveToday();
+      if (newEffective > useDayStartStore.getState().effectiveToday) {
+        useDayStartStore.getState().setEffectiveToday(newEffective);
+      }
+      runDueDateCheck().then(() => {
+        queryClient.invalidateQueries({ queryKey: ['todos'] });
+        queryClient.invalidateQueries({ queryKey: ['completions'], exact: false });
       });
     });
     return () => task.cancel();

--- a/src/stores/dayStartStore.ts
+++ b/src/stores/dayStartStore.ts
@@ -3,9 +3,14 @@ import { create } from 'zustand';
 interface DayStartState {
   dayStartMinutes: number;
   setDayStartMinutes: (minutes: number) => void;
+  /** 하루 시작 시간 기준 유효 오늘 날짜 (YYYY-MM-DD) */
+  effectiveToday: string;
+  setEffectiveToday: (date: string) => void;
 }
 
 export const useDayStartStore = create<DayStartState>((set) => ({
   dayStartMinutes: 0,
   setDayStartMinutes: (minutes) => set({ dayStartMinutes: minutes }),
+  effectiveToday: new Date().toISOString().split('T')[0],
+  setEffectiveToday: (date) => set({ effectiveToday: date }),
 }));


### PR DESCRIPTION
## 이슈
Closes #140

## 변경 사항
- `dayStartStore`에 `effectiveToday` 상태 추가 — 하루 시작 시간 기준 유효 날짜를 전역으로 관리
- `db/index.ts`: `computeEffectiveToday()` 함수 추가 (하루 시작 시간 전이면 어제 날짜 반환)
- `useRoutinesToday`: 쿼리 키와 완료 조회를 `effectiveToday` 기준으로 변경 → 날짜 변경 시 자동 re-fetch
- `useTodayCompletionIds`: 쿼리 키와 조회를 `effectiveToday` 기준으로 변경
- `useTodayToggle` / `useFlushTodayCompleted`: 완료 기록 날짜를 `effectiveToday` 기준으로 통일
- `useDayStartTimer`: 타이머 실행 시 `effectiveToday` 먼저 갱신 후 쿼리 invalidate (changed 여부 무관하게 항상 실행)
- `TodoScreen`: 포그라운드 복귀 시 `effectiveToday` 갱신 + `completions` invalidate 추가
- `SettingsScreen`: 강제 실행 버튼에서 `effectiveToday` 하루 앞으로 이동하여 날짜 변경 시뮬레이션
- `TodoTabToday`: `dayjs().format()` 대신 스토어의 `effectiveToday` 사용
- `App.tsx`: DB 초기화 후 `effectiveToday` 초기값 설정

## 테스트
- [ ] 설정 화면 > "타이머 강제 실행" 버튼 실행 후 오늘 탭 루틴 완료 상태 초기화 확인
- [ ] 자정(또는 하루 시작 시간) 경과 후 앱 포그라운드 복귀 시 루틴 목록 갱신 확인
- [ ] 오늘 탭 루틴 체크/해제가 올바른 날짜로 기록되는지 확인
- [ ] 하루 시작 시간이 오전 6시로 설정된 경우 새벽 2시에 여전히 전날 루틴이 표시되는지 확인