### PR TITLE
#170 언어별 로컬라이즈 샘플 데이터 JSON 파일 및 개발자 옵션 적용 기능 추가

### DIFF
--- a/scripts/build-ios.sh
+++ b/scripts/build-ios.sh
@@ -13,19 +13,10 @@ fi
 # 빌드 시작 시간
 START=$(date +%s)
 
-eas build --platform ios --profile production --local --non-interactive
+eas build --platform ios --profile production --non-interactive
 
-# 빌드 결과물 확인
-IPA_FILE=$(ls *.ipa 2>/dev/null | head -1)
 END=$(date +%s)
 ELAPSED=$((END - START))
 
-if [ -n "$IPA_FILE" ]; then
-  echo ""
-  echo "✅ iOS 빌드 완료 (${ELAPSED}초)"
-  echo "📦 결과물: $IPA_FILE"
-else
-  echo ""
-  echo "❌ ipa 파일을 찾을 수 없습니다."
-  exit 1
-fi
+echo ""
+echo "✅ iOS 빌드 완료 (${ELAPSED}초)"

--- a/scripts/upload-ios.sh
+++ b/scripts/upload-ios.sh
@@ -3,19 +3,7 @@ set -e
 
 echo "🍎 iOS App Store 업로드 시작..."
 
-# 최신 ipa 파일 탐색
-IPA_FILE=$(ls -t *.ipa 2>/dev/null | head -1)
-
-if [ -z "$IPA_FILE" ]; then
-  echo "❌ ipa 파일을 찾을 수 없습니다. 먼저 빌드를 실행하세요:"
-  echo "   npm run build:ios"
-  exit 1
-fi
-
-echo "📦 업로드 파일: $IPA_FILE"
-echo ""
-
-eas submit --platform ios --path "$IPA_FILE" --profile production --non-interactive
+eas submit --platform ios --latest --profile production --non-interactive
 
 echo ""
 echo "✅ iOS 업로드 완료"

--- a/src/data/sample/en.json
+++ b/src/data/sample/en.json
@@ -1,0 +1,44 @@
+{
+  "defaultCategoryName": "Uncategorized",
+  "categories": [
+    { "key": "work", "name": "Work", "color": "#4285F4", "description": "Work tasks", "sortOrder": 1 },
+    { "key": "personal", "name": "Personal", "color": "#EA4335", "description": "Personal tasks", "sortOrder": 2 },
+    { "key": "health", "name": "Health", "color": "#34A853", "description": "Health & fitness", "sortOrder": 3 },
+    { "key": "study", "name": "Study", "color": "#FBBC05", "description": "Learning & growth", "sortOrder": 4 },
+    { "key": "shopping", "name": "Shopping", "color": "#9C27B0", "description": "Shopping list", "sortOrder": 5 }
+  ],
+  "routines": [
+    { "categoryKey": "health", "title": "Morning stretching (10 min)", "description": "Start the day with full-body stretching", "repeatType": "daily", "repeatValue": null, "alarmTime": 420, "urgency": 1, "importance": 3, "sortOrder": 1, "completionRate": 0.85, "completionDays": 90 },
+    { "categoryKey": "health", "title": "Drink 2L of water", "description": "Stay hydrated throughout the day", "repeatType": "daily", "repeatValue": null, "alarmTime": null, "urgency": 1, "importance": 2, "sortOrder": 2, "completionRate": 0.80, "completionDays": 90 },
+    { "categoryKey": "health", "title": "Run or walk 30 min", "description": "Cardio workout for fitness", "repeatType": "weekly", "repeatValue": "1,3,5", "alarmTime": 1140, "urgency": 2, "importance": 4, "sortOrder": 3, "completionRate": 0.75, "completionDays": 90 },
+    { "categoryKey": "work", "title": "Check today's schedule", "description": "Review Slack, email & calendar", "repeatType": "daily", "repeatValue": null, "alarmTime": 540, "urgency": 2, "importance": 3, "sortOrder": 1, "completionRate": 0.90, "completionDays": 90 },
+    { "categoryKey": "work", "title": "Weekly goal review", "description": "Recap this week's goals every Monday", "repeatType": "weekly", "repeatValue": "1", "alarmTime": 570, "urgency": 2, "importance": 4, "sortOrder": 2, "completionRate": 0.80, "completionDays": 90 },
+    { "categoryKey": "personal", "title": "Write daily journal", "description": "Record today's highlights & 3 gratitudes", "repeatType": "daily", "repeatValue": null, "alarmTime": 1350, "urgency": 1, "importance": 3, "sortOrder": 1, "completionRate": 0.70, "completionDays": 90 },
+    { "categoryKey": "personal", "title": "Read for 20 minutes", "description": "Wind down with a book before sleep", "repeatType": "daily", "repeatValue": null, "alarmTime": 1380, "urgency": 1, "importance": 2, "sortOrder": 2, "completionRate": 0.65, "completionDays": 90 },
+    { "categoryKey": "study", "title": "Memorize 20 vocabulary words", "description": "Anki deck review + new words", "repeatType": "daily", "repeatValue": null, "alarmTime": 510, "urgency": 1, "importance": 3, "sortOrder": 1, "completionRate": 0.75, "completionDays": 90 },
+    { "categoryKey": "study", "title": "Study for 1 hour", "description": "Side project or online course", "repeatType": "daily", "repeatValue": null, "alarmTime": null, "urgency": 1, "importance": 4, "sortOrder": 2, "completionRate": 0.70, "completionDays": 90 },
+    { "categoryKey": "shopping", "title": "Write weekly shopping list", "description": "Check fridge and note what's needed", "repeatType": "weekly", "repeatValue": "0", "alarmTime": 600, "urgency": 1, "importance": 2, "sortOrder": 1, "completionRate": 0.85, "completionDays": 90 }
+  ],
+  "todos": [
+    { "categoryKey": "work", "title": "Draft Q2 report", "description": "Compile Q2 performance and summary", "dueDateOffset": 0, "urgency": 3, "importance": 4, "isCompleted": false, "completedAtOffset": null, "sortOrder": 1 },
+    { "categoryKey": "work", "title": "Review team meeting agenda", "description": "Check agenda before 3pm weekly meeting", "dueDateOffset": 0, "urgency": 3, "importance": 3, "isCompleted": false, "completedAtOffset": null, "sortOrder": 2 },
+    { "categoryKey": "personal", "title": "Call parents", "description": "Check in this week", "dueDateOffset": 0, "urgency": 1, "importance": 4, "isCompleted": false, "completedAtOffset": null, "sortOrder": 1 },
+    { "categoryKey": "health", "title": "Book orthopedic appointment", "description": "Knee pain — need to see a doctor", "dueDateOffset": 0, "urgency": 2, "importance": 3, "isCompleted": false, "completedAtOffset": null, "sortOrder": 1 },
+    { "categoryKey": "study", "title": "TypeScript generics notes", "description": "Read official docs and write examples", "dueDateOffset": 0, "urgency": 1, "importance": 3, "isCompleted": false, "completedAtOffset": null, "sortOrder": 1 },
+    { "categoryKey": "shopping", "title": "Buy detergent & fabric softener", "description": "Order online for next-day delivery", "dueDateOffset": 0, "urgency": 1, "importance": 2, "isCompleted": false, "completedAtOffset": null, "sortOrder": 1 },
+    { "categoryKey": "work", "title": "Prepare client presentation", "description": "Final review of proposal deck for Company A", "dueDateOffset": 1, "urgency": 4, "importance": 4, "isCompleted": false, "completedAtOffset": null, "sortOrder": 3 },
+    { "categoryKey": "personal", "title": "Order friend's birthday gift", "description": "Party is next week — order in advance", "dueDateOffset": 3, "urgency": 3, "importance": 3, "isCompleted": false, "completedAtOffset": null, "sortOrder": 2 },
+    { "categoryKey": "health", "title": "Replace running shoes", "description": "6+ months of use, soles are worn", "dueDateOffset": 4, "urgency": 1, "importance": 2, "isCompleted": false, "completedAtOffset": null, "sortOrder": 2 },
+    { "categoryKey": "study", "title": "Algorithm study presentation", "description": "Solve 3 greedy algorithm problems", "dueDateOffset": 5, "urgency": 2, "importance": 3, "isCompleted": false, "completedAtOffset": null, "sortOrder": 2 },
+    { "categoryKey": "work", "title": "H1 KPI review report", "description": "Analyze goal achievement and plan for H2", "dueDateOffset": 9, "urgency": 2, "importance": 4, "isCompleted": false, "completedAtOffset": null, "sortOrder": 4 },
+    { "categoryKey": "personal", "title": "Book summer vacation accommodation", "description": "3-day beach trip in July", "dueDateOffset": 12, "urgency": 1, "importance": 3, "isCompleted": false, "completedAtOffset": null, "sortOrder": 3 },
+    { "categoryKey": "work", "title": "Complete server deployment test", "description": "Full flow test on staging environment", "dueDateOffset": -3, "urgency": 4, "importance": 4, "isCompleted": false, "completedAtOffset": null, "sortOrder": 5 },
+    { "categoryKey": "study", "title": "Summarize 'The One Thing' notes", "description": "Key takeaways from chapters 1–5", "dueDateOffset": -5, "urgency": 1, "importance": 2, "isCompleted": false, "completedAtOffset": null, "sortOrder": 4 },
+    { "categoryKey": "personal", "title": "Dental checkup appointment", "description": "Scaling needed every 6 months", "dueDateOffset": -7, "urgency": 1, "importance": 3, "isCompleted": false, "completedAtOffset": null, "sortOrder": 4 },
+    { "categoryKey": "work", "title": "April expense report", "description": "Submit receipts and expense claims", "dueDateOffset": -4, "urgency": 3, "importance": 4, "isCompleted": true, "completedAtOffset": -2, "sortOrder": 6 },
+    { "categoryKey": "work", "title": "New team member onboarding docs", "description": "Prepare first-week guide document", "dueDateOffset": -7, "urgency": 2, "importance": 3, "isCompleted": true, "completedAtOffset": -5, "sortOrder": 7 },
+    { "categoryKey": "personal", "title": "Car insurance renewal", "description": "Online renewal before March expiry", "dueDateOffset": -9, "urgency": 3, "importance": 4, "isCompleted": true, "completedAtOffset": -7, "sortOrder": 5 },
+    { "categoryKey": "health", "title": "Review blood test results", "description": "Pick up health screening report", "dueDateOffset": -4, "urgency": 2, "importance": 3, "isCompleted": true, "completedAtOffset": -3, "sortOrder": 3 },
+    { "categoryKey": "study", "title": "Finish JavaScript design patterns course", "description": "Completed all 15 patterns", "dueDateOffset": -12, "urgency": 1, "importance": 3, "isCompleted": true, "completedAtOffset": -10, "sortOrder": 5 }
+  ]
+}

--- a/src/data/sample/ja.json
+++ b/src/data/sample/ja.json
@@ -1,0 +1,44 @@
+{
+  "defaultCategoryName": "未分類",
+  "categories": [
+    { "key": "work", "name": "仕事", "color": "#4285F4", "description": "仕事関連のタスク", "sortOrder": 1 },
+    { "key": "personal", "name": "個人", "color": "#EA4335", "description": "個人的なタスク", "sortOrder": 2 },
+    { "key": "health", "name": "健康", "color": "#34A853", "description": "健康・フィットネス", "sortOrder": 3 },
+    { "key": "study", "name": "学習", "color": "#FBBC05", "description": "勉強・自己成長", "sortOrder": 4 },
+    { "key": "shopping", "name": "買い物", "color": "#9C27B0", "description": "買い物リスト", "sortOrder": 5 }
+  ],
+  "routines": [
+    { "categoryKey": "health", "title": "朝のストレッチ 10分", "description": "起床後に全身ストレッチで一日をスタート", "repeatType": "daily", "repeatValue": null, "alarmTime": 420, "urgency": 1, "importance": 3, "sortOrder": 1, "completionRate": 0.85, "completionDays": 90 },
+    { "categoryKey": "health", "title": "水を2L以上飲む", "description": "一日の推奨水分摂取量を達成", "repeatType": "daily", "repeatValue": null, "alarmTime": null, "urgency": 1, "importance": 2, "sortOrder": 2, "completionRate": 0.80, "completionDays": 90 },
+    { "categoryKey": "health", "title": "ランニングまたはウォーキング 30分", "description": "有酸素運動で体力維持", "repeatType": "weekly", "repeatValue": "1,3,5", "alarmTime": 1140, "urgency": 2, "importance": 4, "sortOrder": 3, "completionRate": 0.75, "completionDays": 90 },
+    { "categoryKey": "work", "title": "今日のスケジュール確認", "description": "Slack・メール・カレンダーをチェック", "repeatType": "daily", "repeatValue": null, "alarmTime": 540, "urgency": 2, "importance": 3, "sortOrder": 1, "completionRate": 0.90, "completionDays": 90 },
+    { "categoryKey": "work", "title": "週次目標レビュー", "description": "月曜の朝に今週の目標を振り返る", "repeatType": "weekly", "repeatValue": "1", "alarmTime": 570, "urgency": 2, "importance": 4, "sortOrder": 2, "completionRate": 0.80, "completionDays": 90 },
+    { "categoryKey": "personal", "title": "日記を書く", "description": "今日あったこと＆感謝すること3つ", "repeatType": "daily", "repeatValue": null, "alarmTime": 1350, "urgency": 1, "importance": 3, "sortOrder": 1, "completionRate": 0.70, "completionDays": 90 },
+    { "categoryKey": "personal", "title": "就寝前に20分読書", "description": "読書でリラックスしてから眠る", "repeatType": "daily", "repeatValue": null, "alarmTime": 1380, "urgency": 1, "importance": 2, "sortOrder": 2, "completionRate": 0.65, "completionDays": 90 },
+    { "categoryKey": "study", "title": "英単語を20個暗記", "description": "Ankiデッキの復習＋新単語", "repeatType": "daily", "repeatValue": null, "alarmTime": 510, "urgency": 1, "importance": 3, "sortOrder": 1, "completionRate": 0.75, "completionDays": 90 },
+    { "categoryKey": "study", "title": "1時間以上勉強する", "description": "サイドプロジェクトまたはオンライン講座", "repeatType": "daily", "repeatValue": null, "alarmTime": null, "urgency": 1, "importance": 4, "sortOrder": 2, "completionRate": 0.70, "completionDays": 90 },
+    { "categoryKey": "shopping", "title": "週間買い物リストを作成", "description": "冷蔵庫を確認して必要なものをリストアップ", "repeatType": "weekly", "repeatValue": "0", "alarmTime": 600, "urgency": 1, "importance": 2, "sortOrder": 1, "completionRate": 0.85, "completionDays": 90 }
+  ],
+  "todos": [
+    { "categoryKey": "work", "title": "Q2レポートの下書き作成", "description": "第2四半期の実績まとめと要約", "dueDateOffset": 0, "urgency": 3, "importance": 4, "isCompleted": false, "completedAtOffset": null, "sortOrder": 1 },
+    { "categoryKey": "work", "title": "チーム会議の事前資料確認", "description": "午後3時の週次ミーティング前にアジェンダ確認", "dueDateOffset": 0, "urgency": 3, "importance": 3, "isCompleted": false, "completedAtOffset": null, "sortOrder": 2 },
+    { "categoryKey": "personal", "title": "両親に電話する", "description": "今週中に必ず連絡する", "dueDateOffset": 0, "urgency": 1, "importance": 4, "isCompleted": false, "completedAtOffset": null, "sortOrder": 1 },
+    { "categoryKey": "health", "title": "整形外科の予約を入れる", "description": "膝の痛みで受診が必要", "dueDateOffset": 0, "urgency": 2, "importance": 3, "isCompleted": false, "completedAtOffset": null, "sortOrder": 1 },
+    { "categoryKey": "study", "title": "TypeScriptのジェネリクスまとめ", "description": "公式ドキュメントを読んでサンプルコードを書く", "dueDateOffset": 0, "urgency": 1, "importance": 3, "isCompleted": false, "completedAtOffset": null, "sortOrder": 1 },
+    { "categoryKey": "shopping", "title": "洗剤と柔軟剤を購入", "description": "翌日配達でオンライン注文", "dueDateOffset": 0, "urgency": 1, "importance": 2, "isCompleted": false, "completedAtOffset": null, "sortOrder": 1 },
+    { "categoryKey": "work", "title": "クライアント向けプレゼン準備", "description": "A社への提案資料の最終確認", "dueDateOffset": 1, "urgency": 4, "importance": 4, "isCompleted": false, "completedAtOffset": null, "sortOrder": 3 },
+    { "categoryKey": "personal", "title": "友人の誕生日プレゼントを注文", "description": "来週のパーティーまでに事前準備", "dueDateOffset": 3, "urgency": 3, "importance": 3, "isCompleted": false, "completedAtOffset": null, "sortOrder": 2 },
+    { "categoryKey": "health", "title": "ランニングシューズを買い替え", "description": "6ヶ月以上使用、ソールが磨耗", "dueDateOffset": 4, "urgency": 1, "importance": 2, "isCompleted": false, "completedAtOffset": null, "sortOrder": 2 },
+    { "categoryKey": "study", "title": "アルゴリズム勉強会の発表準備", "description": "貪欲アルゴリズムの問題を3問解く", "dueDateOffset": 5, "urgency": 2, "importance": 3, "isCompleted": false, "completedAtOffset": null, "sortOrder": 2 },
+    { "categoryKey": "work", "title": "上半期KPIレビューレポート", "description": "目標達成率の分析と下半期の戦略策定", "dueDateOffset": 9, "urgency": 2, "importance": 4, "isCompleted": false, "completedAtOffset": null, "sortOrder": 4 },
+    { "categoryKey": "personal", "title": "夏休みの宿泊先を予約", "description": "7月に3日間の旅行", "dueDateOffset": 12, "urgency": 1, "importance": 3, "isCompleted": false, "completedAtOffset": null, "sortOrder": 3 },
+    { "categoryKey": "work", "title": "サーバーデプロイテスト完了", "description": "ステージング環境で全体フローをテスト", "dueDateOffset": -3, "urgency": 4, "importance": 4, "isCompleted": false, "completedAtOffset": null, "sortOrder": 5 },
+    { "categoryKey": "study", "title": "『エッセンシャル思考』読書ノート整理", "description": "第1〜5章のポイント要約", "dueDateOffset": -5, "urgency": 1, "importance": 2, "isCompleted": false, "completedAtOffset": null, "sortOrder": 4 },
+    { "categoryKey": "personal", "title": "歯科定期検診の予約", "description": "6ヶ月ごとにスケーリングが必要", "dueDateOffset": -7, "urgency": 1, "importance": 3, "isCompleted": false, "completedAtOffset": null, "sortOrder": 4 },
+    { "categoryKey": "work", "title": "4月の経費精算締め切り", "description": "経費精算と領収書の提出", "dueDateOffset": -4, "urgency": 3, "importance": 4, "isCompleted": true, "completedAtOffset": -2, "sortOrder": 6 },
+    { "categoryKey": "work", "title": "新メンバーのオンボーディング資料準備", "description": "初週向けのガイドドキュメント作成", "dueDateOffset": -7, "urgency": 2, "importance": 3, "isCompleted": true, "completedAtOffset": -5, "sortOrder": 7 },
+    { "categoryKey": "personal", "title": "自動車保険の更新", "description": "3月期限前にオンラインで更新完了", "dueDateOffset": -9, "urgency": 3, "importance": 4, "isCompleted": true, "completedAtOffset": -7, "sortOrder": 5 },
+    { "categoryKey": "health", "title": "血液検査の結果確認", "description": "健康診断の結果レポートを受け取る", "dueDateOffset": -4, "urgency": 2, "importance": 3, "isCompleted": true, "completedAtOffset": -3, "sortOrder": 3 },
+    { "categoryKey": "study", "title": "JavaScriptデザインパターン講座を完了", "description": "全15パターンを学習完了", "dueDateOffset": -12, "urgency": 1, "importance": 3, "isCompleted": true, "completedAtOffset": -10, "sortOrder": 5 }
+  ]
+}

--- a/src/data/sample/ko.json
+++ b/src/data/sample/ko.json
@@ -1,0 +1,44 @@
+{
+  "defaultCategoryName": "미분류",
+  "categories": [
+    { "key": "work", "name": "업무", "color": "#4285F4", "description": "직장 관련 할 일", "sortOrder": 1 },
+    { "key": "personal", "name": "개인", "color": "#EA4335", "description": "개인적인 할 일", "sortOrder": 2 },
+    { "key": "health", "name": "운동", "color": "#34A853", "description": "운동 및 건강 관리", "sortOrder": 3 },
+    { "key": "study", "name": "학습", "color": "#FBBC05", "description": "공부 및 자기계발", "sortOrder": 4 },
+    { "key": "shopping", "name": "쇼핑", "color": "#9C27B0", "description": "구매 목록", "sortOrder": 5 }
+  ],
+  "routines": [
+    { "categoryKey": "health", "title": "아침 스트레칭 10분", "description": "기상 후 전신 스트레칭으로 하루 시작", "repeatType": "daily", "repeatValue": null, "alarmTime": 420, "urgency": 1, "importance": 3, "sortOrder": 1, "completionRate": 0.85, "completionDays": 90 },
+    { "categoryKey": "health", "title": "물 2L 이상 마시기", "description": "하루 권장 수분 섭취량 달성", "repeatType": "daily", "repeatValue": null, "alarmTime": null, "urgency": 1, "importance": 2, "sortOrder": 2, "completionRate": 0.80, "completionDays": 90 },
+    { "categoryKey": "health", "title": "러닝 또는 걷기 30분", "description": "유산소 운동으로 체력 유지", "repeatType": "weekly", "repeatValue": "1,3,5", "alarmTime": 1140, "urgency": 2, "importance": 4, "sortOrder": 3, "completionRate": 0.75, "completionDays": 90 },
+    { "categoryKey": "work", "title": "오늘 업무 일정 확인", "description": "슬랙·이메일·캘린더 체크", "repeatType": "daily", "repeatValue": null, "alarmTime": 540, "urgency": 2, "importance": 3, "sortOrder": 1, "completionRate": 0.90, "completionDays": 90 },
+    { "categoryKey": "work", "title": "주간 목표 점검", "description": "월요일 아침 이번 주 목표 리마인드", "repeatType": "weekly", "repeatValue": "1", "alarmTime": 570, "urgency": 2, "importance": 4, "sortOrder": 2, "completionRate": 0.80, "completionDays": 90 },
+    { "categoryKey": "personal", "title": "하루 일기 쓰기", "description": "오늘 있었던 일 & 감사한 것 3가지", "repeatType": "daily", "repeatValue": null, "alarmTime": 1350, "urgency": 1, "importance": 3, "sortOrder": 1, "completionRate": 0.70, "completionDays": 90 },
+    { "categoryKey": "personal", "title": "독서 20분", "description": "취침 전 독서로 집중력 향상", "repeatType": "daily", "repeatValue": null, "alarmTime": 1380, "urgency": 1, "importance": 2, "sortOrder": 2, "completionRate": 0.65, "completionDays": 90 },
+    { "categoryKey": "study", "title": "영어 단어 암기 20개", "description": "Anki 덱 복습 + 신규 단어", "repeatType": "daily", "repeatValue": null, "alarmTime": 510, "urgency": 1, "importance": 3, "sortOrder": 1, "completionRate": 0.75, "completionDays": 90 },
+    { "categoryKey": "study", "title": "개발 공부 1시간 이상", "description": "사이드 프로젝트 or 강의 수강", "repeatType": "daily", "repeatValue": null, "alarmTime": null, "urgency": 1, "importance": 4, "sortOrder": 2, "completionRate": 0.70, "completionDays": 90 },
+    { "categoryKey": "shopping", "title": "주간 장보기 리스트 작성", "description": "냉장고 확인 후 필요한 것 정리", "repeatType": "weekly", "repeatValue": "0", "alarmTime": 600, "urgency": 1, "importance": 2, "sortOrder": 1, "completionRate": 0.85, "completionDays": 90 }
+  ],
+  "todos": [
+    { "categoryKey": "work", "title": "분기 보고서 초안 작성", "description": "2분기 실적 취합 및 요약 정리", "dueDateOffset": 0, "urgency": 3, "importance": 4, "isCompleted": false, "completedAtOffset": null, "sortOrder": 1 },
+    { "categoryKey": "work", "title": "팀 미팅 사전 자료 검토", "description": "오후 3시 주간 회의 전 아젠다 확인", "dueDateOffset": 0, "urgency": 3, "importance": 3, "isCompleted": false, "completedAtOffset": null, "sortOrder": 2 },
+    { "categoryKey": "personal", "title": "부모님께 안부 전화", "description": "이번 주 안으로 꼭", "dueDateOffset": 0, "urgency": 1, "importance": 4, "isCompleted": false, "completedAtOffset": null, "sortOrder": 1 },
+    { "categoryKey": "health", "title": "정형외과 예약 전화", "description": "무릎 통증 관련 진료 예약", "dueDateOffset": 0, "urgency": 2, "importance": 3, "isCompleted": false, "completedAtOffset": null, "sortOrder": 1 },
+    { "categoryKey": "study", "title": "TypeScript 제네릭 정리", "description": "공식 문서 읽고 예제 코드 작성", "dueDateOffset": 0, "urgency": 1, "importance": 3, "isCompleted": false, "completedAtOffset": null, "sortOrder": 1 },
+    { "categoryKey": "shopping", "title": "세제 & 섬유유연제 구매", "description": "쿠팡 로켓배송 주문", "dueDateOffset": 0, "urgency": 1, "importance": 2, "isCompleted": false, "completedAtOffset": null, "sortOrder": 1 },
+    { "categoryKey": "work", "title": "클라이언트 미팅 준비", "description": "A사 제안 발표 자료 최종 점검", "dueDateOffset": 1, "urgency": 4, "importance": 4, "isCompleted": false, "completedAtOffset": null, "sortOrder": 3 },
+    { "categoryKey": "personal", "title": "친구 생일 선물 주문", "description": "다음 주 파티 전에 미리 준비", "dueDateOffset": 3, "urgency": 3, "importance": 3, "isCompleted": false, "completedAtOffset": null, "sortOrder": 2 },
+    { "categoryKey": "health", "title": "러닝화 교체", "description": "6개월 이상 사용, 밑창 마모", "dueDateOffset": 4, "urgency": 1, "importance": 2, "isCompleted": false, "completedAtOffset": null, "sortOrder": 2 },
+    { "categoryKey": "study", "title": "알고리즘 스터디 발표 준비", "description": "그리디 알고리즘 예제 3문제 풀기", "dueDateOffset": 5, "urgency": 2, "importance": 3, "isCompleted": false, "completedAtOffset": null, "sortOrder": 2 },
+    { "categoryKey": "work", "title": "상반기 KPI 점검 보고서", "description": "목표 달성률 분석 및 하반기 전략", "dueDateOffset": 9, "urgency": 2, "importance": 4, "isCompleted": false, "completedAtOffset": null, "sortOrder": 4 },
+    { "categoryKey": "personal", "title": "여행 숙소 예약", "description": "7월 제주 여행 2박 3일", "dueDateOffset": 12, "urgency": 1, "importance": 3, "isCompleted": false, "completedAtOffset": null, "sortOrder": 3 },
+    { "categoryKey": "work", "title": "서버 배포 테스트 완료", "description": "스테이징 환경에서 전체 플로우 테스트", "dueDateOffset": -3, "urgency": 4, "importance": 4, "isCompleted": false, "completedAtOffset": null, "sortOrder": 5 },
+    { "categoryKey": "study", "title": "독서 노트 정리 - '원씽'", "description": "챕터 1~5 핵심 요약 정리", "dueDateOffset": -5, "urgency": 1, "importance": 2, "isCompleted": false, "completedAtOffset": null, "sortOrder": 4 },
+    { "categoryKey": "personal", "title": "치과 정기 검진 예약", "description": "6개월마다 스케일링 필요", "dueDateOffset": -7, "urgency": 1, "importance": 3, "isCompleted": false, "completedAtOffset": null, "sortOrder": 4 },
+    { "categoryKey": "work", "title": "4월 정산 마감", "description": "경비 정산 및 영수증 제출", "dueDateOffset": -4, "urgency": 3, "importance": 4, "isCompleted": true, "completedAtOffset": -2, "sortOrder": 6 },
+    { "categoryKey": "work", "title": "신규 팀원 온보딩 자료 준비", "description": "입사 첫 주 가이드 문서 작성", "dueDateOffset": -7, "urgency": 2, "importance": 3, "isCompleted": true, "completedAtOffset": -5, "sortOrder": 7 },
+    { "categoryKey": "personal", "title": "자동차 보험 갱신", "description": "3월 만료 전 온라인 갱신 완료", "dueDateOffset": -9, "urgency": 3, "importance": 4, "isCompleted": true, "completedAtOffset": -7, "sortOrder": 5 },
+    { "categoryKey": "health", "title": "혈액 검사 결과 확인", "description": "건강검진 결과 리포트 수령", "dueDateOffset": -4, "urgency": 2, "importance": 3, "isCompleted": true, "completedAtOffset": -3, "sortOrder": 3 },
+    { "categoryKey": "study", "title": "JavaScript 디자인 패턴 강의 완강", "description": "패턴 15가지 모두 학습 완료", "dueDateOffset": -12, "urgency": 1, "importance": 3, "isCompleted": true, "completedAtOffset": -10, "sortOrder": 5 }
+  ]
+}

--- a/src/data/sample/zh.json
+++ b/src/data/sample/zh.json
@@ -1,0 +1,44 @@
+{
+  "defaultCategoryName": "未分类",
+  "categories": [
+    { "key": "work", "name": "工作", "color": "#4285F4", "description": "工作相关任务", "sortOrder": 1 },
+    { "key": "personal", "name": "个人", "color": "#EA4335", "description": "个人事务", "sortOrder": 2 },
+    { "key": "health", "name": "健康", "color": "#34A853", "description": "健康与运动", "sortOrder": 3 },
+    { "key": "study", "name": "学习", "color": "#FBBC05", "description": "学习与自我提升", "sortOrder": 4 },
+    { "key": "shopping", "name": "购物", "color": "#9C27B0", "description": "购物清单", "sortOrder": 5 }
+  ],
+  "routines": [
+    { "categoryKey": "health", "title": "晨间拉伸 10 分钟", "description": "起床后做全身拉伸，开启美好一天", "repeatType": "daily", "repeatValue": null, "alarmTime": 420, "urgency": 1, "importance": 3, "sortOrder": 1, "completionRate": 0.85, "completionDays": 90 },
+    { "categoryKey": "health", "title": "每天喝够 2L 水", "description": "保持每日推荐水分摄入", "repeatType": "daily", "repeatValue": null, "alarmTime": null, "urgency": 1, "importance": 2, "sortOrder": 2, "completionRate": 0.80, "completionDays": 90 },
+    { "categoryKey": "health", "title": "跑步或散步 30 分钟", "description": "有氧运动，保持体能", "repeatType": "weekly", "repeatValue": "1,3,5", "alarmTime": 1140, "urgency": 2, "importance": 4, "sortOrder": 3, "completionRate": 0.75, "completionDays": 90 },
+    { "categoryKey": "work", "title": "查看今日工作安排", "description": "检查 Slack、邮件和日历", "repeatType": "daily", "repeatValue": null, "alarmTime": 540, "urgency": 2, "importance": 3, "sortOrder": 1, "completionRate": 0.90, "completionDays": 90 },
+    { "categoryKey": "work", "title": "每周目标复盘", "description": "每周一早回顾本周目标", "repeatType": "weekly", "repeatValue": "1", "alarmTime": 570, "urgency": 2, "importance": 4, "sortOrder": 2, "completionRate": 0.80, "completionDays": 90 },
+    { "categoryKey": "personal", "title": "写日记", "description": "记录今天发生的事 & 3 件感恩的事", "repeatType": "daily", "repeatValue": null, "alarmTime": 1350, "urgency": 1, "importance": 3, "sortOrder": 1, "completionRate": 0.70, "completionDays": 90 },
+    { "categoryKey": "personal", "title": "睡前阅读 20 分钟", "description": "睡前读书，放松心情", "repeatType": "daily", "repeatValue": null, "alarmTime": 1380, "urgency": 1, "importance": 2, "sortOrder": 2, "completionRate": 0.65, "completionDays": 90 },
+    { "categoryKey": "study", "title": "背 20 个单词", "description": "Anki 复习 + 新单词学习", "repeatType": "daily", "repeatValue": null, "alarmTime": 510, "urgency": 1, "importance": 3, "sortOrder": 1, "completionRate": 0.75, "completionDays": 90 },
+    { "categoryKey": "study", "title": "学习 1 小时以上", "description": "个人项目或在线课程", "repeatType": "daily", "repeatValue": null, "alarmTime": null, "urgency": 1, "importance": 4, "sortOrder": 2, "completionRate": 0.70, "completionDays": 90 },
+    { "categoryKey": "shopping", "title": "写本周购物清单", "description": "检查冰箱，整理需要购买的物品", "repeatType": "weekly", "repeatValue": "0", "alarmTime": 600, "urgency": 1, "importance": 2, "sortOrder": 1, "completionRate": 0.85, "completionDays": 90 }
+  ],
+  "todos": [
+    { "categoryKey": "work", "title": "撰写 Q2 报告初稿", "description": "整理二季度业绩并撰写摘要", "dueDateOffset": 0, "urgency": 3, "importance": 4, "isCompleted": false, "completedAtOffset": null, "sortOrder": 1 },
+    { "categoryKey": "work", "title": "审阅团队会议议程", "description": "下午 3 点周会前确认议程", "dueDateOffset": 0, "urgency": 3, "importance": 3, "isCompleted": false, "completedAtOffset": null, "sortOrder": 2 },
+    { "categoryKey": "personal", "title": "给父母打电话", "description": "这周一定要打", "dueDateOffset": 0, "urgency": 1, "importance": 4, "isCompleted": false, "completedAtOffset": null, "sortOrder": 1 },
+    { "categoryKey": "health", "title": "预约骨科门诊", "description": "膝盖疼痛，需要就诊", "dueDateOffset": 0, "urgency": 2, "importance": 3, "isCompleted": false, "completedAtOffset": null, "sortOrder": 1 },
+    { "categoryKey": "study", "title": "整理 TypeScript 泛型笔记", "description": "阅读官方文档并编写示例代码", "dueDateOffset": 0, "urgency": 1, "importance": 3, "isCompleted": false, "completedAtOffset": null, "sortOrder": 1 },
+    { "categoryKey": "shopping", "title": "购买洗涤剂和柔顺剂", "description": "网购，次日达", "dueDateOffset": 0, "urgency": 1, "importance": 2, "isCompleted": false, "completedAtOffset": null, "sortOrder": 1 },
+    { "categoryKey": "work", "title": "准备客户演示文稿", "description": "最终审查 A 公司提案幻灯片", "dueDateOffset": 1, "urgency": 4, "importance": 4, "isCompleted": false, "completedAtOffset": null, "sortOrder": 3 },
+    { "categoryKey": "personal", "title": "订购朋友生日礼物", "description": "下周派对前提前准备", "dueDateOffset": 3, "urgency": 3, "importance": 3, "isCompleted": false, "completedAtOffset": null, "sortOrder": 2 },
+    { "categoryKey": "health", "title": "更换跑步鞋", "description": "使用超过 6 个月，鞋底磨损", "dueDateOffset": 4, "urgency": 1, "importance": 2, "isCompleted": false, "completedAtOffset": null, "sortOrder": 2 },
+    { "categoryKey": "study", "title": "算法学习小组演讲准备", "description": "解答 3 道贪心算法题目", "dueDateOffset": 5, "urgency": 2, "importance": 3, "isCompleted": false, "completedAtOffset": null, "sortOrder": 2 },
+    { "categoryKey": "work", "title": "上半年 KPI 复盘报告", "description": "分析目标完成率并制定下半年战略", "dueDateOffset": 9, "urgency": 2, "importance": 4, "isCompleted": false, "completedAtOffset": null, "sortOrder": 4 },
+    { "categoryKey": "personal", "title": "预订暑假住宿", "description": "7 月三天两夜海岛之旅", "dueDateOffset": 12, "urgency": 1, "importance": 3, "isCompleted": false, "completedAtOffset": null, "sortOrder": 3 },
+    { "categoryKey": "work", "title": "完成服务器部署测试", "description": "在预发布环境进行全流程测试", "dueDateOffset": -3, "urgency": 4, "importance": 4, "isCompleted": false, "completedAtOffset": null, "sortOrder": 5 },
+    { "categoryKey": "study", "title": "整理《最重要的事只有一件》读书笔记", "description": "第 1~5 章核心要点摘要", "dueDateOffset": -5, "urgency": 1, "importance": 2, "isCompleted": false, "completedAtOffset": null, "sortOrder": 4 },
+    { "categoryKey": "personal", "title": "预约牙科定期检查", "description": "每 6 个月需要洗牙", "dueDateOffset": -7, "urgency": 1, "importance": 3, "isCompleted": false, "completedAtOffset": null, "sortOrder": 4 },
+    { "categoryKey": "work", "title": "四月报销结算", "description": "提交费用报销及发票", "dueDateOffset": -4, "urgency": 3, "importance": 4, "isCompleted": true, "completedAtOffset": -2, "sortOrder": 6 },
+    { "categoryKey": "work", "title": "准备新员工入职资料", "description": "制作第一周引导文档", "dueDateOffset": -7, "urgency": 2, "importance": 3, "isCompleted": true, "completedAtOffset": -5, "sortOrder": 7 },
+    { "categoryKey": "personal", "title": "续保汽车保险", "description": "三月到期前完成在线续保", "dueDateOffset": -9, "urgency": 3, "importance": 4, "isCompleted": true, "completedAtOffset": -7, "sortOrder": 5 },
+    { "categoryKey": "health", "title": "查看血液检查报告", "description": "领取体检结果报告", "dueDateOffset": -4, "urgency": 2, "importance": 3, "isCompleted": true, "completedAtOffset": -3, "sortOrder": 3 },
+    { "categoryKey": "study", "title": "完成 JavaScript 设计模式课程", "description": "学完全部 15 种设计模式", "dueDateOffset": -12, "urgency": 1, "importance": 3, "isCompleted": true, "completedAtOffset": -10, "sortOrder": 5 }
+  ]
+}

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -51,6 +51,7 @@ export default function SettingsScreen() {
   const { language, setLanguage } = useLanguageStore();
   const [showTimePicker, setShowTimePicker] = useState(false);
   const [showLangDialog, setShowLangDialog] = useState(false);
+  const [sampleLocale, setSampleLocale] = useState<'ko' | 'en' | 'zh' | 'ja'>('ko');
   const [tempDate, setTempDate] = useState<Date>(() => {
     const d = new Date();
     d.setHours(Math.floor(dayStartMinutes / 60), dayStartMinutes % 60, 0, 0);
@@ -158,6 +159,34 @@ export default function SettingsScreen() {
     queryClient.invalidateQueries({ queryKey: ['completions'], exact: false });
     Alert.alert('시드 완료', `루틴 ${result.routines}개 · 할 일 ${result.todos}개 · 루틴 완료 기록 ${result.routineCompletions}건 · 할 일 완료 기록 ${result.todoCompletions}건 생성됨`);
   };
+  const handleApplySampleData = () => {
+    const localeLabel = { ko: '한국어', en: 'English', zh: '中文', ja: '日本語' };
+    Alert.alert(
+      '샘플 데이터 적용',
+      `[${localeLabel[sampleLocale]}] 샘플 데이터를 적용합니다.\n기존 할 일·루틴·완료 기록이 모두 삭제됩니다.`,
+      [
+        { text: '취소', style: 'cancel' },
+        {
+          text: '적용',
+          style: 'destructive',
+          onPress: () => {
+            const { applySampleData } = require('../utils/sampleDataLoader');
+            const result = applySampleData(sampleLocale);
+            queryClient.invalidateQueries({ queryKey: ['todos'] });
+            queryClient.invalidateQueries({ queryKey: ['routines'] });
+            queryClient.invalidateQueries({ queryKey: ['routinesToday'] });
+            queryClient.invalidateQueries({ queryKey: ['completions'], exact: false });
+            queryClient.invalidateQueries({ queryKey: ['categories'] });
+            Alert.alert(
+              '적용 완료',
+              `카테고리 ${result.categories}개 · 루틴 ${result.routines}개 · 할 일 ${result.todos}개\n루틴 완료 ${result.routineCompletions}건 · 할 일 완료 ${result.todoCompletions}건`,
+            );
+          },
+        },
+      ],
+    );
+  };
+
   const handleReplayOnboarding = () => {
     resetOnboardingCompleted();
     navigation.getParent()?.getParent()?.dispatch(
@@ -269,6 +298,34 @@ export default function SettingsScreen() {
                   </Text>
                 </View>
               </TouchableOpacity>
+              <Divider />
+              <View style={styles.item}>
+                <View style={{ flex: 1 }}>
+                  <Text variant="bodyLarge" style={{ color: Colors.danger }}>스크린샷용 샘플 데이터</Text>
+                  <Text variant="bodySmall" style={styles.description}>
+                    언어별 로컬라이즈 데이터로 초기화 (기존 데이터 전체 삭제)
+                  </Text>
+                  <View style={styles.localePicker}>
+                    {(['ko', 'en', 'zh', 'ja'] as ('ko' | 'en' | 'zh' | 'ja')[]).map((loc) => (
+                      <TouchableOpacity
+                        key={loc}
+                        style={[styles.localeBtn, sampleLocale === loc && styles.localeBtnActive]}
+                        onPress={() => setSampleLocale(loc)}
+                      >
+                        <Text
+                          variant="labelMedium"
+                          style={sampleLocale === loc ? styles.localeBtnTextActive : styles.localeBtnText}
+                        >
+                          {loc}
+                        </Text>
+                      </TouchableOpacity>
+                    ))}
+                  </View>
+                  <TouchableOpacity style={styles.applyBtn} onPress={handleApplySampleData}>
+                    <Text variant="labelMedium" style={styles.applyBtnText}>적용</Text>
+                  </TouchableOpacity>
+                </View>
+              </View>
             </View>
           </>
         )}
@@ -375,6 +432,26 @@ const styles = StyleSheet.create({
     padding: 16,
   },
   description: { color: Colors.textSecondary, marginTop: 2 },
+  localePicker: { flexDirection: 'row', gap: 8, marginTop: 10 },
+  localeBtn: {
+    paddingHorizontal: 12,
+    paddingVertical: 5,
+    borderRadius: 6,
+    borderWidth: 1,
+    borderColor: Colors.border,
+  },
+  localeBtnActive: { backgroundColor: Colors.danger, borderColor: Colors.danger },
+  localeBtnText: { color: Colors.textSecondary },
+  localeBtnTextActive: { color: '#fff' },
+  applyBtn: {
+    marginTop: 10,
+    alignSelf: 'flex-start',
+    paddingHorizontal: 16,
+    paddingVertical: 7,
+    borderRadius: 6,
+    backgroundColor: Colors.danger,
+  },
+  applyBtnText: { color: '#fff' },
   checkmark: { fontSize: 18, color: Colors.primary, fontWeight: '700' },
   infoItem: {
     flexDirection: 'row',

--- a/src/utils/sampleDataLoader.ts
+++ b/src/utils/sampleDataLoader.ts
@@ -1,0 +1,218 @@
+import dayjs from 'dayjs';
+import { eq } from 'drizzle-orm';
+import { db } from '../db';
+import { categories, todos, routines, todoCompletions, routineCompletions } from '../db/schema';
+
+export type SampleLocale = 'ko' | 'en' | 'zh' | 'ja';
+
+const sampleFiles: Record<SampleLocale, () => SampleData> = {
+  ko: () => require('../data/sample/ko.json'),
+  en: () => require('../data/sample/en.json'),
+  zh: () => require('../data/sample/zh.json'),
+  ja: () => require('../data/sample/ja.json'),
+};
+
+interface SampleCategory {
+  key: string;
+  name: string;
+  color: string;
+  description: string;
+  sortOrder: number;
+}
+
+interface SampleRoutine {
+  categoryKey: string;
+  title: string;
+  description: string | null;
+  repeatType: string;
+  repeatValue: string | null;
+  alarmTime: number | null;
+  urgency: number;
+  importance: number;
+  sortOrder: number;
+  completionRate: number;
+  completionDays: number;
+}
+
+interface SampleTodo {
+  categoryKey: string;
+  title: string;
+  description: string | null;
+  dueDateOffset: number;
+  dueTime?: number | null;
+  urgency: number;
+  importance: number;
+  isCompleted: boolean;
+  completedAtOffset: number | null;
+  sortOrder: number;
+}
+
+interface SampleData {
+  defaultCategoryName: string;
+  categories: SampleCategory[];
+  routines: SampleRoutine[];
+  todos: SampleTodo[];
+}
+
+function makeDailyCompletions(
+  routineId: number,
+  days: number,
+  rate: number,
+): { routineId: number; completedDate: string }[] {
+  const records: { routineId: number; completedDate: string }[] = [];
+  const seed = routineId * 7919;
+  const today = dayjs().startOf('day');
+  for (let i = days; i >= 1; i--) {
+    const pseudo = Math.abs(Math.sin(seed + i * 13));
+    if (pseudo < rate) {
+      records.push({ routineId, completedDate: today.subtract(i, 'day').format('YYYY-MM-DD') });
+    }
+  }
+  return records;
+}
+
+function makeWeeklyCompletions(
+  routineId: number,
+  days: number,
+  weekdays: number[],
+  rate: number,
+): { routineId: number; completedDate: string }[] {
+  const records: { routineId: number; completedDate: string }[] = [];
+  const seed = routineId * 6271;
+  const today = dayjs().startOf('day');
+  for (let i = days; i >= 1; i--) {
+    const d = today.subtract(i, 'day');
+    if (!weekdays.includes(d.day())) continue;
+    const pseudo = Math.abs(Math.sin(seed + i * 17));
+    if (pseudo < rate) {
+      records.push({ routineId, completedDate: d.format('YYYY-MM-DD') });
+    }
+  }
+  return records;
+}
+
+export function applySampleData(locale: SampleLocale): {
+  categories: number;
+  routines: number;
+  todos: number;
+  routineCompletions: number;
+  todoCompletions: number;
+} {
+  const data = sampleFiles[locale]();
+  const now = Date.now();
+  const today = dayjs().startOf('day');
+
+  // 1. 기존 데이터 삭제 (todos → cascade todoCompletions, routines → cascade routineCompletions)
+  db.delete(todos).run();
+  db.delete(routines).run();
+  db.delete(categories).where(eq(categories.isDefault, 0)).run();
+
+  // 2. 기본 카테고리 이름 로컬라이즈
+  db.update(categories)
+    .set({ name: data.defaultCategoryName })
+    .where(eq(categories.isDefault, 1))
+    .run();
+
+  const defaultCat = db.select({ id: categories.id }).from(categories).where(eq(categories.isDefault, 1)).get();
+  const defaultId = defaultCat?.id ?? 1;
+
+  // 3. 카테고리 삽입 & key→id 맵 생성
+  const catKeyToId: Record<string, number> = {};
+  for (const cat of data.categories) {
+    const result = db.insert(categories).values({
+      name: cat.name,
+      description: cat.description,
+      color: cat.color,
+      sortOrder: cat.sortOrder,
+      isDefault: 0,
+      createdAt: now,
+    }).returning({ id: categories.id }).get();
+    if (result) catKeyToId[cat.key] = result.id;
+  }
+
+  // 4. 루틴 삽입 + 완료 이력 생성
+  const routineCompletionInserts: { routineId: number; completedDate: string }[] = [];
+  let routineCount = 0;
+
+  for (const r of data.routines) {
+    const categoryId = catKeyToId[r.categoryKey] ?? defaultId;
+    const result = db.insert(routines).values({
+      categoryId,
+      title: r.title,
+      description: r.description ?? null,
+      repeatType: r.repeatType,
+      repeatValue: r.repeatValue ?? null,
+      alarmTime: r.alarmTime ?? null,
+      urgency: r.urgency,
+      importance: r.importance,
+      sortOrder: r.sortOrder,
+      isActive: 1,
+      createdAt: now - 86400000 * r.completionDays,
+      updatedAt: now,
+    }).returning({ id: routines.id }).get();
+
+    if (!result) continue;
+    routineCount++;
+
+    if (r.repeatType === 'daily') {
+      routineCompletionInserts.push(...makeDailyCompletions(result.id, r.completionDays, r.completionRate));
+    } else if (r.repeatType === 'weekly' && r.repeatValue) {
+      const weekdays = r.repeatValue.split(',').map(Number);
+      routineCompletionInserts.push(...makeWeeklyCompletions(result.id, r.completionDays, weekdays, r.completionRate));
+    }
+  }
+
+  if (routineCompletionInserts.length > 0) {
+    db.insert(routineCompletions).values(routineCompletionInserts).run();
+  }
+
+  // 5. 할 일 삽입 + 완료 이력 생성
+  const todoCompletionInserts: { todoId: number; completedDate: string }[] = [];
+  let todoCount = 0;
+
+  for (const todo of data.todos) {
+    const categoryId = catKeyToId[todo.categoryKey] ?? defaultId;
+    const dueDate = today.add(todo.dueDateOffset, 'day').valueOf();
+    const completedAt = todo.completedAtOffset != null
+      ? today.add(todo.completedAtOffset, 'day').valueOf()
+      : null;
+
+    const result = db.insert(todos).values({
+      categoryId,
+      title: todo.title,
+      description: todo.description ?? null,
+      dueDate,
+      dueTime: todo.dueTime ?? null,
+      urgency: todo.urgency,
+      importance: todo.importance,
+      sortOrder: todo.sortOrder,
+      isCompleted: todo.isCompleted ? 1 : 0,
+      completedAt,
+      isDeleted: 0,
+      createdAt: now - Math.floor(Math.abs(Math.sin(todo.sortOrder * 1234)) * 86400000 * 30),
+      updatedAt: now,
+    }).returning({ id: todos.id, isCompleted: todos.isCompleted, completedAt: todos.completedAt }).get();
+
+    if (!result) continue;
+    todoCount++;
+
+    if (result.isCompleted === 1 && result.completedAt) {
+      todoCompletionInserts.push({
+        todoId: result.id,
+        completedDate: dayjs(result.completedAt).format('YYYY-MM-DD'),
+      });
+    }
+  }
+
+  if (todoCompletionInserts.length > 0) {
+    db.insert(todoCompletions).values(todoCompletionInserts).run();
+  }
+
+  return {
+    categories: data.categories.length,
+    routines: routineCount,
+    todos: todoCount,
+    routineCompletions: routineCompletionInserts.length,
+    todoCompletions: todoCompletionInserts.length,
+  };
+}


### PR DESCRIPTION
## 이슈
Closes #170

## 변경 사항
- `src/data/sample/{ko,en,zh,ja}.json` — 언어별 샘플 데이터 JSON 파일 추가 (카테고리, 할 일, 루틴, 완료 기록 포함)
- `src/utils/sampleDataLoader.ts` — JSON 데이터를 DB에 적재하는 `applySampleData(locale)` 유틸 함수 구현 (기존 데이터 초기화 후 재적재)
- `src/screens/SettingsScreen.tsx` — 개발자 옵션에 언어 선택(ko/en/zh/ja) 및 샘플 데이터 적용 버튼 추가, 확인 다이얼로그 포함
- `scripts/build-ios.sh` — `--local` 플래그 제거 및 ipa 파일 탐색 로직 정리
- `scripts/upload-ios.sh` — 로컬 ipa 경로 탐색 대신 `--latest` 플래그로 업로드 방식 변경

## 테스트
- [ ] 개발 환경에서 설정 화면 → 개발자 옵션에 샘플 데이터 섹션 노출 확인
- [ ] ko/en/zh/ja 각 언어 선택 후 적용 시 데이터 정상 로드 확인
- [ ] 적용 전 확인 다이얼로그 동작 확인 (취소/적용)
- [ ] 기존 데이터가 초기화되고 샘플 데이터로 교체되는지 확인
- [ ] 할 일, 루틴, 완료 기록 화면에 샘플 데이터 반영 확인