### PR TITLE
#190 미완료 할 일 후처리 개선

### DIFF
--- a/src/components/TodoTabOverdue.tsx
+++ b/src/components/TodoTabOverdue.tsx
@@ -5,7 +5,7 @@ import { useNavigation, useIsFocused } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useTranslation } from 'react-i18next';
 import { Colors } from '../theme';
-import { useTodosOverdue, useBulkMoveToToday, useBulkDeleteTodos, useSetInProgress } from '../hooks/useTodos';
+import { useTodosOverdue, useBulkMoveToToday, useBulkDeleteTodos, useSetInProgress, useBulkComplete } from '../hooks/useTodos';
 import { useCategories } from '../hooks/useCategories';
 import { useCategoryMap } from '../hooks/useCategoryMap';
 import { useSelectable } from '../hooks/useSelectable';
@@ -56,6 +56,7 @@ export default function TodoTabOverdue() {
   const { mutate: bulkMoveToToday } = useBulkMoveToToday();
   const { mutate: bulkDelete } = useBulkDeleteTodos();
   const { mutate: setInProgress } = useSetInProgress();
+  const { mutate: bulkComplete } = useBulkComplete();
 
   const isFocused = useIsFocused();
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
@@ -75,6 +76,14 @@ export default function TodoTabOverdue() {
     { key: 'urgency' as SortKey, label: t('todo.sort_urgency') },
     { key: 'importance' as SortKey, label: t('todo.sort_importance') },
   ];
+
+  const handleMarkComplete = () => {
+    if (selectedIds.size === 0) return;
+    bulkComplete([...selectedIds]);
+    clearSelection();
+    setSnackbarMessage(t('todo.mark_complete_msg'));
+    setSnackbarVisible(true);
+  };
 
   const handleMoveToToday = () => {
     if (selectedIds.size === 0) return;
@@ -157,6 +166,12 @@ export default function TodoTabOverdue() {
         icon={fabOpen ? 'close' : 'dots-vertical'}
         fabStyle={styles.fab}
         actions={[
+          {
+            icon: 'check-circle-outline',
+            label: t('todo.mark_complete_label'),
+            onPress: () => { handleMarkComplete(); setFabOpen(false); },
+            size: 'small' as const,
+          },
           {
             icon: 'calendar-arrow-right',
             label: t('todo.move_to_today_label'),

--- a/src/hooks/useTodos.ts
+++ b/src/hooks/useTodos.ts
@@ -453,3 +453,26 @@ export const useBulkDeleteTodos = () => {
   });
 };
 
+export const useBulkComplete = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (ids: number[]) => {
+      const now = Date.now();
+      const today = dayjs().format('YYYY-MM-DD');
+      for (const id of ids) {
+        await db.update(todos)
+          .set({ isCompleted: 1, isInProgress: 0, completedAt: now, updatedAt: now })
+          .where(eq(todos.id, id)).run();
+        await db.insert(todoCompletions)
+          .values({ todoId: id, completedDate: today })
+          .onConflictDoNothing()
+          .run();
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['todos'] });
+      queryClient.invalidateQueries({ queryKey: ['completions'] });
+    },
+  });
+};
+

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -57,6 +57,8 @@ const en: TranslationKeys = {
     search_section_routine: 'Routines',
     search_uncategorized: 'Uncategorized',
     status_in_progress: 'In Progress',
+    mark_complete_label: 'Mark as Complete',
+    mark_complete_msg: 'Marked as complete',
     in_progress_label: 'Mark as In Progress',
     in_progress_msg: 'Moved to Tasks tab',
     in_progress_clear: 'Clear In Progress',

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -57,6 +57,8 @@ const ja: TranslationKeys = {
     search_section_routine: 'ルーティン',
     search_uncategorized: '未分類',
     status_in_progress: '進行中',
+    mark_complete_label: '完了にする',
+    mark_complete_msg: '完了にしました',
     in_progress_label: '進行中にする',
     in_progress_msg: 'タスクタブに移動しました',
     in_progress_clear: '進行中を解除',

--- a/src/i18n/locales/ko.ts
+++ b/src/i18n/locales/ko.ts
@@ -55,6 +55,8 @@ const ko = {
     search_section_routine: '루틴',
     search_uncategorized: '미분류',
     status_in_progress: '진행 중',
+    mark_complete_label: '완료로 변경',
+    mark_complete_msg: '완료 처리했어요',
     in_progress_label: '진행 중으로 표시',
     in_progress_msg: '할 일 탭으로 이동했어요',
     in_progress_clear: '진행 중 해제',

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -57,6 +57,8 @@ const zh: TranslationKeys = {
     search_section_routine: '习惯',
     search_uncategorized: '未分类',
     status_in_progress: '进行中',
+    mark_complete_label: '标为已完成',
+    mark_complete_msg: '已标为完成',
     in_progress_label: '标为进行中',
     in_progress_msg: '已移至任务标签',
     in_progress_clear: '取消进行中',


### PR DESCRIPTION
## 이슈
Closes #190

## 변경 사항
- `useBulkComplete` 훅 추가: 선택한 미완료 할 일을 일괄로 완료 처리 (`isCompleted=1`, `isInProgress=0`, `todo_completions` 기록)
- `TodoTabOverdue`: FAB 액션 최상단에 "완료로 변경" 옵션 추가
- i18n (ko/en/ja/zh): `mark_complete_label`, `mark_complete_msg` 키 추가

## 테스트
- [ ] 미완료 탭에서 항목 선택 후 FAB 열었을 때 "완료로 변경"이 첫 번째로 표시되는지 확인
- [ ] "완료로 변경" 실행 후 해당 항목이 미완료 탭에서 사라지는지 확인
- [ ] 완료된 항목이 완료 탭에 정상 표시되는지 확인
- [ ] 기록 화면의 잔디 UI에 완료 기록이 반영되는지 확인