### PR TITLE
#176 FAB.Group 펼침 버튼 아이콘을 의미에 맞게 변경

### DIFF
--- a/src/components/TodoTabList.tsx
+++ b/src/components/TodoTabList.tsx
@@ -150,7 +150,7 @@ export default function TodoTabList() {
       <FAB.Group
         open={fabOpen}
         visible={isFocused}
-        icon={fabOpen ? 'close' : 'plus'}
+        icon={fabOpen ? 'close' : 'dots-vertical'}
         fabStyle={styles.fab}
         actions={[
           ...(completedIds.size > 0 ? [{ icon: 'broom', label: t('todo.menu_clear'), onPress: () => { cleanup(); setFabOpen(false); }, size: 'small' as const }] : []),

--- a/src/components/TodoTabRoutine.tsx
+++ b/src/components/TodoTabRoutine.tsx
@@ -69,7 +69,7 @@ export default function TodoTabRoutine() {
       <FAB.Group
         open={fabOpen}
         visible={isFocused}
-        icon={fabOpen ? 'close' : 'plus'}
+        icon={fabOpen ? 'close' : 'dots-vertical'}
         fabStyle={styles.fab}
         actions={[
           ...(hasCompleted && !cleanedUp ? [{ icon: 'broom', label: t('todo.menu_clear'), onPress: () => { setCleanedUp(true); setFabOpen(false); }, size: 'small' as const }] : []),


### PR DESCRIPTION
## 이슈
Closes #176

## 변경 사항
- `TodoTabList.tsx` — `FAB.Group` 닫힘 상태 아이콘 `'plus'` → `'dots-vertical'`
- `TodoTabRoutine.tsx` — 동일하게 `'plus'` → `'dots-vertical'`
- 이제 할 일·루틴·미완료 세 탭 모두 `dots-vertical`(닫힘) / `close`(열림)으로 통일

## 테스트
- [ ] 할 일 탭 FAB 버튼이 `dots-vertical` 아이콘으로 표시되는지 확인
- [ ] 루틴 탭 FAB 버튼이 `dots-vertical` 아이콘으로 표시되는지 확인
- [ ] FAB 펼쳤을 때 `close` 아이콘으로 전환되는지 확인
- [ ] 카테고리·루틴 관리 화면의 단순 FAB `plus` 아이콘은 변경 없이 유지되는지 확인