### PR TITLE
#180 기록 화면 전체 잔디 및 완료 목록에 카테고리 컬러칩 추가

### DIFF
--- a/src/components/ContributionGrid.tsx
+++ b/src/components/ContributionGrid.tsx
@@ -1,11 +1,13 @@
-import { View, StyleSheet } from 'react-native';
+import { View, StyleSheet, TouchableOpacity } from 'react-native';
 import { Colors } from '../theme';
 import { useCompletionsByCategory } from '../hooks/useCompletions';
 
 type Props = {
-  categoryId: number;
-  color: string;
+  categoryId?: number;
+  color?: string;
   year: number;
+  cellColorMap?: Record<string, string>;
+  onPress?: () => void;
 };
 
 const CELL_GAP = 2;
@@ -19,8 +21,8 @@ const TODAY_STR = (() => {
   return `${d.getFullYear()}-${mm}-${dd}`;
 })();
 
-// 완료 수 → 색상 (0=빈셀, 1=40%, 2=60%, 3=80%, 4+=95%)
-const OPACITY_HEX = ['', '66', '99', 'CC', 'F2'];
+// 완료 수 → 색상 (0=빈셀, 1=30%, 2=55%, 3=75%, 4+=100%)
+const OPACITY_HEX = ['', '4D', '8C', 'BF', 'FF'];
 
 function getCellColor(count: number, baseColor: string): string {
   if (count === 0) return Colors.surface;
@@ -59,13 +61,13 @@ function groupByWeek(dates: { date: string; isFuture: boolean }[], year: number)
   return weeks;
 }
 
-export default function ContributionGrid({ categoryId, color, year }: Props) {
-  const { data: completionMap = {} } = useCompletionsByCategory(categoryId, year);
+export default function ContributionGrid({ categoryId, color = '', year, cellColorMap, onPress }: Props) {
+  const { data: completionMap = {} } = useCompletionsByCategory(categoryId ?? 0, year);
 
   const dates = buildGrid(year);
   const weeks = groupByWeek(dates, year);
 
-  return (
+  const grid = (
     <View style={styles.grid}>
       {weeks.map((week, wi) => (
         <View key={wi} style={[styles.column, { gap: CELL_GAP }]}>
@@ -73,9 +75,13 @@ export default function ContributionGrid({ categoryId, color, year }: Props) {
             const isToday = cell?.date === TODAY_STR;
             let cellColor = 'transparent';
             if (cell) {
-              cellColor = cell.isFuture
-                ? Colors.surface
-                : getCellColor(completionMap[cell.date] ?? 0, color);
+              if (cell.isFuture) {
+                cellColor = Colors.surface;
+              } else if (cellColorMap) {
+                cellColor = cellColorMap[cell.date] ?? Colors.surface;
+              } else {
+                cellColor = getCellColor(completionMap[cell.date] ?? 0, color);
+              }
             }
             return (
               <View
@@ -92,6 +98,11 @@ export default function ContributionGrid({ categoryId, color, year }: Props) {
       ))}
     </View>
   );
+
+  if (onPress) {
+    return <TouchableOpacity onPress={onPress} activeOpacity={0.7}>{grid}</TouchableOpacity>;
+  }
+  return grid;
 }
 
 const styles = StyleSheet.create({

--- a/src/hooks/useCompletions.ts
+++ b/src/hooks/useCompletions.ts
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { eq, and, gte, lte, sql, desc } from 'drizzle-orm';
 import { db } from '../db';
-import { todoCompletions, todos, routineCompletions, routines } from '../db/schema';
+import { todoCompletions, todos, routineCompletions, routines, categories } from '../db/schema';
 
 export type RoutineCompletionRecord = {
   completionId: number;
@@ -105,4 +105,102 @@ export const useRoutineCompletionsByCategory = (categoryId: number) =>
       .where(eq(routines.categoryId, categoryId))
       .orderBy(desc(routineCompletions.completedDate))
       .all(),
+  });
+
+export type AllRoutineCompletionRecord = RoutineCompletionRecord & {
+  categoryId: number;
+  categoryName: string;
+  categoryColor: string;
+};
+
+export const useAllRoutineCompletions = () =>
+  useQuery({
+    queryKey: ['completions', 'routine', 'all'],
+    queryFn: (): AllRoutineCompletionRecord[] =>
+      db.select({
+        completionId: routineCompletions.id,
+        routineId: routineCompletions.routineId,
+        title: routines.title,
+        urgency: routines.urgency,
+        importance: routines.importance,
+        completedDate: routineCompletions.completedDate,
+        categoryId: routines.categoryId,
+        categoryName: categories.name,
+        categoryColor: categories.color,
+      })
+      .from(routineCompletions)
+      .innerJoin(routines, eq(routineCompletions.routineId, routines.id))
+      .innerJoin(categories, eq(routines.categoryId, categories.id))
+      .orderBy(desc(routineCompletions.completedDate))
+      .all(),
+  });
+
+// 전체 잔디 전용: 0=빈셀, 1~7=10%~100% 균등 7단계
+const ALL_OPACITY_HEX = ['', '1A', '40', '66', '8C', 'B3', 'D9', 'FF'];
+
+// 전체 카테고리 날짜별 지배 카테고리 색상 맵 (전체 잔디용)
+// { 'YYYY-MM-DD': '#RRGGBBAA', ... }
+export const useAllCompletionsByYear = (year: number) =>
+  useQuery({
+    queryKey: ['completions', 'all', year],
+    queryFn: () => {
+      const startDate = `${year}-01-01`;
+      const endDate = `${year}-12-31`;
+
+      const todoRows = db
+        .select({
+          completedDate: todoCompletions.completedDate,
+          categoryId: todos.categoryId,
+          categoryColor: categories.color,
+          count: sql<number>`count(*)`,
+        })
+        .from(todoCompletions)
+        .innerJoin(todos, eq(todoCompletions.todoId, todos.id))
+        .innerJoin(categories, eq(todos.categoryId, categories.id))
+        .where(and(
+          gte(todoCompletions.completedDate, startDate),
+          lte(todoCompletions.completedDate, endDate),
+        ))
+        .groupBy(todoCompletions.completedDate, todos.categoryId)
+        .all();
+
+      const routineRows = db
+        .select({
+          completedDate: routineCompletions.completedDate,
+          categoryId: routines.categoryId,
+          categoryColor: categories.color,
+          count: sql<number>`count(*)`,
+        })
+        .from(routineCompletions)
+        .innerJoin(routines, eq(routineCompletions.routineId, routines.id))
+        .innerJoin(categories, eq(routines.categoryId, categories.id))
+        .where(and(
+          gte(routineCompletions.completedDate, startDate),
+          lte(routineCompletions.completedDate, endDate),
+        ))
+        .groupBy(routineCompletions.completedDate, routines.categoryId)
+        .all();
+
+      const dateMap: Record<string, Record<number, { color: string; count: number }>> = {};
+
+      for (const row of [...todoRows, ...routineRows]) {
+        if (!dateMap[row.completedDate]) dateMap[row.completedDate] = {};
+        const entry = dateMap[row.completedDate][row.categoryId];
+        if (entry) entry.count += row.count;
+        else dateMap[row.completedDate][row.categoryId] = { color: row.categoryColor, count: row.count };
+      }
+
+      const result: Record<string, string> = {};
+      for (const [date, cats] of Object.entries(dateMap)) {
+        let maxCount = 0;
+        let dominantColor = '';
+        let totalCount = 0;
+        for (const { color, count } of Object.values(cats)) {
+          totalCount += count;
+          if (count > maxCount) { maxCount = count; dominantColor = color; }
+        }
+        result[date] = dominantColor + ALL_OPACITY_HEX[Math.min(totalCount, 7)];
+      }
+      return result;
+    },
   });

--- a/src/hooks/useTodos.ts
+++ b/src/hooks/useTodos.ts
@@ -82,6 +82,22 @@ export const useTodosCompleted = () =>
 
 const PAGE_SIZE = 30;
 
+/** 기록 화면: 전체 완료 항목, 최신순 무한 스크롤 */
+export const useAllTodosCompleted = () =>
+  useInfiniteQuery({
+    queryKey: ['todos', 'completed', 'all'],
+    queryFn: ({ pageParam }: { pageParam: number }) =>
+      db.select().from(todos)
+        .where(and(eq(todos.isCompleted, 1), eq(todos.isDeleted, 0)))
+        .orderBy(desc(todos.completedAt))
+        .limit(PAGE_SIZE)
+        .offset(pageParam * PAGE_SIZE)
+        .all(),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage, allPages) =>
+      lastPage.length < PAGE_SIZE ? undefined : allPages.length,
+  });
+
 /** 기록 화면: 카테고리별 완료 항목, 최신순 무한 스크롤 */
 export const useTodosCompletedByCategory = (categoryId: number) =>
   useInfiniteQuery({

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -188,6 +188,7 @@ const en: TranslationKeys = {
     menu_category: 'Categories',
     menu_routine: 'Routines',
     empty_completed: 'No completed tasks',
+    all_title: 'All',
   },
 };
 

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -188,6 +188,7 @@ const ja: TranslationKeys = {
     menu_category: 'カテゴリ管理',
     menu_routine: 'ルーティン管理',
     empty_completed: '完了したタスクがありません',
+    all_title: 'すべて',
   },
 };
 

--- a/src/i18n/locales/ko.ts
+++ b/src/i18n/locales/ko.ts
@@ -186,6 +186,7 @@ const ko = {
     menu_category: '카테고리 관리',
     menu_routine: '루틴 관리',
     empty_completed: '완료된 항목이 없어요',
+    all_title: '전체',
   },
 };
 

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -188,6 +188,7 @@ const zh: TranslationKeys = {
     menu_category: '分类管理',
     menu_routine: '习惯管理',
     empty_completed: '没有已完成的任务',
+    all_title: '全部',
   },
 };
 

--- a/src/navigation/RecordStack.tsx
+++ b/src/navigation/RecordStack.tsx
@@ -1,6 +1,7 @@
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import RecordScreen from '../screens/RecordScreen';
 import CategoryCompletedScreen from '../screens/CategoryCompletedScreen';
+import AllCompletedScreen from '../screens/AllCompletedScreen';
 
 export type RecordStackParamList = {
   RecordHome: undefined;
@@ -9,6 +10,7 @@ export type RecordStackParamList = {
     categoryName: string;
     categoryColor: string;
   };
+  AllCompleted: undefined;
 };
 
 const Stack = createNativeStackNavigator<RecordStackParamList>();
@@ -18,6 +20,7 @@ export default function RecordStack() {
     <Stack.Navigator screenOptions={{ headerShown: false, animation: 'slide_from_right' }}>
       <Stack.Screen name="RecordHome" component={RecordScreen} />
       <Stack.Screen name="CategoryCompleted" component={CategoryCompletedScreen} />
+      <Stack.Screen name="AllCompleted" component={AllCompletedScreen} />
     </Stack.Navigator>
   );
 }

--- a/src/screens/AllCompletedScreen.tsx
+++ b/src/screens/AllCompletedScreen.tsx
@@ -1,28 +1,28 @@
 import { View, FlatList, ActivityIndicator, StyleSheet } from 'react-native';
 import { Appbar, Text, Divider } from 'react-native-paper';
-import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
+import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useMemo } from 'react';
 import dayjs from 'dayjs';
 import { useTranslation } from 'react-i18next';
 import { Colors } from '../theme';
-import { useTodosCompletedByCategory } from '../hooks/useTodos';
-import { useRoutineCompletionsByCategory, RoutineCompletionRecord } from '../hooks/useCompletions';
+import { useAllTodosCompleted } from '../hooks/useTodos';
+import { useAllRoutineCompletions, AllRoutineCompletionRecord } from '../hooks/useCompletions';
+import { useCategories } from '../hooks/useCategories';
 import TodoItem from '../components/TodoItem';
 import TodoItemMeta from '../components/TodoItem/TodoItemMeta';
 import { toDateKey, formatDateLabel } from '../utils/date';
 import { RecordStackParamList } from '../navigation/RecordStack';
 import { Todo } from '../types';
 
-type Nav = NativeStackNavigationProp<RecordStackParamList, 'CategoryCompleted'>;
-type Route = RouteProp<RecordStackParamList, 'CategoryCompleted'>;
+type Nav = NativeStackNavigationProp<RecordStackParamList, 'AllCompleted'>;
 
 type ListItem =
   | { type: 'header'; label: string; key: string }
   | { type: 'todo'; key: string; todo: Todo }
-  | { type: 'routine'; key: string; record: RoutineCompletionRecord };
+  | { type: 'routine'; key: string; record: AllRoutineCompletionRecord };
 
-function buildMergedList(todos: Todo[], routineRecords: RoutineCompletionRecord[]): ListItem[] {
+function buildMergedList(todos: Todo[], routineRecords: AllRoutineCompletionRecord[]): ListItem[] {
   type Entry = { dateKey: string; sortTs: number; item: ListItem };
   const entries: Entry[] = [];
 
@@ -45,9 +45,7 @@ function buildMergedList(todos: Todo[], routineRecords: RoutineCompletionRecord[
     if (entry.dateKey !== lastKey) {
       const ts = entry.item.type === 'todo'
         ? (entry.item.todo.completedAt ?? 0)
-        : entry.item.type === 'routine'
-          ? dayjs(entry.item.record.completedDate).valueOf()
-          : 0;
+        : dayjs((entry.item as { record: AllRoutineCompletionRecord }).record.completedDate).valueOf();
       result.push({ type: 'header', label: formatDateLabel(ts), key: entry.dateKey });
       lastKey = entry.dateKey;
     }
@@ -56,8 +54,9 @@ function buildMergedList(todos: Todo[], routineRecords: RoutineCompletionRecord[
   return result;
 }
 
-function RoutineCompletionItem({ record, category }: { record: RoutineCompletionRecord; category?: { id: number; name: string; color: string } }) {
+function RoutineItem({ record }: { record: AllRoutineCompletionRecord }) {
   const { t } = useTranslation();
+  const category = { id: record.categoryId, name: record.categoryName, color: record.categoryColor };
   return (
     <View style={styles.routineRow}>
       <View style={styles.routineContent}>
@@ -73,15 +72,18 @@ function RoutineCompletionItem({ record, category }: { record: RoutineCompletion
   );
 }
 
-export default function CategoryCompletedScreen() {
+export default function AllCompletedScreen() {
   const navigation = useNavigation<Nav>();
-  const route = useRoute<Route>();
   const { t } = useTranslation();
-  const { categoryId, categoryName, categoryColor } = route.params;
 
-  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
-    useTodosCompletedByCategory(categoryId);
-  const { data: routineRecords = [] } = useRoutineCompletionsByCategory(categoryId);
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = useAllTodosCompleted();
+  const { data: routineRecords = [] } = useAllRoutineCompletions();
+  const { data: categoriesList = [] } = useCategories();
+
+  const categoryMap = useMemo(
+    () => Object.fromEntries(categoriesList.map((c) => [c.id, c])),
+    [categoriesList],
+  );
 
   const flatTodos = useMemo(
     () => (data?.pages.flat() ?? []) as Todo[],
@@ -93,8 +95,6 @@ export default function CategoryCompletedScreen() {
     [flatTodos, routineRecords],
   );
 
-  const category = { id: categoryId, name: categoryName, color: categoryColor };
-
   const renderItem = ({ item }: { item: ListItem }) => {
     if (item.type === 'header') {
       return <Text style={styles.dateHeader}>{item.label}</Text>;
@@ -102,11 +102,12 @@ export default function CategoryCompletedScreen() {
     if (item.type === 'routine') {
       return (
         <>
-          <RoutineCompletionItem record={item.record} category={category} />
+          <RoutineItem record={item.record} />
           <Divider />
         </>
       );
     }
+    const category = categoryMap[item.todo.categoryId];
     return (
       <>
         <TodoItem
@@ -126,14 +127,7 @@ export default function CategoryCompletedScreen() {
     <View style={styles.container}>
       <Appbar.Header style={styles.header}>
         <Appbar.BackAction onPress={() => navigation.goBack()} />
-        <Appbar.Content
-          title={
-            <View style={styles.titleRow}>
-              <View style={[styles.dot, { backgroundColor: categoryColor }]} />
-              <Text style={styles.titleText}>{categoryName}</Text>
-            </View>
-          }
-        />
+        <Appbar.Content title={t('record.all_title')} titleStyle={styles.titleText} />
       </Appbar.Header>
 
       <FlatList
@@ -143,9 +137,9 @@ export default function CategoryCompletedScreen() {
         onEndReached={() => { if (hasNextPage && !isFetchingNextPage) fetchNextPage(); }}
         onEndReachedThreshold={0.5}
         ListFooterComponent={
-          isFetchingNextPage ? (
-            <ActivityIndicator style={styles.footer} color={Colors.primary} />
-          ) : null
+          isFetchingNextPage
+            ? <ActivityIndicator style={styles.footer} color={Colors.primary} />
+            : null
         }
         ListEmptyComponent={
           <Text style={styles.empty}>{t('record.empty_completed')}</Text>
@@ -159,8 +153,6 @@ export default function CategoryCompletedScreen() {
 const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: Colors.background },
   header: { height: 72 },
-  titleRow: { flexDirection: 'row', alignItems: 'center', gap: 8 },
-  dot: { width: 10, height: 10, borderRadius: 5 },
   titleText: { fontWeight: '700', fontSize: 18, color: Colors.text },
   list: { flex: 1 },
   empty: { textAlign: 'center', marginTop: 60, color: Colors.textMuted },

--- a/src/screens/RecordScreen.tsx
+++ b/src/screens/RecordScreen.tsx
@@ -6,7 +6,7 @@ import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useTranslation } from 'react-i18next';
 import { Colors } from '../theme';
 import { useCategories } from '../hooks/useCategories';
-import { useEarliestCompletionYear } from '../hooks/useCompletions';
+import { useEarliestCompletionYear, useAllCompletionsByYear } from '../hooks/useCompletions';
 import ContributionGrid from '../components/ContributionGrid';
 import BannerAdView from '../components/BannerAdView';
 import { RecordStackParamList } from '../navigation/RecordStack';
@@ -22,6 +22,7 @@ export default function RecordScreen() {
   const [menuVisible, setMenuVisible] = useState(false);
   const { data: categories = [] } = useCategories();
   const { data: earliestYear = CURRENT_YEAR } = useEarliestCompletionYear();
+  const { data: allCellColorMap = {} } = useAllCompletionsByYear(year);
 
   return (
     <View style={styles.container}>
@@ -64,6 +65,28 @@ export default function RecordScreen() {
       </View>
 
       <ScrollView contentContainerStyle={styles.content}>
+        {/* 전체 섹션 */}
+        <View style={styles.section}>
+          <TouchableRipple
+            onPress={() => navigation.navigate('AllCompleted')}
+            rippleColor={Colors.surfaceVariant}
+          >
+            <View style={styles.sectionHeader}>
+              <View style={[styles.dot, { backgroundColor: Colors.textMuted }]} />
+              <Text variant="titleSmall" style={styles.categoryName}>
+                {t('record.all_title')}
+              </Text>
+              <IconButton
+                icon="chevron-right"
+                size={16}
+                iconColor={Colors.textMuted}
+                style={styles.chevron}
+              />
+            </View>
+          </TouchableRipple>
+          <ContributionGrid year={year} cellColorMap={allCellColorMap} onPress={() => navigation.navigate('AllCompleted')} />
+        </View>
+
         {categories.map((category) => (
           <View key={category.id} style={styles.section}>
             <TouchableRipple


### PR DESCRIPTION
## 이슈
Closes #180

## 변경 사항
- `useAllCompletionsByYear` 훅 추가 — 날짜별 지배 카테고리 색상 + 전체 완료 수 기반 투명도 반환
- `useAllRoutineCompletions` 훅 추가 — 카테고리 정보 포함한 전체 루틴 완료 기록
- `useAllTodosCompleted` 훅 추가 — 전체 완료 할 일 무한 스크롤
- `ContributionGrid` 확장 — `cellColorMap`, `onPress` prop 지원 (전체 잔디용)
- `RecordScreen` 상단에 "전체" 섹션 추가 (탭 시 `AllCompletedScreen` 이동)
- `AllCompletedScreen` 신규 추가 — 날짜별 그룹, 카테고리 컬러칩 포함
- `CategoryCompletedScreen` — 할 일·루틴 아이템에 카테고리 컬러칩 추가
- `RecordStack` — `AllCompleted` 화면 등록
- 잔디 투명도: 전체 7단계 10~100% 균등, 개별 4단계 최대 100%
- locale 4개 `record.all_title` 키 추가

## 테스트
- [ ] 기록 화면 상단 전체 잔디 렌더링 확인
- [ ] 전체 잔디 탭 → AllCompletedScreen 진입 확인
- [ ] AllCompletedScreen 날짜별 그룹 + 카테고리 컬러칩 노출 확인
- [ ] CategoryCompletedScreen 컬러칩 추가 확인
- [ ] 연도 변경 시 전체 잔디 업데이트 확인