### PR TITLE
#156 프로그레스 바 항상 표시 및 정리 후에도 진행률 유지

### DIFF
--- a/.claude/phase-map.json
+++ b/.claude/phase-map.json
@@ -14,7 +14,7 @@
       "title": "정리 FAB 구현 (할 일/루틴 탭)",
       "issueNumber": 153,
       "branch": "feature/issue-151/cleanup-fab",
-      "status": "in_progress"
+      "status": "done"
     }
   ]
 }

--- a/src/components/TodayProgressBar.tsx
+++ b/src/components/TodayProgressBar.tsx
@@ -55,10 +55,8 @@ type Props = {
 };
 
 export default function TodayProgressBar({ segments, totalCompleted, total }: Props) {
-  if (total === 0) return null;
-
-  const uncompleted = total - totalCompleted;
-  const percent = Math.round((totalCompleted / total) * 100);
+  const uncompleted = Math.max(0, total - totalCompleted);
+  const percent = total > 0 ? Math.round((totalCompleted / total) * 100) : 0;
 
   return (
     <View style={styles.container}>

--- a/src/components/TodoTabList.tsx
+++ b/src/components/TodoTabList.tsx
@@ -5,7 +5,7 @@ import { useNavigation, useIsFocused } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useTranslation } from 'react-i18next';
 import { Colors } from '../theme';
-import { useTodosList, useTodosToday, useTodayCompletionIds, useTodayToggle, useCleanupChecked } from '../hooks/useTodos';
+import { useTodosList, useTodayAllTodos, useTodayCompletionIds, useTodayToggle, useCleanupChecked } from '../hooks/useTodos';
 import { useCategories } from '../hooks/useCategories';
 import { useCategoryMap } from '../hooks/useCategoryMap';
 import { useCheckable } from '../hooks/useCheckable';
@@ -53,7 +53,7 @@ export default function TodoTabList() {
   const navigation = useNavigation<Nav>();
   const { t } = useTranslation();
   const { data: todos = [] } = useTodosList();
-  const { data: todayTodos = [] } = useTodosToday();
+  const { data: allTodayTodos = [] } = useTodayAllTodos();
   const { data: completedIds = new Set<number>() } = useTodayCompletionIds();
   const { data: categories = [] } = useCategories();
   const { mutate: todayToggle } = useTodayToggle();
@@ -71,7 +71,7 @@ export default function TodoTabList() {
 
   const progressSegments = useMemo(() => {
     const map = new Map<number, { color: string; count: number }>();
-    for (const todo of todayTodos as Todo[]) {
+    for (const todo of allTodayTodos as Todo[]) {
       if (!completedIds.has(todo.id)) continue;
       const cat = categoryMap.get(todo.categoryId);
       const color = cat?.color ?? Colors.primary;
@@ -79,9 +79,9 @@ export default function TodoTabList() {
       map.set(key, { color, count: (map.get(key)?.count ?? 0) + 1 });
     }
     return [...map.entries()].map(([categoryId, { color, count }]) => ({ categoryId, color, count }));
-  }, [todayTodos, completedIds, categoryMap]);
+  }, [allTodayTodos, completedIds, categoryMap]);
 
-  const progressTotal = (todayTodos as Todo[]).length;
+  const progressTotal = (allTodayTodos as Todo[]).length;
   const progressCompleted = progressSegments.reduce((s, seg) => s + seg.count, 0);
 
   const LIST_SORT_OPTIONS = [

--- a/src/hooks/useTodos.ts
+++ b/src/hooks/useTodos.ts
@@ -102,6 +102,24 @@ export const useTodosCompletedByCategory = (categoryId: number) =>
       lastPage.length < PAGE_SIZE ? undefined : allPages.length,
   });
 
+/** 프로그레스 바 전용: 기한 == 오늘인 모든 할 일 (완료 여부 무관) */
+export const useTodayAllTodos = () => {
+  const todayStart = dayjs().startOf('day').valueOf();
+  const todayEnd = dayjs().endOf('day').valueOf();
+  return useQuery({
+    queryKey: ['todos', 'today', 'all'],
+    queryFn: () =>
+      db.select().from(todos)
+        .where(and(
+          eq(todos.isDeleted, 0),
+          gte(todos.dueDate, todayStart),
+          lt(todos.dueDate, todayEnd + 1),
+        ))
+        .orderBy(asc(todos.sortOrder))
+        .all(),
+  });
+};
+
 /** 오늘 탭 전용: 오늘 완료 체크된 todoId Set */
 export const useTodayCompletionIds = () => {
   const effectiveToday = useDayStartStore(s => s.effectiveToday);


### PR DESCRIPTION
## 이슈
Closes #156

## 변경 사항
- `TodayProgressBar`: `total === 0`일 때 null 반환 제거 → 항상 렌더링, 0% 빈 바로 표시
- `useTodos.ts`: `useTodayAllTodos` 훅 추가 — 오늘 기한인 모든 할 일 조회 (완료 여부 무관)
- `TodoTabList`: 프로그레스 계산 기준을 `useTodosToday`(미완료만) → `useTodayAllTodos`(전체)로 변경하여 🧹 정리 후에도 진행률 보존

## 테스트
- [ ] 오늘 할 일이 없을 때 프로그레스 바 0%로 표시 확인 (할 일 탭)
- [ ] 오늘 루틴이 없을 때 프로그레스 바 0%로 표시 확인 (루틴 탭)
- [ ] 할 일 탭: 🧹 정리 후 완료 진행률 유지 확인
- [ ] 루틴 탭: 🧹 정리 후 100% 프로그레스 바 유지 확인