### PR TITLE
#172 하루 시작 시각 도래 시 체크된 할 일이 자동 완료 처리되지 않는 버그 수정

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,6 +1,6 @@
 import { openDatabaseSync } from 'expo-sqlite';
 import { drizzle } from 'drizzle-orm/expo-sqlite';
-import { eq } from 'drizzle-orm';
+import { and, eq, lt } from 'drizzle-orm';
 import dayjs from 'dayjs';
 import * as schema from './schema';
 
@@ -145,6 +145,25 @@ export function computeEffectiveToday(): string {
   return now.isBefore(todayAtStart)
     ? now.subtract(1, 'day').format('YYYY-MM-DD')
     : now.format('YYYY-MM-DD');
+}
+
+/** beforeDate(YYYY-MM-DD) 이전에 체크된 할 일을 isCompleted=1로 자동 완료 처리 */
+export function autoCompleteCheckedTodosBeforeDate(beforeDate: string): void {
+  const records = db.select().from(schema.todoCompletions)
+    .where(lt(schema.todoCompletions.completedDate, beforeDate))
+    .all();
+  if (records.length === 0) return;
+  const now = Date.now();
+  for (const c of records) {
+    db.update(schema.todos)
+      .set({ isCompleted: 1, completedAt: now, updatedAt: now })
+      .where(and(
+        eq(schema.todos.id, c.todoId),
+        eq(schema.todos.isCompleted, 0),
+        eq(schema.todos.isDeleted, 0),
+      ))
+      .run();
+  }
 }
 
 export function setDayStartMinutes(minutes: number): void {

--- a/src/hooks/useDayStartTimer.ts
+++ b/src/hooks/useDayStartTimer.ts
@@ -1,13 +1,19 @@
 import { useEffect, useRef } from 'react';
 import dayjs from 'dayjs';
 import { useQueryClient } from '@tanstack/react-query';
-import { computeEffectiveToday } from '../db';
+import { computeEffectiveToday, autoCompleteCheckedTodosBeforeDate } from '../db';
 import { useDayStartStore } from '../stores/dayStartStore';
 
 export function useDayStartTimer(dayStartMinutes: number) {
   const queryClient = useQueryClient();
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const scheduleRef = useRef<() => void>(() => {});
+
+  // 앱 시작 시: 이전 날 미처리 체크 항목 자동 완료
+  useEffect(() => {
+    const effectiveToday = useDayStartStore.getState().effectiveToday;
+    autoCompleteCheckedTodosBeforeDate(effectiveToday);
+  }, []);
 
   useEffect(() => {
     scheduleRef.current = () => {
@@ -27,11 +33,14 @@ export function useDayStartTimer(dayStartMinutes: number) {
 
       timerRef.current = setTimeout(() => {
         const newEffective = computeEffectiveToday();
+        // 하루 전환 시: 직전 날 체크된 할 일 자동 완료
+        autoCompleteCheckedTodosBeforeDate(newEffective);
         const current = useDayStartStore.getState().effectiveToday;
         if (newEffective > current) {
           useDayStartStore.getState().setEffectiveToday(newEffective);
         }
         queryClient.invalidateQueries({ queryKey: ['todos'] });
+        queryClient.invalidateQueries({ queryKey: ['todayCompletionIds'] });
         queryClient.invalidateQueries({ queryKey: ['completions'], exact: false });
         scheduleRef.current();
       }, delay);


### PR DESCRIPTION
## 이슈
Closes #172

## 변경 사항
- `src/db/index.ts`에 `autoCompleteCheckedTodosBeforeDate(beforeDate)` 함수 추가 — `todo_completions`에서 `beforeDate` 이전 날짜에 체크된 항목을 조회해 `isCompleted=1`로 업데이트 (미완료·미삭제 항목만)
- `src/hooks/useDayStartTimer.ts` 마운트 시 실행 — 앱 시작/재실행 시 이전 날 미처리 체크 항목 자동 완료
- `src/hooks/useDayStartTimer.ts` 타이머 콜백 — 하루 시작 시각 도래 시 직전 날 체크 항목 자동 완료 + `todayCompletionIds` 쿼리 무효화 추가

## 테스트
- [ ] 오늘 탭에서 할 일 체크 후 하루 시작 시각까지 대기 → 기록 탭 잔디에 자동 반영 확인
- [ ] 체크 상태에서 앱 종료 후 재실행 → 할 일이 완료 처리되어 있는지 확인
- [ ] 기존 수동 "정리" 버튼이 여전히 정상 동작하는지 확인
- [ ] 이미 `isCompleted=1`인 항목에 중복 처리가 일어나지 않는지 확인