### PR TITLE
#142 배너 광고 및 리워드 광고 미표시 버그 수정

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -7,7 +7,7 @@ import { AppState, AppStateStatus } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { PaperProvider } from 'react-native-paper';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
-import MobileAds from 'react-native-google-mobile-ads';
+import MobileAds, { MaxAdContentRating } from 'react-native-google-mobile-ads';
 import { initDb, getDayStartMinutes } from './src/db';
 import { requestNotificationPermission } from './src/utils/notifications';
 import RootNavigator from './src/navigation/RootNavigator';
@@ -42,7 +42,16 @@ export default function App() {
   useEffect(() => {
     const start = Date.now();
 
-    MobileAds().initialize()
+    MobileAds()
+      .setRequestConfiguration({
+        tagForChildDirectedTreatment: false,
+        tagForUnderAgeOfConsent: false,
+        maxAdContentRating: MaxAdContentRating.T,
+      })
+      .then(() => MobileAds().initialize())
+      .then((adapterStatuses) => {
+        console.log('[AdMob] 초기화 완료:', JSON.stringify(adapterStatuses));
+      })
       .then(() => initDb())
       .then(() => {
         // DB 초기화 완료 후 스토어에 설정값 동기화

--- a/src/components/BannerAdView.tsx
+++ b/src/components/BannerAdView.tsx
@@ -1,8 +1,15 @@
+import { Platform } from 'react-native';
 import { BannerAd, BannerAdSize, TestIds } from 'react-native-google-mobile-ads';
 import { getAdFreeUntil } from '../db';
 
-const PROD_AD_UNIT_ID = 'ca-app-pub-9156090950228888/1226497541';
-const adUnitId = __DEV__ ? TestIds.BANNER : PROD_AD_UNIT_ID;
+const PROD_AD_UNIT_ID = Platform.select({
+  ios: 'ca-app-pub-9156090950228888/1226497541',
+  // TODO: AdMob에 Android 앱 등록 후 아래 ID 교체
+  android: TestIds.BANNER,
+  default: TestIds.BANNER,
+});
+
+const adUnitId = __DEV__ ? TestIds.BANNER : PROD_AD_UNIT_ID!;
 
 export default function BannerAdView() {
   if (getAdFreeUntil() > Date.now()) return null;
@@ -11,7 +18,8 @@ export default function BannerAdView() {
     <BannerAd
       unitId={adUnitId}
       size={BannerAdSize.ANCHORED_ADAPTIVE_BANNER}
-      requestOptions={{ requestNonPersonalizedAdsOnly: true }}
+      onAdLoaded={() => console.log('[BannerAd] 로드 성공')}
+      onAdFailedToLoad={(error) => console.warn('[BannerAd] 로드 실패 코드', error.code, error.message)}
     />
   );
 }

--- a/src/hooks/useAdFree.ts
+++ b/src/hooks/useAdFree.ts
@@ -1,13 +1,21 @@
 import { useState } from 'react';
+import { Platform } from 'react-native';
 import { RewardedAd, RewardedAdEventType, AdEventType, TestIds } from 'react-native-google-mobile-ads';
 import { getAdFreeUntil, setAdFreeUntil } from '../db';
 
-// TODO: AdMob 콘솔에서 리워드 광고 단위 ID 생성 후 교체
-const PROD_REWARDED_AD_UNIT_ID = 'ca-app-pub-9156090950228888/3269553980';
-const adUnitId = __DEV__ ? TestIds.REWARDED : PROD_REWARDED_AD_UNIT_ID;
+const PROD_REWARDED_AD_UNIT_ID = Platform.select({
+  ios: 'ca-app-pub-9156090950228888/3269553980',
+  // TODO: AdMob에 Android 앱 등록 후 아래 ID 교체
+  android: TestIds.REWARDED,
+  default: TestIds.REWARDED,
+});
+
+const adUnitId = __DEV__ ? TestIds.REWARDED : PROD_REWARDED_AD_UNIT_ID!;
 
 const AD_FREE_DURATION_MS = 30 * 24 * 60 * 60 * 1000; // 30일
 export const REQUIRED_AD_COUNT = 2;
+
+const AD_LOAD_TIMEOUT_MS = 30_000;
 
 export function useAdFree() {
   const [adFreeUntil, setAdFreeUntilState] = useState(() => getAdFreeUntil());
@@ -20,40 +28,53 @@ export function useAdFree() {
     if (isLoading) return;
     setIsLoading(true);
 
-    const rewarded = RewardedAd.createForAdRequest(adUnitId, {
-      requestNonPersonalizedAdsOnly: true,
-    });
+    const rewarded = RewardedAd.createForAdRequest(adUnitId);
 
-    const unsubLoaded = rewarded.addAdEventListener(RewardedAdEventType.LOADED, () => {
+    const unsubs: Array<() => void> = [];
+    let cleanedUp = false;
+    let loadTimeoutId: ReturnType<typeof setTimeout>;
+
+    const cleanup = () => {
+      if (cleanedUp) return;
+      cleanedUp = true;
+      clearTimeout(loadTimeoutId);
+      unsubs.forEach(fn => fn());
+    };
+
+    loadTimeoutId = setTimeout(() => {
+      if (__DEV__) console.warn('[AdFree] 광고 로드 타임아웃');
+      cleanup();
       setIsLoading(false);
-      rewarded.show().catch(() => setIsLoading(false));
-    });
+    }, AD_LOAD_TIMEOUT_MS);
 
-    const unsubEarned = rewarded.addAdEventListener(
-      RewardedAdEventType.EARNED_REWARD,
-      () => {
-        unsubLoaded();
-        unsubEarned();
-        unsubError();
-        setWatchedCount((prev) => {
-          const next = prev + 1;
-          if (next >= REQUIRED_AD_COUNT) {
-            const until = Date.now() + AD_FREE_DURATION_MS;
-            setAdFreeUntil(until);
-            setAdFreeUntilState(until);
-            return 0;
-          }
-          return next;
-        });
-      }
-    );
-
-    const unsubError = rewarded.addAdEventListener(AdEventType.ERROR, () => {
-      unsubLoaded();
-      unsubEarned();
-      unsubError();
+    unsubs.push(rewarded.addAdEventListener(RewardedAdEventType.LOADED, () => {
+      clearTimeout(loadTimeoutId);
       setIsLoading(false);
-    });
+      rewarded.show().catch(() => cleanup());
+    }));
+
+    unsubs.push(rewarded.addAdEventListener(RewardedAdEventType.EARNED_REWARD, () => {
+      setWatchedCount((prev) => {
+        const next = prev + 1;
+        if (next >= REQUIRED_AD_COUNT) {
+          const until = Date.now() + AD_FREE_DURATION_MS;
+          setAdFreeUntil(until);
+          setAdFreeUntilState(until);
+          return 0;
+        }
+        return next;
+      });
+    }));
+
+    unsubs.push(rewarded.addAdEventListener(AdEventType.CLOSED, () => {
+      cleanup();
+    }));
+
+    unsubs.push(rewarded.addAdEventListener(AdEventType.ERROR, (error) => {
+      console.warn('[AdFree] 광고 로드 실패:', error);
+      cleanup();
+      setIsLoading(false);
+    }));
 
     rewarded.load();
   };


### PR DESCRIPTION
## 이슈
Closes #142

## 변경 사항
- `BannerAdView`: `requestNonPersonalizedAdsOnly: true` 제거 → 광고 인벤토리 풀 확대로 fill rate 개선
- `useAdFree`: 동일하게 `requestNonPersonalizedAdsOnly` 제거
- `useAdFree`: 30초 로딩 타임아웃 추가 — 리워드 광고 무한 스피너 방지
- `useAdFree`: `CLOSED` 이벤트 핸들러 추가 — 광고 닫을 때 리스너 정리
- `useAdFree`: `ERROR` 이벤트에 에러 로깅 추가
- `BannerAdView`: Platform별 광고 단위 ID 분리 (iOS/Android)
- `BannerAdView`: `onAdLoaded` / `onAdFailedToLoad` 로깅 추가
- `App.tsx`: `setRequestConfiguration` 추가, `initialize()` 완료 상태 로깅

## 원인 분석
AdMob 보고서 확인 결과 요청수 24건, 일치율 0.00%. SDK는 정상 동작 중이며 `requestNonPersonalizedAdsOnly: true`가 광고 인벤토리 풀을 과도하게 제한한 것이 주요 원인. 실 사용자 트래픽이 쌓이면 fill rate는 자연히 상승함.

## 테스트
- [ ] DEV 빌드에서 테스트 광고 정상 출력 확인
- [ ] Production 빌드 후 AdMob 보고서에서 일치율 변화 모니터링
- [ ] 리워드 광고 로딩 후 닫기 시 정상 종료 (무한 스피너 없음) 확인
- [ ] 리워드 광고 30초 이상 응답 없을 때 타임아웃 처리 확인