### PR TITLE
#153 [Phase 2] 정리 FAB 구현 (할 일/루틴 탭)

### DIFF
--- a/.claude/phase-map.json
+++ b/.claude/phase-map.json
@@ -7,14 +7,14 @@
       "title": "자동 완료 프로세스 제거 및 훅 교체",
       "issueNumber": 152,
       "branch": "feature/issue-151/remove-auto-complete-process",
-      "status": "in_progress"
+      "status": "done"
     },
     {
       "number": 2,
       "title": "정리 FAB 구현 (할 일/루틴 탭)",
       "issueNumber": 153,
       "branch": "feature/issue-151/cleanup-fab",
-      "status": "pending"
+      "status": "in_progress"
     }
   ]
 }

--- a/src/components/TodoTabList.tsx
+++ b/src/components/TodoTabList.tsx
@@ -1,11 +1,11 @@
 import { useMemo, useState } from 'react';
 import { View, FlatList, StyleSheet, TouchableOpacity } from 'react-native';
-import { Text, Divider, Menu } from 'react-native-paper';
-import { useNavigation } from '@react-navigation/native';
+import { Text, Divider, Menu, FAB } from 'react-native-paper';
+import { useNavigation, useIsFocused } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useTranslation } from 'react-i18next';
 import { Colors } from '../theme';
-import { useTodosList, useTodosToday, useTodayCompletionIds, useTodayToggle } from '../hooks/useTodos';
+import { useTodosList, useTodosToday, useTodayCompletionIds, useTodayToggle, useCleanupChecked } from '../hooks/useTodos';
 import { useCategories } from '../hooks/useCategories';
 import { useCategoryMap } from '../hooks/useCategoryMap';
 import { useCheckable } from '../hooks/useCheckable';
@@ -57,9 +57,12 @@ export default function TodoTabList() {
   const { data: completedIds = new Set<number>() } = useTodayCompletionIds();
   const { data: categories = [] } = useCategories();
   const { mutate: todayToggle } = useTodayToggle();
+  const { mutate: cleanup } = useCleanupChecked();
+  const isFocused = useIsFocused();
 
   const [sortKey, setSortKey] = useState<SortKey>('deadline');
   const [sortMenuVisible, setSortMenuVisible] = useState(false);
+  const [fabOpen, setFabOpen] = useState(false);
 
   const categoryMap = useCategoryMap(categories);
   const getCheckable = useCheckable({ mode: 'today', completedIds, toggleFn: todayToggle });
@@ -143,6 +146,18 @@ export default function TodoTabList() {
         renderItem={renderItem}
         style={styles.list}
       />
+
+      <FAB.Group
+        open={fabOpen}
+        visible={isFocused}
+        icon={fabOpen ? 'close' : 'plus'}
+        fabStyle={styles.fab}
+        actions={[
+          ...(completedIds.size > 0 ? [{ icon: 'broom', label: t('todo.menu_clear'), onPress: () => { cleanup(); setFabOpen(false); }, size: 'small' as const }] : []),
+          { icon: 'plus', label: t('todo.title_new'), onPress: () => { navigation.navigate('TodoForm'); setFabOpen(false); }, size: 'small' as const },
+        ]}
+        onStateChange={({ open }) => setFabOpen(open)}
+      />
     </View>
   );
 }
@@ -164,4 +179,5 @@ const styles = StyleSheet.create({
   sortText: { color: Colors.textSecondary },
   list: { flex: 1 },
   empty: { textAlign: 'center', marginTop: 60, color: Colors.textMuted },
+  fab: { transform: [{ scale: 0.85 }] },
 });

--- a/src/components/TodoTabOverdue.tsx
+++ b/src/components/TodoTabOverdue.tsx
@@ -1,11 +1,11 @@
 import { useState, useMemo } from 'react';
 import { View, StyleSheet, FlatList, TouchableOpacity } from 'react-native';
 import { Text, Divider, Button, FAB, Dialog, Portal, Snackbar, Menu } from 'react-native-paper';
-import { useNavigation } from '@react-navigation/native';
+import { useNavigation, useIsFocused } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useTranslation } from 'react-i18next';
 import { Colors } from '../theme';
-import { useTodosOverdue, useToggleTodo, useBulkMoveToToday, useBulkDeleteTodos } from '../hooks/useTodos';
+import { useTodosOverdue, useBulkMoveToToday, useBulkDeleteTodos } from '../hooks/useTodos';
 import { useCategories } from '../hooks/useCategories';
 import { useCategoryMap } from '../hooks/useCategoryMap';
 import { useSelectable } from '../hooks/useSelectable';
@@ -53,19 +53,19 @@ export default function TodoTabOverdue() {
   const { t } = useTranslation();
   const { data: todos = [] } = useTodosOverdue();
   const { data: categories = [] } = useCategories();
-  const { mutate: toggleTodo } = useToggleTodo();
   const { mutate: bulkMoveToToday } = useBulkMoveToToday();
   const { mutate: bulkDelete } = useBulkDeleteTodos();
 
+  const isFocused = useIsFocused();
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [snackbarVisible, setSnackbarVisible] = useState(false);
   const [snackbarMessage, setSnackbarMessage] = useState('');
   const [sortKey, setSortKey] = useState<SortKey>('deadline');
   const [sortMenuVisible, setSortMenuVisible] = useState(false);
+  const [fabOpen, setFabOpen] = useState(false);
 
   const categoryMap = useCategoryMap(categories);
-  const { isSelecting, selectedIds, startSelecting, clearSelection, toggleSelection } =
-    useSelectable(todos as Todo[]);
+  const { selectedIds, clearSelection, toggleSelection } = useSelectable(todos as Todo[]);
 
   const listItems = useMemo(() => buildGroupedList(todos as Todo[], sortKey), [todos, sortKey]);
 
@@ -95,22 +95,14 @@ export default function TodoTabOverdue() {
       return <DateSeparator label={item.label} />;
     }
     const { todo } = item;
-    const checked = isSelecting ? selectedIds.has(todo.id) : false;
-    const onCheck = isSelecting
-      ? () => toggleSelection(todo.id)
-      : () => toggleTodo({ id: todo.id, isCompleted: todo.isCompleted });
-    const onPress = isSelecting
-      ? () => toggleSelection(todo.id)
-      : () => navigation.navigate('TodoForm', { todo });
-
     return (
       <TodoItem
         todo={todo}
         category={categoryMap.get(todo.categoryId)}
-        checked={checked}
-        onCheck={onCheck}
-        onPress={onPress}
-        checkboxVisible={isSelecting}
+        checked={selectedIds.has(todo.id)}
+        onCheck={() => toggleSelection(todo.id)}
+        onPress={() => navigation.navigate('TodoForm', { todo })}
+        checkboxVisible
         showDescription
       />
     );
@@ -120,28 +112,26 @@ export default function TodoTabOverdue() {
 
   return (
     <View style={styles.container}>
-      {!isSelecting && (
-        <View style={styles.sortRow}>
-          <Menu
-            visible={sortMenuVisible}
-            onDismiss={() => setSortMenuVisible(false)}
-            anchor={
-              <TouchableOpacity style={styles.sortAnchor} onPress={() => setSortMenuVisible(true)}>
-                <Text variant="labelSmall" style={styles.sortText}>{currentLabel} ▾</Text>
-              </TouchableOpacity>
-            }
-          >
-            {OVERDUE_SORT_OPTIONS.map((opt) => (
-              <Menu.Item
-                key={opt.key}
-                title={opt.label}
-                onPress={() => { setSortKey(opt.key); setSortMenuVisible(false); }}
-                trailingIcon={sortKey === opt.key ? 'check' : undefined}
-              />
-            ))}
-          </Menu>
-        </View>
-      )}
+      <View style={styles.sortRow}>
+        <Menu
+          visible={sortMenuVisible}
+          onDismiss={() => setSortMenuVisible(false)}
+          anchor={
+            <TouchableOpacity style={styles.sortAnchor} onPress={() => setSortMenuVisible(true)}>
+              <Text variant="labelSmall" style={styles.sortText}>{currentLabel} ▾</Text>
+            </TouchableOpacity>
+          }
+        >
+          {OVERDUE_SORT_OPTIONS.map((opt) => (
+            <Menu.Item
+              key={opt.key}
+              title={opt.label}
+              onPress={() => { setSortKey(opt.key); setSortMenuVisible(false); }}
+              trailingIcon={sortKey === opt.key ? 'check' : undefined}
+            />
+          ))}
+        </Menu>
+      </View>
       <FlatList
         data={listItems}
         keyExtractor={(item) => item.key}
@@ -153,34 +143,27 @@ export default function TodoTabOverdue() {
         style={styles.list}
       />
 
-      {isSelecting ? (
-        <View style={styles.actionColumn}>
-          <FAB
-            icon="calendar-arrow-right"
-            style={[styles.fabAction, selectedIds.size === 0 && styles.fabDisabled]}
-            onPress={handleMoveToToday}
-            disabled={selectedIds.size === 0}
-          />
-          <FAB
-            icon="trash-can-outline"
-            style={[styles.fabAction, styles.fabDanger, selectedIds.size === 0 && styles.fabDisabled]}
-            color={Colors.danger}
-            onPress={() => selectedIds.size > 0 && setShowDeleteDialog(true)}
-            disabled={selectedIds.size === 0}
-          />
-          <FAB
-            icon="close-circle-outline"
-            style={styles.fabAction}
-            onPress={clearSelection}
-          />
-        </View>
-      ) : (
-        <FAB
-          icon="check-circle-outline"
-          style={styles.fab}
-          onPress={startSelecting}
-        />
-      )}
+      <FAB.Group
+        open={fabOpen}
+        visible={isFocused && selectedIds.size > 0}
+        icon={fabOpen ? 'close' : 'dots-vertical'}
+        fabStyle={styles.fab}
+        actions={[
+          {
+            icon: 'calendar-arrow-right',
+            label: t('todo.move_to_today_msg', { count: selectedIds.size }),
+            onPress: () => { handleMoveToToday(); setFabOpen(false); },
+            size: 'small' as const,
+          },
+          {
+            icon: 'trash-can-outline',
+            label: t('common.delete'),
+            onPress: () => { setShowDeleteDialog(true); setFabOpen(false); },
+            size: 'small' as const,
+          },
+        ]}
+        onStateChange={({ open }) => setFabOpen(open)}
+      />
 
       <Portal>
         <Dialog visible={showDeleteDialog} onDismiss={() => setShowDeleteDialog(false)}>
@@ -226,16 +209,5 @@ const styles = StyleSheet.create({
   list: { flex: 1, backgroundColor: Colors.background },
   empty: { textAlign: 'center', marginTop: 60, color: Colors.textMuted },
   snackbar: { marginBottom: 80 },
-  fab: { position: 'absolute', right: 16, bottom: 16 },
-  actionColumn: {
-    position: 'absolute',
-    right: 16,
-    bottom: 16,
-    flexDirection: 'column',
-    alignItems: 'center',
-    gap: 12,
-  },
-  fabAction: {},
-  fabDanger: { backgroundColor: Colors.surfaceVariant },
-  fabDisabled: { opacity: 0.4 },
+  fab: { transform: [{ scale: 0.85 }] },
 });

--- a/src/components/TodoTabRoutine.tsx
+++ b/src/components/TodoTabRoutine.tsx
@@ -1,6 +1,7 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { View, FlatList, StyleSheet } from 'react-native';
-import { Text, Divider } from 'react-native-paper';
+import { Text, Divider, FAB } from 'react-native-paper';
+import { useNavigation, useIsFocused } from '@react-navigation/native';
 import { useTranslation } from 'react-i18next';
 import { Colors } from '../theme';
 import { useRoutinesToday, useToggleRoutineCompletion } from '../hooks/useRoutines';
@@ -11,12 +12,19 @@ import TodayProgressBar from './TodayProgressBar';
 import RoutineItem from './RoutineItem';
 
 export default function TodoTabRoutine() {
+  const navigation = useNavigation();
   const { t } = useTranslation();
   const { data: routines = [] } = useRoutinesToday();
   const { data: categories = [] } = useCategories();
   const { mutate: toggleRoutine } = useToggleRoutineCompletion();
   const effectiveToday = useDayStartStore(s => s.effectiveToday);
   const categoryMap = useCategoryMap(categories);
+  const isFocused = useIsFocused();
+  const [cleanedUp, setCleanedUp] = useState(false);
+  const [fabOpen, setFabOpen] = useState(false);
+
+  const displayRoutines = cleanedUp ? routines.filter(r => !r.isCompletedToday) : routines;
+  const hasCompleted = routines.some(r => r.isCompletedToday);
 
   const segments = useMemo(() => {
     const map = new Map<number, { color: string; count: number }>();
@@ -36,7 +44,7 @@ export default function TodoTabRoutine() {
   return (
     <View style={styles.container}>
       <FlatList
-        data={routines}
+        data={displayRoutines}
         keyExtractor={(item) => `routine-${item.id}`}
         ListHeaderComponent={
           <TodayProgressBar segments={segments} totalCompleted={totalCompleted} total={total} />
@@ -57,6 +65,18 @@ export default function TodoTabRoutine() {
         )}
         style={styles.list}
       />
+
+      <FAB.Group
+        open={fabOpen}
+        visible={isFocused}
+        icon={fabOpen ? 'close' : 'plus'}
+        fabStyle={styles.fab}
+        actions={[
+          ...(hasCompleted && !cleanedUp ? [{ icon: 'broom', label: t('todo.menu_clear'), onPress: () => { setCleanedUp(true); setFabOpen(false); }, size: 'small' as const }] : []),
+          { icon: 'autorenew', label: t('todo.menu_routine'), onPress: () => { navigation.navigate('RoutineRoot' as never); setFabOpen(false); }, size: 'small' as const },
+        ]}
+        onStateChange={({ open }) => setFabOpen(open)}
+      />
     </View>
   );
 }
@@ -65,4 +85,5 @@ const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: Colors.background },
   list: { flex: 1 },
   empty: { textAlign: 'center', marginTop: 60, color: Colors.textMuted },
+  fab: { transform: [{ scale: 0.85 }] },
 });


### PR DESCRIPTION
## 이슈
Closes #153

## 변경 사항
- `TodoTabList`: FAB.Group(speed-dial) 추가 — 완료 항목 있을 때 🧹 액션 노출, 없을 때 + 만 표시
- `TodoTabRoutine`: FAB.Group 추가 — 완료 루틴 있을 때 🧹 액션 표시, cleanedUp 상태로 세션 내 숨김 처리
- `TodoTabOverdue`: 기존 isSelecting 모드 제거, 체크박스 항상 표시, 선택 항목 있을 때 FAB.Group(dots-vertical) 노출 → 이동/삭제 액션
- Portal 제거 — View 내 렌더링으로 배너 광고/탭바 가림 방지
- useIsFocused()로 폼 화면 진입 시 FAB 자동 숨김
- fabStyle scale 0.85로 FAB 크기 소폭 축소

## 테스트
- [ ] 할 일 체크 → FAB 펼치면 🧹 액션 노출 확인
- [ ] 🧹 누름 → 완료 처리 후 목록에서 사라짐 확인
- [ ] 루틴 완료 → 🧹 액션 등장, 누르면 목록에서 숨김 확인
- [ ] 미완료 탭: 아이템 선택 시 FAB 등장, 이동/삭제 동작 확인
- [ ] TodoForm 진입 시 FAB 숨김 확인
- [ ] FAB이 광고 배너/탭바를 가리지 않는지 확인