### PR TITLE
#158 기록 상세 화면에 루틴 완료 이력 추가

### DIFF
--- a/src/hooks/useCompletions.ts
+++ b/src/hooks/useCompletions.ts
@@ -1,7 +1,16 @@
 import { useQuery } from '@tanstack/react-query';
-import { eq, and, gte, lte, sql } from 'drizzle-orm';
+import { eq, and, gte, lte, sql, desc } from 'drizzle-orm';
 import { db } from '../db';
 import { todoCompletions, todos, routineCompletions, routines } from '../db/schema';
+
+export type RoutineCompletionRecord = {
+  completionId: number;
+  routineId: number;
+  title: string;
+  urgency: number | null;
+  importance: number | null;
+  completedDate: string; // YYYY-MM-DD
+};
 
 const CURRENT_YEAR = new Date().getFullYear();
 
@@ -77,4 +86,23 @@ export const useCompletionsByCategory = (categoryId: number, year: number) =>
       }
       return map;
     },
+  });
+
+export const useRoutineCompletionsByCategory = (categoryId: number) =>
+  useQuery({
+    queryKey: ['completions', 'routine', categoryId],
+    queryFn: (): RoutineCompletionRecord[] =>
+      db.select({
+        completionId: routineCompletions.id,
+        routineId: routineCompletions.routineId,
+        title: routines.title,
+        urgency: routines.urgency,
+        importance: routines.importance,
+        completedDate: routineCompletions.completedDate,
+      })
+      .from(routineCompletions)
+      .innerJoin(routines, eq(routineCompletions.routineId, routines.id))
+      .where(eq(routines.categoryId, categoryId))
+      .orderBy(desc(routineCompletions.completedDate))
+      .all(),
   });

--- a/src/screens/CategoryCompletedScreen.tsx
+++ b/src/screens/CategoryCompletedScreen.tsx
@@ -3,10 +3,13 @@ import { Appbar, Text, Divider } from 'react-native-paper';
 import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useMemo } from 'react';
+import dayjs from 'dayjs';
 import { useTranslation } from 'react-i18next';
 import { Colors } from '../theme';
 import { useTodosCompletedByCategory } from '../hooks/useTodos';
+import { useRoutineCompletionsByCategory, RoutineCompletionRecord } from '../hooks/useCompletions';
 import TodoItem from '../components/TodoItem';
+import TodoItemMeta from '../components/TodoItem/TodoItemMeta';
 import { toDateKey, formatDateLabel } from '../utils/date';
 import { RecordStackParamList } from '../navigation/RecordStack';
 import { Todo } from '../types';
@@ -16,20 +19,58 @@ type Route = RouteProp<RecordStackParamList, 'CategoryCompleted'>;
 
 type ListItem =
   | { type: 'header'; label: string; key: string }
-  | { type: 'todo'; todo: Todo };
+  | { type: 'todo'; key: string; todo: Todo }
+  | { type: 'routine'; key: string; record: RoutineCompletionRecord };
 
-function buildCompletedList(todos: Todo[]): ListItem[] {
+function buildMergedList(todos: Todo[], routineRecords: RoutineCompletionRecord[]): ListItem[] {
+  type Entry = { dateKey: string; sortTs: number; item: ListItem };
+  const entries: Entry[] = [];
+
+  for (const todo of todos) {
+    const dateKey = toDateKey(todo.completedAt);
+    entries.push({ dateKey, sortTs: todo.completedAt ?? 0, item: { type: 'todo', key: `todo-${todo.id}`, todo } });
+  }
+
+  for (const record of routineRecords) {
+    const ts = dayjs(record.completedDate).valueOf();
+    const dateKey = toDateKey(ts);
+    entries.push({ dateKey, sortTs: ts, item: { type: 'routine', key: `routine-${record.completionId}`, record } });
+  }
+
+  entries.sort((a, b) => b.sortTs - a.sortTs);
+
   const result: ListItem[] = [];
   let lastKey = '';
-  for (const todo of todos) {
-    const key = toDateKey(todo.completedAt);
-    if (key !== lastKey) {
-      result.push({ type: 'header', label: formatDateLabel(todo.completedAt), key });
-      lastKey = key;
+  for (const entry of entries) {
+    if (entry.dateKey !== lastKey) {
+      const ts = entry.item.type === 'todo'
+        ? (entry.item.todo.completedAt ?? 0)
+        : entry.item.type === 'routine'
+          ? dayjs(entry.item.record.completedDate).valueOf()
+          : 0;
+      result.push({ type: 'header', label: formatDateLabel(ts), key: entry.dateKey });
+      lastKey = entry.dateKey;
     }
-    result.push({ type: 'todo', todo });
+    result.push(entry.item);
   }
   return result;
+}
+
+function RoutineCompletionItem({ record }: { record: RoutineCompletionRecord }) {
+  const { t } = useTranslation();
+  return (
+    <View style={styles.routineRow}>
+      <View style={styles.routineContent}>
+        <Text variant="bodyLarge" style={styles.routineTitle}>{record.title}</Text>
+        <View style={styles.metaRow}>
+          <View style={styles.routineTag}>
+            <Text style={styles.routineTagText}>{t('todo.tab_routine')}</Text>
+          </View>
+          <TodoItemMeta urgency={record.urgency} importance={record.importance} />
+        </View>
+      </View>
+    </View>
+  );
 }
 
 export default function CategoryCompletedScreen() {
@@ -40,16 +81,29 @@ export default function CategoryCompletedScreen() {
 
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useTodosCompletedByCategory(categoryId);
+  const { data: routineRecords = [] } = useRoutineCompletionsByCategory(categoryId);
+
   const flatTodos = useMemo(
     () => (data?.pages.flat() ?? []) as Todo[],
     [data],
   );
 
-  const listItems = useMemo(() => buildCompletedList(flatTodos), [flatTodos]);
+  const listItems = useMemo(
+    () => buildMergedList(flatTodos, routineRecords),
+    [flatTodos, routineRecords],
+  );
 
   const renderItem = ({ item }: { item: ListItem }) => {
     if (item.type === 'header') {
       return <Text style={styles.dateHeader}>{item.label}</Text>;
+    }
+    if (item.type === 'routine') {
+      return (
+        <>
+          <RoutineCompletionItem record={item.record} />
+          <Divider />
+        </>
+      );
     }
     return (
       <>
@@ -81,9 +135,7 @@ export default function CategoryCompletedScreen() {
 
       <FlatList
         data={listItems}
-        keyExtractor={(item) =>
-          item.type === 'header' ? `header-${item.key}` : `todo-${item.todo.id}`
-        }
+        keyExtractor={(item) => item.type === 'header' ? `header-${item.key}` : item.key}
         renderItem={renderItem}
         onEndReached={() => { if (hasNextPage && !isFetchingNextPage) fetchNextPage(); }}
         onEndReachedThreshold={0.5}
@@ -118,4 +170,21 @@ const styles = StyleSheet.create({
     fontWeight: '600',
     color: Colors.textMuted,
   },
+  routineRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 10,
+    paddingHorizontal: 16,
+    backgroundColor: Colors.background,
+  },
+  routineContent: { flex: 1 },
+  routineTitle: { color: Colors.textMuted, textDecorationLine: 'line-through' },
+  metaRow: { flexDirection: 'row', alignItems: 'center', flexWrap: 'wrap', marginTop: 4, gap: 6 },
+  routineTag: {
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    borderRadius: 4,
+    backgroundColor: Colors.primary + '22',
+  },
+  routineTagText: { fontSize: 10, fontWeight: '600', color: Colors.primary },
 });


### PR DESCRIPTION
## 이슈
Closes #158

## 변경 사항
- `useCompletions.ts`: `RoutineCompletionRecord` 타입 및 `useRoutineCompletionsByCategory(categoryId)` 훅 추가 — `routine_completions JOIN routines` 쿼리, 날짜 내림차순
- `CategoryCompletedScreen`: 완료된 할 일 + 루틴 완료 기록을 날짜 기준으로 병합 정렬하는 `buildMergedList` 함수 구현
- 루틴 완료 항목 인라인 컴포넌트 `RoutineCompletionItem` — 루틴 태그(badge), 취소선 스타일, 긴급도/중요도 메타 표시
- 기존 `useTodosCompletedByCategory` 페이지네이션 유지, 루틴은 전체 조회 후 병합

## 테스트
- [ ] 카테고리 상세 화면에 완료된 할 일 + 루틴 완료 기록이 날짜 내림차순으로 함께 표시되는지 확인
- [ ] 루틴 항목에 루틴 태그와 취소선 스타일이 정상 적용되는지 확인
- [ ] 루틴 완료 기록만 있는 카테고리에서도 목록이 정상 표시되는지 확인
- [ ] 잔디 격자(ContributionGrid)가 기존과 동일하게 todo+routine 합산으로 정상 표시되는지 확인