### PR TITLE
#162 개발 환경에서 온보딩 화면 재진입 옵션 추가

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -180,6 +180,12 @@ export function setOnboardingCompleted(): void {
     .run();
 }
 
+export function resetOnboardingCompleted(): void {
+  db.delete(schema.appSettings)
+    .where(eq(schema.appSettings.key, 'onboarding_completed'))
+    .run();
+}
+
 export function getAppLanguage(): string {
   const row = db.select().from(schema.appSettings)
     .where(eq(schema.appSettings.key, 'app_language')).get();

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -7,12 +7,12 @@ import { useTranslation } from 'react-i18next';
 import dayjs from 'dayjs';
 import i18next from 'i18next';
 import { Colors } from '../theme';
-import { useNavigation } from '@react-navigation/native';
+import { useNavigation, CommonActions } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { SettingsStackParamList } from '../navigation/SettingsStack';
 import Constants from 'expo-constants';
 import { useAdFree, REQUIRED_AD_COUNT } from '../hooks/useAdFree';
-import { setDayStartMinutes, db, setAppLanguage } from '../db';
+import { setDayStartMinutes, db, setAppLanguage, resetOnboardingCompleted } from '../db';
 import { todos, todoCompletions } from '../db/schema';
 import { seedDemoData } from '../utils/seedData';
 import { useDayStartStore } from '../stores/dayStartStore';
@@ -158,6 +158,12 @@ export default function SettingsScreen() {
     queryClient.invalidateQueries({ queryKey: ['completions'], exact: false });
     Alert.alert('시드 완료', `루틴 ${result.routines}개 · 할 일 ${result.todos}개 · 루틴 완료 기록 ${result.routineCompletions}건 · 할 일 완료 기록 ${result.todoCompletions}건 생성됨`);
   };
+  const handleReplayOnboarding = () => {
+    resetOnboardingCompleted();
+    navigation.getParent()?.getParent()?.dispatch(
+      CommonActions.reset({ index: 0, routes: [{ name: 'Onboarding' }] }),
+    );
+  };
   // ────────────────────────────────────────────────────
 
   return (
@@ -251,6 +257,15 @@ export default function SettingsScreen() {
                   <Text variant="bodyLarge" style={{ color: Colors.danger }}>시드 데이터 생성</Text>
                   <Text variant="bodySmall" style={styles.description}>
                     할 일 / 루틴 / 완료 이력 데모 데이터 삽입 (기존 데이터 없을 때만 동작)
+                  </Text>
+                </View>
+              </TouchableOpacity>
+              <Divider />
+              <TouchableOpacity style={styles.item} onPress={handleReplayOnboarding}>
+                <View>
+                  <Text variant="bodyLarge" style={{ color: Colors.danger }}>온보딩 다시 보기</Text>
+                  <Text variant="bodySmall" style={styles.description}>
+                    완료 기록을 초기화하고 가이드 화면으로 이동
                   </Text>
                 </View>
               </TouchableOpacity>


### PR DESCRIPTION
## 이슈
Closes #162

## 변경 사항
- `src/db/index.ts`: `resetOnboardingCompleted()` 함수 추가 — `appSettings`에서 `onboarding_completed` 레코드 삭제
- `SettingsScreen` 개발자 섹션에 "온보딩 다시 보기" 버튼 추가
- 버튼 동작: `resetOnboardingCompleted()` 호출 → `navigation.getParent()?.getParent()?.dispatch(CommonActions.reset)` 으로 RootStack을 Onboarding 화면으로 리셋

## 테스트
- [ ] 설정 → 개발자 섹션 → "온보딩 다시 보기" 버튼 노출 확인 (`__DEV__` 모드)
- [ ] 버튼 탭 시 온보딩 화면으로 이동하는지 확인
- [ ] 온보딩 완료 후 메인 화면으로 정상 전환되는지 확인
- [ ] 앱 재시작 후 온보딩이 다시 표시되지 않는지 확인 (완료 후 정상 저장)