### PR TITLE
#148 [Phase 2] 할 일 탭 오늘 프로그레스 바 추가

### DIFF
--- a/.claude/phase-map.json
+++ b/.claude/phase-map.json
@@ -7,14 +7,14 @@
       "title": "루틴 탭 신설 및 오늘 탭 제거",
       "issueNumber": 147,
       "branch": "feature/issue-146/tab-restructure-add-routine-tab",
-      "status": "in_progress"
+      "status": "done"
     },
     {
       "number": 2,
       "title": "할 일 탭 오늘 프로그레스 바 추가",
       "issueNumber": 148,
       "branch": "feature/issue-146/todo-tab-today-progress",
-      "status": "pending"
+      "status": "in_progress"
     }
   ]
 }

--- a/src/components/TodoTabList.tsx
+++ b/src/components/TodoTabList.tsx
@@ -5,12 +5,13 @@ import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useTranslation } from 'react-i18next';
 import { Colors } from '../theme';
-import { useTodosList, useTodayCompletionIds, useTodayToggle } from '../hooks/useTodos';
+import { useTodosList, useTodosToday, useTodayCompletionIds, useTodayToggle } from '../hooks/useTodos';
 import { useCategories } from '../hooks/useCategories';
 import { useCategoryMap } from '../hooks/useCategoryMap';
 import { useCheckable } from '../hooks/useCheckable';
 import TodoItem from './TodoItem';
 import DateSeparator from './DateSeparator';
+import TodayProgressBar from './TodayProgressBar';
 import { TodoStackParamList } from '../navigation/TodoStack';
 import { Todo } from '../types';
 import { toDateKey, formatDueDateLabel } from '../utils/date';
@@ -52,6 +53,7 @@ export default function TodoTabList() {
   const navigation = useNavigation<Nav>();
   const { t } = useTranslation();
   const { data: todos = [] } = useTodosList();
+  const { data: todayTodos = [] } = useTodosToday();
   const { data: completedIds = new Set<number>() } = useTodayCompletionIds();
   const { data: categories = [] } = useCategories();
   const { mutate: todayToggle } = useTodayToggle();
@@ -63,6 +65,21 @@ export default function TodoTabList() {
   const getCheckable = useCheckable({ mode: 'today', completedIds, toggleFn: todayToggle });
 
   const listItems = useMemo(() => buildGroupedList(todos as Todo[], sortKey), [todos, sortKey]);
+
+  const progressSegments = useMemo(() => {
+    const map = new Map<number, { color: string; count: number }>();
+    for (const todo of todayTodos as Todo[]) {
+      if (!completedIds.has(todo.id)) continue;
+      const cat = categoryMap.get(todo.categoryId);
+      const color = cat?.color ?? Colors.primary;
+      const key = todo.categoryId ?? 0;
+      map.set(key, { color, count: (map.get(key)?.count ?? 0) + 1 });
+    }
+    return [...map.entries()].map(([categoryId, { color, count }]) => ({ categoryId, color, count }));
+  }, [todayTodos, completedIds, categoryMap]);
+
+  const progressTotal = (todayTodos as Todo[]).length;
+  const progressCompleted = progressSegments.reduce((s, seg) => s + seg.count, 0);
 
   const LIST_SORT_OPTIONS = [
     { key: 'deadline' as SortKey, label: t('todo.sort_deadline') },
@@ -91,6 +108,11 @@ export default function TodoTabList() {
 
   return (
     <View style={styles.container}>
+      <TodayProgressBar
+        segments={progressSegments}
+        totalCompleted={progressCompleted}
+        total={progressTotal}
+      />
       <View style={styles.sortRow}>
         <Menu
           visible={sortMenuVisible}


### PR DESCRIPTION
## 이슈
Closes #148

## 변경 사항
- `TodoTabList.tsx`: 상단에 오늘 할일 프로그레스 바 추가 (`useTodosToday` + `useTodayCompletionIds` 기반)
- 오늘 할일이 없는 경우 프로그레스 바 자동 미표시 (`total=0` 시 `TodayProgressBar`가 null 반환)
- 카테고리별 색상 세그먼트로 완료 현황 시각화

## 테스트
- [ ] 할 일 탭 상단에 오늘 할일 프로그레스 바 표시 확인
- [ ] 오늘 할일 체크 시 프로그레스 바 실시간 업데이트 확인
- [ ] 오늘 할일이 없는 경우 프로그레스 바 미표시 확인
- [ ] 정렬 메뉴 및 할일 목록 정상 렌더링 확인