### PR TITLE
빌드 스크립트 non-interactive 모드 적용

### DIFF
--- a/scripts/build-android.sh
+++ b/scripts/build-android.sh
@@ -13,7 +13,7 @@ fi
 # 빌드 시작 시간
 START=$(date +%s)
 
-eas build --platform android --profile production --local
+eas build --platform android --profile production --local --non-interactive
 
 # 빌드 결과물 확인
 BUILD_FILE=$(ls *.apk *.aab 2>/dev/null | head -1)

--- a/scripts/build-ios.sh
+++ b/scripts/build-ios.sh
@@ -13,7 +13,7 @@ fi
 # 빌드 시작 시간
 START=$(date +%s)
 
-eas build --platform ios --profile production --local
+eas build --platform ios --profile production --local --non-interactive
 
 # 빌드 결과물 확인
 IPA_FILE=$(ls *.ipa 2>/dev/null | head -1)


### PR DESCRIPTION
## 변경 사항
- `scripts/build-ios.sh`: `--non-interactive` 플래그 추가
- `scripts/build-android.sh`: `--non-interactive` 플래그 추가

## 테스트
- [ ] `npm run build:ios` 대화 없이 바로 빌드 시작되는지 확인