### PR TITLE
#186 할 일 진행 중 상태 추가

### DIFF
--- a/src/components/TodoItem/TodoItemMeta.tsx
+++ b/src/components/TodoItem/TodoItemMeta.tsx
@@ -1,10 +1,12 @@
 import { View, StyleSheet } from 'react-native';
 import { Text } from 'react-native-paper';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
+import { useTranslation } from 'react-i18next';
 import { Colors } from '../../theme';
 
 const URGENCY_COLOR = Colors.urgency;
 const IMPORTANCE_COLOR = Colors.importance;
+const IN_PROGRESS_COLOR = Colors.inProgress;
 
 // 레벨별 아이콘 수 (1→1개, 2→2개, 3→3개)
 const URGENCY_ICON = 'lightning-bolt';
@@ -29,14 +31,22 @@ type Props = {
   dueTime?: number | null;
   urgency?: number | null;
   importance?: number | null;
+  isInProgress?: boolean;
 };
 
-export default function TodoItemMeta({ category, dueTime, urgency, importance }: Props) {
+export default function TodoItemMeta({ category, dueTime, urgency, importance, isInProgress }: Props) {
+  const { t } = useTranslation();
   const urgencyLevel = urgency ?? 0;
   const importanceLevel = importance ?? 0;
 
   return (
     <View style={styles.meta}>
+      {isInProgress && (
+        <View style={[styles.tag, { backgroundColor: IN_PROGRESS_COLOR + '28' }]}>
+          <MaterialCommunityIcons name="play-circle-outline" size={10} color={IN_PROGRESS_COLOR} />
+          <Text style={[styles.tagText, { color: IN_PROGRESS_COLOR }]}>{t('todo.status_in_progress')}</Text>
+        </View>
+      )}
       {category && (
         <View style={[styles.tag, { backgroundColor: category.color + '28' }]}>
           <View style={[styles.tagDot, { backgroundColor: category.color }]} />

--- a/src/components/TodoItem/index.tsx
+++ b/src/components/TodoItem/index.tsx
@@ -26,6 +26,7 @@ type Props = {
   todo: Todo;
   category?: Category;
   checked: boolean;
+  isInProgress?: boolean;
   onCheck: () => void;
   onPress?: () => void;        // 본문 탭 (없으면 onCheck 호출)
   onDrag?: () => void;
@@ -38,6 +39,7 @@ export default function TodoItem({
   todo,
   category,
   checked,
+  isInProgress = false,
   onCheck,
   onPress,
   onDrag,
@@ -58,8 +60,8 @@ export default function TodoItem({
       {checkboxVisible && (
         <TouchableOpacity onPress={onCheck} activeOpacity={0.6} style={styles.checkboxArea}>
           <Checkbox.Android
-            status={checked ? 'checked' : 'unchecked'}
-            color={Colors.primary}
+            status={checked ? 'checked' : isInProgress ? 'indeterminate' : 'unchecked'}
+            color={isInProgress && !checked ? Colors.inProgress : Colors.primary}
           />
         </TouchableOpacity>
       )}
@@ -92,6 +94,7 @@ export default function TodoItem({
           dueTime={todo.dueTime}
           urgency={todo.urgency}
           importance={todo.importance}
+          isInProgress={isInProgress}
         />
       </TouchableOpacity>
 

--- a/src/components/TodoTabList.tsx
+++ b/src/components/TodoTabList.tsx
@@ -5,10 +5,9 @@ import { useNavigation, useIsFocused } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useTranslation } from 'react-i18next';
 import { Colors } from '../theme';
-import { useTodosList, useTodayAllTodos, useTodayCompletionIds, useTodayToggle, useCleanupChecked } from '../hooks/useTodos';
+import { useTodosList, useTodayAllTodos, useTodayCompletionIds, useThreeStateToggle, useCleanupChecked } from '../hooks/useTodos';
 import { useCategories } from '../hooks/useCategories';
 import { useCategoryMap } from '../hooks/useCategoryMap';
-import { useCheckable } from '../hooks/useCheckable';
 import TodoItem from './TodoItem';
 import DateSeparator from './DateSeparator';
 import TodayProgressBar from './TodayProgressBar';
@@ -56,7 +55,7 @@ export default function TodoTabList() {
   const { data: allTodayTodos = [] } = useTodayAllTodos();
   const { data: completedIds = new Set<number>() } = useTodayCompletionIds();
   const { data: categories = [] } = useCategories();
-  const { mutate: todayToggle } = useTodayToggle();
+  const { mutate: threeStateToggle } = useThreeStateToggle();
   const { mutate: cleanup } = useCleanupChecked();
   const isFocused = useIsFocused();
 
@@ -65,7 +64,6 @@ export default function TodoTabList() {
   const [fabOpen, setFabOpen] = useState(false);
 
   const categoryMap = useCategoryMap(categories);
-  const getCheckable = useCheckable({ mode: 'today', completedIds, toggleFn: todayToggle });
 
   const listItems = useMemo(() => buildGroupedList(todos as Todo[], sortKey), [todos, sortKey]);
 
@@ -94,13 +92,15 @@ export default function TodoTabList() {
     if (item.type === 'header') {
       return <DateSeparator label={item.label} />;
     }
-    const { checked, onCheck } = getCheckable(item.todo);
+    const isInProgress = item.todo.isInProgress === 1;
+    const isCheckedToday = completedIds.has(item.todo.id);
     return (
       <TodoItem
         todo={item.todo}
         category={categoryMap.get(item.todo.categoryId)}
-        checked={checked}
-        onCheck={onCheck}
+        checked={isCheckedToday}
+        isInProgress={isInProgress && !isCheckedToday}
+        onCheck={() => threeStateToggle({ id: item.todo.id, isInProgress: item.todo.isInProgress, isCheckedToday })}
         onPress={() => navigation.navigate('TodoForm', { todo: item.todo })}
         showDescription
       />

--- a/src/components/TodoTabOverdue.tsx
+++ b/src/components/TodoTabOverdue.tsx
@@ -5,7 +5,7 @@ import { useNavigation, useIsFocused } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useTranslation } from 'react-i18next';
 import { Colors } from '../theme';
-import { useTodosOverdue, useBulkMoveToToday, useBulkDeleteTodos } from '../hooks/useTodos';
+import { useTodosOverdue, useBulkMoveToToday, useBulkDeleteTodos, useSetInProgress } from '../hooks/useTodos';
 import { useCategories } from '../hooks/useCategories';
 import { useCategoryMap } from '../hooks/useCategoryMap';
 import { useSelectable } from '../hooks/useSelectable';
@@ -55,6 +55,7 @@ export default function TodoTabOverdue() {
   const { data: categories = [] } = useCategories();
   const { mutate: bulkMoveToToday } = useBulkMoveToToday();
   const { mutate: bulkDelete } = useBulkDeleteTodos();
+  const { mutate: setInProgress } = useSetInProgress();
 
   const isFocused = useIsFocused();
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
@@ -77,10 +78,17 @@ export default function TodoTabOverdue() {
 
   const handleMoveToToday = () => {
     if (selectedIds.size === 0) return;
-    const count = selectedIds.size;
     bulkMoveToToday([...selectedIds]);
     clearSelection();
     setSnackbarMessage(t('todo.move_to_today_msg'));
+    setSnackbarVisible(true);
+  };
+
+  const handleMarkInProgress = () => {
+    if (selectedIds.size === 0) return;
+    setInProgress([...selectedIds]);
+    clearSelection();
+    setSnackbarMessage(t('todo.in_progress_msg'));
     setSnackbarVisible(true);
   };
 
@@ -153,6 +161,12 @@ export default function TodoTabOverdue() {
             icon: 'calendar-arrow-right',
             label: t('todo.move_to_today_label'),
             onPress: () => { handleMoveToToday(); setFabOpen(false); },
+            size: 'small' as const,
+          },
+          {
+            icon: 'play-circle-outline',
+            label: t('todo.in_progress_label'),
+            onPress: () => { handleMarkInProgress(); setFabOpen(false); },
             size: 'small' as const,
           },
           {

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -58,6 +58,8 @@ export const initDb = async () => {
     sqlite.execSync('ALTER TABLE todos ADD COLUMN due_time INTEGER;');
   if (!todoColumns.includes('notification_offsets'))
     sqlite.execSync('ALTER TABLE todos ADD COLUMN notification_offsets TEXT;');
+  if (!todoColumns.includes('is_in_progress'))
+    sqlite.execSync('ALTER TABLE todos ADD COLUMN is_in_progress INTEGER NOT NULL DEFAULT 0;');
 
   sqlite.execSync(`
     CREATE TABLE IF NOT EXISTS app_settings (
@@ -197,6 +199,7 @@ export function autoCompleteCheckedTodosBeforeDate(beforeDate: string): void {
       .where(and(
         eq(schema.todos.id, c.todoId),
         eq(schema.todos.isCompleted, 0),
+        eq(schema.todos.isInProgress, 0),
         eq(schema.todos.isDeleted, 0),
       ))
       .run();

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -23,6 +23,7 @@ export const todos = sqliteTable('todos', {
   urgency: int('urgency').default(0),
   importance: int('importance').default(0),
   sortOrder: int('sort_order').notNull().default(0),
+  isInProgress: int('is_in_progress').notNull().default(0),
   isCompleted: int('is_completed').notNull().default(0),
   completedAt: int('completed_at'),
   isDeleted: int('is_deleted').notNull().default(0),

--- a/src/hooks/useCheckable.ts
+++ b/src/hooks/useCheckable.ts
@@ -6,32 +6,34 @@ type CheckableTodayConfig = {
 
 type CheckableToggleConfig = {
   mode: 'toggle';
-  toggleFn: (args: { id: number; isCompleted: number }) => void;
+  toggleFn: (args: { id: number; isCompleted: number; isInProgress: number }) => void;
 };
 
 type CheckableConfig = CheckableTodayConfig | CheckableToggleConfig;
 
-type TodoLike = { id: number; isCompleted: number };
+type TodoLike = { id: number; isCompleted: number; isInProgress?: number };
 
 /**
  * 컴포넌트 레벨에서 호출해 per-item 팩토리 함수를 반환한다.
  * renderItem 안에서는 반환된 함수를 호출하면 됨.
  *
- * const getCheckable = useCheckable({ mode: 'today', completedIds, toggleFn: todayToggle });
+ * const getCheckable = useCheckable({ mode: 'today', completedIds, toggleFn });
  * // renderItem:
- * const { checked, onCheck } = getCheckable(item);
+ * const { checked, isInProgress, onCheck } = getCheckable(item);
  */
 export function useCheckable(config: CheckableConfig) {
   if (config.mode === 'today') {
     const { completedIds, toggleFn } = config;
     return (todo: TodoLike) => ({
       checked: completedIds.has(todo.id),
+      isInProgress: false,
       onCheck: () => toggleFn(todo.id),
     });
   }
   const { toggleFn } = config;
   return (todo: TodoLike) => ({
     checked: todo.isCompleted === 1,
-    onCheck: () => toggleFn({ id: todo.id, isCompleted: todo.isCompleted }),
+    isInProgress: todo.isInProgress === 1,
+    onCheck: () => toggleFn({ id: todo.id, isCompleted: todo.isCompleted, isInProgress: todo.isInProgress ?? 0 }),
   });
 }

--- a/src/hooks/useTodos.ts
+++ b/src/hooks/useTodos.ts
@@ -1,5 +1,5 @@
 import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { and, asc, desc, eq, gte, isNull, lt, or } from 'drizzle-orm';
+import { and, asc, desc, eq, gte, inArray, isNull, lt, or } from 'drizzle-orm';
 import dayjs from 'dayjs';
 import { db } from '../db';
 import { todos, todoCompletions } from '../db/schema';
@@ -35,7 +35,7 @@ export const useTodosToday = () => {
   });
 };
 
-/** 할 일 탭: 기한 >= 오늘 AND 미완료 (기한 없는 항목도 포함) */
+/** 할 일 탭: 기한 >= 오늘 AND 미완료 (기한 없는 항목 + 진행 중 항목도 포함) */
 export const useTodosList = () => {
   const todayStart = dayjs().startOf('day').valueOf();
   return useQuery({
@@ -45,14 +45,14 @@ export const useTodosList = () => {
         .where(and(
           eq(todos.isCompleted, 0),
           eq(todos.isDeleted, 0),
-          or(isNull(todos.dueDate), gte(todos.dueDate, todayStart)),
+          or(isNull(todos.dueDate), gte(todos.dueDate, todayStart), eq(todos.isInProgress, 1)),
         ))
         .orderBy(asc(todos.sortOrder))
         .all(),
   });
 };
 
-/** 미완료 탭: 기한 < 오늘 AND 미완료 */
+/** 미완료 탭: 기한 < 오늘 AND 미완료 AND 진행 중 아님 */
 export const useTodosOverdue = () => {
   const todayStart = dayjs().startOf('day').valueOf();
   return useQuery({
@@ -61,6 +61,7 @@ export const useTodosOverdue = () => {
       db.select().from(todos)
         .where(and(
           eq(todos.isCompleted, 0),
+          eq(todos.isInProgress, 0),
           eq(todos.isDeleted, 0),
           lt(todos.dueDate, todayStart),
         ))
@@ -261,6 +262,7 @@ export const useUpdateTodo = () => {
       notificationOffsets,
       urgency,
       importance,
+      isInProgress,
     }: {
       id: number;
       categoryId: number;
@@ -271,6 +273,7 @@ export const useUpdateTodo = () => {
       notificationOffsets?: number[];
       urgency?: number;
       importance?: number;
+      isInProgress?: number;
     }) => {
       const offsets = notificationOffsets ?? [];
       await db.update(todos).set({
@@ -282,6 +285,7 @@ export const useUpdateTodo = () => {
         notificationOffsets: offsets.length > 0 ? offsetsToString(offsets) : null,
         urgency: urgency ?? 0,
         importance: importance ?? 0,
+        ...(isInProgress !== undefined ? { isInProgress } : {}),
         updatedAt: Date.now(),
       }).where(eq(todos.id, id)).run();
       await cancelTodoNotifications(id);
@@ -293,25 +297,24 @@ export const useUpdateTodo = () => {
   });
 };
 
+/** 3단계 상태 토글: 미완료 → 진행 중 → 완료 → 미완료 */
 export const useToggleTodo = () => {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async ({ id, isCompleted }: { id: number; isCompleted: number }) => {
-      const newCompleted = isCompleted === 1 ? 0 : 1;
+    mutationFn: async ({ id, isCompleted, isInProgress }: { id: number; isCompleted: number; isInProgress: number }) => {
       const now = Date.now();
-      await db.update(todos).set({
-        isCompleted: newCompleted,
-        completedAt: newCompleted === 1 ? now : null,
-        updatedAt: now,
-      }).where(eq(todos.id, id)).run();
-      if (newCompleted === 1) {
+      const today = useDayStartStore.getState().effectiveToday;
+      if (isCompleted === 0 && isInProgress === 0) {
+        // 미완료 → 진행 중
+        await db.update(todos).set({ isInProgress: 1, updatedAt: now }).where(eq(todos.id, id)).run();
+      } else if (isInProgress === 1) {
+        // 진행 중 → 완료
+        await db.update(todos).set({ isInProgress: 0, isCompleted: 1, completedAt: now, updatedAt: now }).where(eq(todos.id, id)).run();
         cancelTodoNotifications(id).catch(() => {});
-      }
-
-      const today = new Date().toISOString().split('T')[0];
-      if (newCompleted === 1) {
         await db.insert(todoCompletions).values({ todoId: id, completedDate: today }).run();
       } else {
+        // 완료 → 미완료 (완료 취소)
+        await db.update(todos).set({ isCompleted: 0, completedAt: null, updatedAt: now }).where(eq(todos.id, id)).run();
         await db.delete(todoCompletions)
           .where(and(eq(todoCompletions.todoId, id), eq(todoCompletions.completedDate, today)))
           .run();
@@ -362,6 +365,60 @@ export const useReorderTodos = () => {
       for (let i = 0; i < orderedIds.length; i++) {
         await db.update(todos).set({ sortOrder: i }).where(eq(todos.id, orderedIds[i])).run();
       }
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['todos'] }),
+  });
+};
+
+/** 할 일 탭 3단계 토글: 미완료 → 진행 중 → 오늘 체크 → 미완료 (항목은 목록에 유지) */
+export const useThreeStateToggle = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ id, isInProgress, isCheckedToday }: { id: number; isInProgress: number; isCheckedToday: boolean }) => {
+      const now = Date.now();
+      const today = useDayStartStore.getState().effectiveToday;
+      if (isInProgress === 0 && !isCheckedToday) {
+        // 미완료 → 진행 중
+        await db.update(todos).set({ isInProgress: 1, updatedAt: now }).where(eq(todos.id, id)).run();
+      } else if (isInProgress === 1) {
+        // 진행 중 → 오늘 체크 (todoCompletions 기록, isInProgress 해제)
+        await db.update(todos).set({ isInProgress: 0, updatedAt: now }).where(eq(todos.id, id)).run();
+        const existing = db.select().from(todoCompletions)
+          .where(and(eq(todoCompletions.todoId, id), eq(todoCompletions.completedDate, today))).get();
+        if (!existing) {
+          await db.insert(todoCompletions).values({ todoId: id, completedDate: today }).run();
+        }
+      } else {
+        // 오늘 체크 → 미완료 (todoCompletions 제거)
+        await db.delete(todoCompletions)
+          .where(and(eq(todoCompletions.todoId, id), eq(todoCompletions.completedDate, today)))
+          .run();
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['todos'] });
+      queryClient.invalidateQueries({ queryKey: ['todayCompletionIds'] });
+      queryClient.invalidateQueries({ queryKey: ['completions'], exact: false });
+    },
+  });
+};
+
+export const useSetInProgress = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (ids: number[]) => {
+      await db.update(todos).set({ isInProgress: 1, updatedAt: Date.now() })
+        .where(inArray(todos.id, ids)).run();
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['todos'] }),
+  });
+};
+
+export const useClearInProgress = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (id: number) => {
+      await db.update(todos).set({ isInProgress: 0, updatedAt: Date.now() }).where(eq(todos.id, id)).run();
     },
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['todos'] }),
   });

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -56,6 +56,10 @@ const en: TranslationKeys = {
     search_section_todo: 'Tasks',
     search_section_routine: 'Routines',
     search_uncategorized: 'Uncategorized',
+    status_in_progress: 'In Progress',
+    in_progress_label: 'Mark as In Progress',
+    in_progress_msg: 'Moved to Tasks tab',
+    in_progress_clear: 'Clear In Progress',
   },
   notif: {
     on_time: 'On time',

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -56,6 +56,10 @@ const ja: TranslationKeys = {
     search_section_todo: 'タスク',
     search_section_routine: 'ルーティン',
     search_uncategorized: '未分類',
+    status_in_progress: '進行中',
+    in_progress_label: '進行中にする',
+    in_progress_msg: 'タスクタブに移動しました',
+    in_progress_clear: '進行中を解除',
   },
   notif: {
     on_time: '時間通り',

--- a/src/i18n/locales/ko.ts
+++ b/src/i18n/locales/ko.ts
@@ -54,6 +54,10 @@ const ko = {
     search_section_todo: '할 일',
     search_section_routine: '루틴',
     search_uncategorized: '미분류',
+    status_in_progress: '진행 중',
+    in_progress_label: '진행 중으로 표시',
+    in_progress_msg: '할 일 탭으로 이동했어요',
+    in_progress_clear: '진행 중 해제',
   },
   notif: {
     on_time: '정시',

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -56,6 +56,10 @@ const zh: TranslationKeys = {
     search_section_todo: '任务',
     search_section_routine: '习惯',
     search_uncategorized: '未分类',
+    status_in_progress: '进行中',
+    in_progress_label: '标为进行中',
+    in_progress_msg: '已移至任务标签',
+    in_progress_clear: '取消进行中',
   },
   notif: {
     on_time: '准时',

--- a/src/navigation/TodoStack.tsx
+++ b/src/navigation/TodoStack.tsx
@@ -16,6 +16,7 @@ export type TodoStackParamList = {
       importance?: number | null;
       categoryId: number;
       isCompleted: number;
+      isInProgress?: number;
       notificationOffsets?: string | null;
     };
   } | undefined;

--- a/src/screens/TodoFormScreen.tsx
+++ b/src/screens/TodoFormScreen.tsx
@@ -7,7 +7,7 @@ import DateTimePicker from '@react-native-community/datetimepicker';
 import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useCategories } from '../hooks/useCategories';
-import { useCreateTodo, useUpdateTodo, useDeleteTodo } from '../hooks/useTodos';
+import { useCreateTodo, useUpdateTodo, useDeleteTodo, useClearInProgress } from '../hooks/useTodos';
 import { TodoStackParamList } from '../navigation/TodoStack';
 import { getLevelOptions } from '../constants/todo';
 import { getOffsetOptions, offsetsFromString, offsetLabel } from '../utils/notifications';
@@ -38,6 +38,7 @@ export default function TodoFormScreen() {
   const { mutate: createTodo } = useCreateTodo();
   const { mutate: updateTodo } = useUpdateTodo();
   const { mutate: deleteTodo } = useDeleteTodo();
+  const { mutate: clearInProgress } = useClearInProgress();
 
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
@@ -290,6 +291,19 @@ export default function TodoFormScreen() {
           style={styles.segment}
         />
 
+        {isEdit && todo?.isInProgress === 1 && (
+          <Button
+            mode="outlined"
+            icon="stop-circle-outline"
+            onPress={() => { clearInProgress(todo.id); navigation.goBack(); }}
+            style={styles.inProgressButton}
+            labelStyle={styles.actionButtonLabel}
+            textColor={Colors.inProgress}
+          >
+            {t('todo.in_progress_clear')}
+          </Button>
+        )}
+
         {isEdit && (
           <Button
             mode="outlined"
@@ -361,6 +375,7 @@ const styles = StyleSheet.create({
   input: { marginBottom: 16 },
   descriptionInput: { minHeight: 120 },
   label: { marginBottom: 8, marginTop: 4 },
+  inProgressButton: { marginTop: 8 },
   deleteButton: { marginTop: 8 },
   saveButton: { marginRight: 8, alignSelf: 'center' },
   actionButtonLabel: { fontSize: 14 },

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -51,4 +51,5 @@ export const Colors = {
   primary: '#A78BFA',
   urgency: '#FF6B6B',
   importance: '#4ECDC4',
+  inProgress: '#FBBF24',
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -14,6 +14,7 @@ export interface Todo {
   dueTime: number | null; // minutes from midnight (0-1439), null = no time set
   urgency: number | null;
   importance: number | null;
+  isInProgress: number; // 0 | 1 (SQLite boolean)
   isCompleted: number; // 0 | 1 (SQLite boolean)
   completedAt: number | null;
   sortOrder: number;


### PR DESCRIPTION
## 이슈
Closes #186

## 변경 사항
- `is_in_progress` 컬럼 추가 (DB 스키마 + 마이그레이션)
- 할 일 탭 체크박스 3단계 토글: 미완료 → 진행 중 → 오늘 체크 → 미완료
- 진행 중 항목은 기한 초과 시에도 미완료 탭으로 이동하지 않고 할 일 탭에 유지
- 진행 중 항목은 하루 시작 타이머 자동 완료에서 제외
- 미완료 탭에 "진행 중으로 표시" FAB 액션 추가 (선택 항목 일괄 처리)
- 할 일 상세 화면에 "진행 중 해제" 버튼 추가
- 진행 중 상태 앰버색 시각 표시 (체크박스 indeterminate + 메타 뱃지)
- 4개 언어 i18n 추가 (ko/en/ja/zh)

## 테스트
- [ ] 할 일 탭 체크박스 클릭 시 미완료 → 진행 중 → 오늘 체크 → 미완료 순환 확인
- [ ] 진행 중 항목이 기한 초과 후에도 할 일 탭에 유지되는지 확인
- [ ] 진행 중 항목이 미완료 탭에 표시되지 않는지 확인
- [ ] 하루 시작 타이머 실행 시 진행 중 항목이 자동 완료되지 않는지 확인
- [ ] 미완료 탭에서 항목 선택 후 FAB → "진행 중으로 표시" 동작 확인
- [ ] 할 일 상세 화면에서 "진행 중 해제" 버튼 동작 확인
- [ ] 기존 사용자 DB 마이그레이션 정상 동작 확인