### PR TITLE
#152 [Phase 1] 자동 완료 프로세스 제거 및 훅 교체

### DIFF
--- a/.claude/phase-map.json
+++ b/.claude/phase-map.json
@@ -1,20 +1,20 @@
 {
   "planFile": "warm-fluttering-cray.md",
-  "mainIssueNumber": 146,
+  "mainIssueNumber": 151,
   "phases": [
     {
       "number": 1,
-      "title": "루틴 탭 신설 및 오늘 탭 제거",
-      "issueNumber": 147,
-      "branch": "feature/issue-146/tab-restructure-add-routine-tab",
-      "status": "done"
+      "title": "자동 완료 프로세스 제거 및 훅 교체",
+      "issueNumber": 152,
+      "branch": "feature/issue-151/remove-auto-complete-process",
+      "status": "in_progress"
     },
     {
       "number": 2,
-      "title": "할 일 탭 오늘 프로그레스 바 추가",
-      "issueNumber": 148,
-      "branch": "feature/issue-146/todo-tab-today-progress",
-      "status": "in_progress"
+      "title": "정리 FAB 구현 (할 일/루틴 탭)",
+      "issueNumber": 153,
+      "branch": "feature/issue-151/cleanup-fab",
+      "status": "pending"
     }
   ]
 }

--- a/src/hooks/useDayStartTimer.ts
+++ b/src/hooks/useDayStartTimer.ts
@@ -1,7 +1,6 @@
 import { useEffect, useRef } from 'react';
 import dayjs from 'dayjs';
 import { useQueryClient } from '@tanstack/react-query';
-import { runDueDateCheck } from './useTodos';
 import { computeEffectiveToday } from '../db';
 import { useDayStartStore } from '../stores/dayStartStore';
 
@@ -26,15 +25,12 @@ export function useDayStartTimer(dayStartMinutes: number) {
         );
       }
 
-      timerRef.current = setTimeout(async () => {
-        if (__DEV__) console.log('[DayStartTimer] 할 일 정리 실행');
-        // effectiveToday 먼저 갱신 → 이후 쿼리 re-fetch 시 새 날짜 기준으로 동작
+      timerRef.current = setTimeout(() => {
         const newEffective = computeEffectiveToday();
         const current = useDayStartStore.getState().effectiveToday;
         if (newEffective > current) {
           useDayStartStore.getState().setEffectiveToday(newEffective);
         }
-        await runDueDateCheck();
         queryClient.invalidateQueries({ queryKey: ['todos'] });
         queryClient.invalidateQueries({ queryKey: ['completions'], exact: false });
         scheduleRef.current();

--- a/src/hooks/useTodos.ts
+++ b/src/hooks/useTodos.ts
@@ -1,7 +1,7 @@
 import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { and, asc, desc, eq, gte, isNull, lt, lte, or } from 'drizzle-orm';
+import { and, asc, desc, eq, gte, isNull, lt, or } from 'drizzle-orm';
 import dayjs from 'dayjs';
-import { db, getDayStartMinutes } from '../db';
+import { db } from '../db';
 import { todos, todoCompletions } from '../db/schema';
 import { useDayStartStore } from '../stores/dayStartStore';
 import { scheduleTodoNotifications, cancelTodoNotifications, offsetsToString } from '../utils/notifications';
@@ -141,72 +141,28 @@ export const useTodayToggle = () => {
   });
 };
 
-/** 기한/완료 체크: 아래 두 조건 중 하나라도 해당하면 isCompleted=1로 이동.
- *  1. 기한이 지난 항목 중 완료 기록이 있는 경우
- *  2. 기한에 관계없이 이전 날짜에 완료 기록된 항목 (어제 이전에 체크한 항목)
- *  앱 포그라운드 진입 및 탭 포커스 시 실행, 하루 1회만 실제 처리 */
-let _lastDueDateCheckDate = '';
-
-export const resetDueDateCheckGuard = () => { _lastDueDateCheckDate = ''; };
-
-export const runDueDateCheck = async (): Promise<boolean> => {
-  const dayStartMinutes = getDayStartMinutes();
-  const now = dayjs();
-  const todayAtStart = now.startOf('day').add(dayStartMinutes, 'minute');
-  const effectiveDayStart = now.isBefore(todayAtStart)
-    ? todayAtStart.subtract(1, 'day')
-    : todayAtStart;
-
-  const today = effectiveDayStart.format('YYYY-MM-DD');
-  if (_lastDueDateCheckDate === today) return false;
-  _lastDueDateCheckDate = today;
-
-  const todayStart = effectiveDayStart.valueOf();
-  let changed = false;
-
-  // 1. 기한이 지난 항목 중 완료 기록 있는 경우
-  const overdueTodos = db.select().from(todos)
-    .where(and(eq(todos.isCompleted, 0), eq(todos.isDeleted, 0), lt(todos.dueDate, todayStart)))
-    .all();
-
-  for (const todo of overdueTodos) {
-    const completion = db.select().from(todoCompletions)
-      .where(eq(todoCompletions.todoId, todo.id))
-      .get();
-    if (completion) {
+/** 오늘 체크된 할일을 isCompleted=1로 일괄 처리 (사용자가 정리 버튼 눌렀을 때) */
+export const useCleanupChecked = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async () => {
+      const today = useDayStartStore.getState().effectiveToday;
+      const completions = db.select().from(todoCompletions)
+        .where(eq(todoCompletions.completedDate, today))
+        .all();
       const now = Date.now();
-      await db.update(todos).set({
-        isCompleted: 1,
-        completedAt: now,
-        updatedAt: now,
-      }).where(eq(todos.id, todo.id)).run();
-      changed = true;
-    }
-  }
-
-  // 2. 이전 날짜에 체크된 항목 (오늘 이전 completedDate 기록이 있는 미완료 항목)
-  const prevCompletions = db.select({ todoId: todoCompletions.todoId })
-    .from(todoCompletions)
-    .where(lt(todoCompletions.completedDate, today))
-    .all();
-
-  const prevIds = [...new Set(prevCompletions.map((r) => r.todoId))];
-  for (const id of prevIds) {
-    const todo = db.select().from(todos)
-      .where(and(eq(todos.id, id), eq(todos.isCompleted, 0), eq(todos.isDeleted, 0)))
-      .get();
-    if (todo) {
-      const now = Date.now();
-      await db.update(todos).set({
-        isCompleted: 1,
-        completedAt: now,
-        updatedAt: now,
-      }).where(eq(todos.id, id)).run();
-      changed = true;
-    }
-  }
-
-  return changed;
+      for (const c of completions) {
+        db.update(todos).set({ isCompleted: 1, completedAt: now, updatedAt: now })
+          .where(and(eq(todos.id, c.todoId), eq(todos.isCompleted, 0), eq(todos.isDeleted, 0)))
+          .run();
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['todos'] });
+      queryClient.invalidateQueries({ queryKey: ['todayCompletionIds'] });
+      queryClient.invalidateQueries({ queryKey: ['completions'], exact: false });
+    },
+  });
 };
 
 export const useCreateTodo = () => {
@@ -406,49 +362,3 @@ export const useBulkDeleteTodos = () => {
   });
 };
 
-/** 오늘 탭에서 체크된 항목을 즉시 완료 처리 (isCompleted=1)
- *  자정이 지나도 앱이 켜져 있어 runDueDateCheck가 재실행되지 않을 때 수동으로 정리 */
-export const useFlushTodayCompleted = () => {
-  const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: async (): Promise<number> => {
-      const today = useDayStartStore.getState().effectiveToday;
-      const todayStart = dayjs(today).startOf('day').valueOf();
-      const todayEnd = dayjs(today).endOf('day').valueOf();
-      const now = Date.now();
-
-      const todayTodos = db.select().from(todos)
-        .where(and(
-          eq(todos.isCompleted, 0),
-          eq(todos.isDeleted, 0),
-          gte(todos.dueDate, todayStart),
-          lte(todos.dueDate, todayEnd),
-        ))
-        .all();
-
-      let count = 0;
-      for (const todo of todayTodos) {
-        const completion = db.select().from(todoCompletions)
-          .where(and(
-            eq(todoCompletions.todoId, todo.id),
-            eq(todoCompletions.completedDate, today),
-          ))
-          .get();
-        if (completion) {
-          db.update(todos).set({
-            isCompleted: 1,
-            completedAt: now,
-            updatedAt: now,
-          }).where(eq(todos.id, todo.id)).run();
-          count++;
-        }
-      }
-      return count;
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['todos'] });
-      queryClient.invalidateQueries({ queryKey: ['todo-completions'] });
-      queryClient.invalidateQueries({ queryKey: ['completions'] });
-    },
-  });
-};

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -16,7 +16,6 @@ import { setDayStartMinutes, db, setAppLanguage } from '../db';
 import { todos, todoCompletions } from '../db/schema';
 import { useDayStartStore } from '../stores/dayStartStore';
 import { useLanguageStore } from '../stores/languageStore';
-import { resetDueDateCheckGuard, runDueDateCheck } from '../hooks/useTodos';
 
 type NavigationProp = NativeStackNavigationProp<SettingsStackParamList, 'SettingsHome'>;
 
@@ -139,18 +138,12 @@ export default function SettingsScreen() {
     }
   };
 
-  const handleForceRunTimer = async () => {
-    resetDueDateCheckGuard();
-    // 다음날 시작 시각을 시뮬레이션 — effectiveToday를 하루 앞으로 이동
+  const handleForceRunTimer = () => {
     const currentEffective = useDayStartStore.getState().effectiveToday;
     setEffectiveToday(dayjs(currentEffective).add(1, 'day').format('YYYY-MM-DD'));
-    const changed = await runDueDateCheck();
     queryClient.invalidateQueries({ queryKey: ['todos'] });
     queryClient.invalidateQueries({ queryKey: ['completions'], exact: false });
-    Alert.alert(
-      t('settings.dev_timer_alert_title'),
-      changed ? t('settings.dev_timer_alert_changed') : t('settings.dev_timer_alert_no_change'),
-    );
+    Alert.alert(t('settings.dev_timer_alert_title'), t('settings.dev_timer_alert_changed'));
   };
   // ────────────────────────────────────────────────────
 

--- a/src/screens/TodoScreen.tsx
+++ b/src/screens/TodoScreen.tsx
@@ -1,5 +1,5 @@
 import { StyleSheet, View, useWindowDimensions, InteractionManager } from 'react-native';
-import { Appbar, FAB, Menu } from 'react-native-paper';
+import { Appbar, Menu } from 'react-native-paper';
 import { TabView, TabBar } from 'react-native-tab-view';
 import { useNavigation, useIsFocused, CommonActions } from '@react-navigation/native';
 import { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
@@ -8,9 +8,8 @@ import { useState, useEffect } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import { Colors } from '../theme';
-import { getAdFreeUntil, computeEffectiveToday } from '../db';
+import { computeEffectiveToday } from '../db';
 import { useDayStartStore } from '../stores/dayStartStore';
-import { runDueDateCheck, useFlushTodayCompleted } from '../hooks/useTodos';
 import { TodoStackParamList } from '../navigation/TodoStack';
 import BannerAdView from '../components/BannerAdView';
 import TodoTabList from '../components/TodoTabList';
@@ -34,8 +33,6 @@ export default function TodoScreen() {
   const layout = useWindowDimensions();
   const [tabIndex, setTabIndex] = useState(0);
   const [menuVisible, setMenuVisible] = useState(false);
-  const isAdFree = getAdFreeUntil() > Date.now();
-  const { mutate: flushTodayCompleted } = useFlushTodayCompleted();
   const isFocused = useIsFocused();
   const queryClient = useQueryClient();
 
@@ -60,20 +57,15 @@ export default function TodoScreen() {
   useEffect(() => {
     if (!isFocused) return;
     const task = InteractionManager.runAfterInteractions(() => {
-      // effectiveToday를 앞으로만 갱신 (뒤로 돌아가지 않음)
       const newEffective = computeEffectiveToday();
       if (newEffective > useDayStartStore.getState().effectiveToday) {
         useDayStartStore.getState().setEffectiveToday(newEffective);
       }
-      runDueDateCheck().then(() => {
-        queryClient.invalidateQueries({ queryKey: ['todos'] });
-        queryClient.invalidateQueries({ queryKey: ['completions'], exact: false });
-      });
+      queryClient.invalidateQueries({ queryKey: ['todos'] });
+      queryClient.invalidateQueries({ queryKey: ['completions'], exact: false });
     });
     return () => task.cancel();
   }, [isFocused, queryClient]);
-
-  const showFab = tabIndex === 0 || tabIndex === 1;
 
   return (
     <View style={styles.container}>
@@ -87,13 +79,6 @@ export default function TodoScreen() {
             <Appbar.Action icon="dots-vertical" onPress={() => setMenuVisible(true)} />
           }
         >
-          {tabIndex === 0 && (
-            <Menu.Item
-              leadingIcon="broom"
-              title={t('todo.menu_clear')}
-              onPress={() => { setMenuVisible(false); flushTodayCompleted(); }}
-            />
-          )}
           <Menu.Item
             leadingIcon="label-multiple-outline"
             title={t('todo.menu_category')}
@@ -125,17 +110,6 @@ export default function TodoScreen() {
       />
 
       <BannerAdView />
-
-      {showFab && (
-        <FAB
-          icon="plus"
-          style={[styles.fab, !isAdFree && styles.fabWithAd]}
-          onPress={() => {
-            if (tabIndex === 0) navigation.navigate('TodoForm');
-            else navigation.navigate('RoutineRoot' as never);
-          }}
-        />
-      )}
     </View>
   );
 }
@@ -145,6 +119,4 @@ const styles = StyleSheet.create({
   header: { height: 72 },
   tabBar: { backgroundColor: Colors.surface },
   indicator: { backgroundColor: Colors.primary },
-  fab: { position: 'absolute', right: 16, bottom: 16 },
-  fabWithAd: { bottom: 74 },
 });


### PR DESCRIPTION
## 이슈
Closes #152

## 변경 사항
- `runDueDateCheck`, `resetDueDateCheckGuard`, `_lastDueDateCheckDate` 삭제
- `useFlushTodayCompleted` 삭제
- `useCleanupChecked` 훅 추가 (오늘 체크된 할일을 일괄 isCompleted=1 처리)
- `useDayStartTimer`: `runDueDateCheck` 호출 제거, effectiveToday 갱신 + 쿼리 invalidate만 유지
- `TodoScreen`: FAB 제거, "완료 항목 정리" 메뉴 제거, 자동완료 useEffect 정리
- `SettingsScreen`: `resetDueDateCheckGuard`, `runDueDateCheck` 제거, `handleForceRunTimer` 단순화

## 테스트
- [ ] 앱 실행 시 할일이 자동 완료 처리되지 않음
- [ ] ⋮ 메뉴에 "완료 항목 정리" 항목 없음
- [ ] 개발자 메뉴 "타이머 강제 실행" 오류 없이 동작
- [ ] 할 일 탭 / 루틴 탭 전반 정상 동작