### PR TITLE
#193 광고 영역 수정

### DIFF
--- a/src/screens/GoalScreen.tsx
+++ b/src/screens/GoalScreen.tsx
@@ -13,6 +13,7 @@ import { useCategories } from '../hooks/useCategories';
 import { GoalStackParamList } from '../navigation/GoalStack';
 import { Goal, Category } from '../types';
 import PageHelpModal from '../components/PageHelpModal';
+import BannerAdView from '../components/BannerAdView';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 
 type Nav = NativeStackNavigationProp<GoalStackParamList, 'GoalList'>;
@@ -200,6 +201,7 @@ export default function GoalScreen() {
           onPress={() => navigation.navigate('GoalForm', undefined)}
         />
       )}
+      <BannerAdView />
     </View>
   );
 }
@@ -216,7 +218,7 @@ const styles = StyleSheet.create({
   tabBar: { backgroundColor: Colors.surface },
   indicator: { backgroundColor: Colors.primary },
   tabContainer: { flex: 1 },
-  listContent: { paddingTop: 12, paddingBottom: 100 },
+  listContent: { paddingTop: 12, paddingBottom: 150 },
   goalItem: {
     backgroundColor: Colors.surface,
     marginHorizontal: 16,
@@ -259,7 +261,7 @@ const styles = StyleSheet.create({
   fab: {
     position: 'absolute',
     right: 16,
-    bottom: 16,
+    bottom: 106,
     transform: [{ scale: 0.85 }],
   },
 });

--- a/src/screens/RecordScreen.tsx
+++ b/src/screens/RecordScreen.tsx
@@ -61,7 +61,7 @@ export default function RecordScreen() {
         />
       </View>
 
-      <ScrollView contentContainerStyle={styles.content}>
+      <ScrollView style={styles.scroll} contentContainerStyle={styles.content}>
         {/* 전체 섹션 */}
         <View style={styles.section}>
           <TouchableRipple
@@ -140,6 +140,7 @@ const styles = StyleSheet.create({
     borderBottomColor: Colors.border,
   },
   yearText: { color: Colors.text, fontWeight: '700', fontSize: 16, minWidth: 40, textAlign: 'center' },
+  scroll: { flex: 1 },
   content: { paddingVertical: 8 },
   section: {
     paddingHorizontal: 2,


### PR DESCRIPTION
## 이슈
Closes #193

## 변경 사항
- `GoalScreen`: `BannerAdView` 추가, FAB 위치를 광고 영역 위로 조정 (bottom: 16 → 106), 리스트 하단 패딩 조정 (100 → 150)
- `RecordScreen`: `ScrollView`에 `flex: 1` 스타일 추가하여 광고 영역이 항상 하단에 고정되도록 수정

## 테스트
- [ ] GoalScreen 하단에 광고 배너가 표시되는지 확인
- [ ] GoalScreen FAB 버튼이 광고 배너 위에 위치하는지 확인
- [ ] RecordScreen 하단에 광고 배너가 표시되는지 확인
- [ ] 각 화면에서 광고 영역 크기/여백이 일관성 있게 표시되는지 확인