### PR TITLE
#178 기록 화면 셀 색상 투명도 상향 조정으로 완료 가시성 개선

### DIFF
--- a/src/components/ContributionGrid.tsx
+++ b/src/components/ContributionGrid.tsx
@@ -19,8 +19,8 @@ const TODAY_STR = (() => {
   return `${d.getFullYear()}-${mm}-${dd}`;
 })();
 
-// 완료 수 → 색상 (0=빈셀, 1=20%, 2=40%, 3=65%, 4+=85%)
-const OPACITY_HEX = ['', '33', '66', 'A6', 'D9'];
+// 완료 수 → 색상 (0=빈셀, 1=40%, 2=60%, 3=80%, 4+=95%)
+const OPACITY_HEX = ['', '66', '99', 'CC', 'F2'];
 
 function getCellColor(count: number, baseColor: string): string {
   if (count === 0) return Colors.surface;


### PR DESCRIPTION
## 이슈
Closes #178

## 변경 사항
- `ContributionGrid.tsx` — `OPACITY_HEX` 값 상향 조정

| 완료 수 | 변경 전 | 변경 후 |
|--------|--------|--------|
| 1 | `33` (20%) | `66` (40%) |
| 2 | `66` (40%) | `99` (60%) |
| 3 | `A6` (65%) | `CC` (80%) |
| 4+ | `D9` (85%) | `F2` (95%) |

## 테스트
- [ ] 기록 탭에서 완료 1건인 날짜 셀이 이전보다 명확히 보이는지 확인
- [ ] 완료 수가 많을수록 자연스럽게 진해지는 그라데이션 유지 확인
- [ ] 다크 배경에서 각 단계별 색상 시각 확인